### PR TITLE
fix: orphan parcours script & code

### DIFF
--- a/docs/parcours/INCIDENT-double-progression-amo.md
+++ b/docs/parcours/INCIDENT-double-progression-amo.md
@@ -183,6 +183,50 @@ tsx scripts/ops/fix-double-progression-amo.ts --apply --with-cleanup  # + cas "E
 
 Ramener à `eligibilite/todo` est sûr : pour les cas "cleanup requis", on ne supprime que des brouillons DS jamais soumis. Le parcours reprend normalement via l'UI à la prochaine connexion de l'utilisateur, et un dossier diagnostic neuf (avec les bonnes annotations) sera créé le moment venu.
 
+### Runbook d'exécution
+
+À jouer dans l'ordre, sur un **restore frais de la BDD prod en local** (`DATABASE_URL` du `.env.local` doit pointer vers ce restore). Les alias pnpm transmettent les flags directement, sans `--`.
+
+`--anonymize` masque les PII (id, email, ds_number) à l'affichage — disponible sur **toutes** les commandes ci-dessous (audit, dry-run ET apply), pour produire des logs partageables. Les vraies valeurs restent utilisées en interne pour les écritures.
+
+```bash
+# 0. Restore frais de la BDD prod en local
+bash .local/restore-db.sh <backup>.tar.gz
+
+# 1. Audit (read-only). Catégorise et affiche un résumé :
+#    légitimes (rien à corriger) / régressables / cleanup requis / à reviewer.
+#    --anonymize : version masquée (partage / ticket Notion). Sans flag : version interne avec identités.
+pnpm audit:parcours-ds --anonymize --csv=audit-J0-anon.csv
+pnpm audit:parcours-ds --csv=audit-J0.csv
+
+# 2. Plan de correction (dry-run, aucune écriture).
+#    Affiche les mêmes catégories que l'audit (logique partagée) : régressables / cleanup requis / à reviewer.
+pnpm fix:double-progression --anonymize
+
+# 3. Correction. --with-cleanup traite aussi les cas "Edouard"
+#    (suppression des brouillons diagnostic en_construction + régression).
+#    --anonymize : logs d'exécution partageables (OK/SKIP/ERR avec id masqués).
+pnpm fix:double-progression --apply --with-cleanup --anonymize
+
+# 4. Vérification : doit afficher 0 régressable / 0 cleanup requis.
+pnpm fix:double-progression --anonymize
+
+# 5. Re-audit : ne doit rester que les cas légitimes (groupe A, utilisateurs passifs).
+pnpm audit:parcours-ds --anonymize
+
+# --- J+3 puis J+7 (après déploiement du fix serveur) ---
+# Confirme qu'aucun NOUVEAU cas n'apparaît (le fix d'idempotence tient).
+pnpm fix:double-progression --anonymize
+```
+
+Cibler un seul parcours (ex. débloquer un cas isolé sans toucher au reste) :
+
+```bash
+pnpm fix:double-progression --parcours-id=<uuid> --apply --with-cleanup --anonymize
+```
+
+Si l'étape 1, 2 ou 3 liste des cas en catégorie **à reviewer** (dossier downstream soumis côté DS), ils ne sont jamais touchés automatiquement : les traiter au cas par cas (recherche du dossier DS, rattachement manuel ou décision métier).
+
 ---
 
 ## 6. Prévention future

--- a/docs/parcours/INCIDENT-double-progression-amo.md
+++ b/docs/parcours/INCIDENT-double-progression-amo.md
@@ -1,0 +1,224 @@
+# Incident : double-progression du parcours à la validation AMO
+
+Document de référence sur le bug constaté en prod en mai 2026 : certains parcours sautaient deux étapes (`CHOIX_AMO → ELIGIBILITE → DIAGNOSTIC`) en une seule transaction de validation AMO, sans qu'aucun dossier DS n'ait été créé entre les deux.
+
+À lire en complément de [FLOW-AND-SYNC.md](./FLOW-AND-SYNC.md) qui décrit le modèle d'état nominal.
+
+---
+
+## 1. Symptômes observés
+
+En prod, 12 parcours étaient à `current_step = diagnostic, current_status = todo` mais sans aucune ligne dans `dossiers_demarches_simplifiees` pour l'étape `diagnostic`. Le script [`audit-parcours-ds-integrity.ts`](../../scripts/ops/audit-parcours-ds-integrity.ts) a permis de les lister.
+
+On a découpé en deux groupes :
+
+- **Groupe A — 9 parcours** : avaient bien une ligne BDD `step = eligibilite, ds_status = accepte`. Le CRON les a progressés normalement après acceptance de leur dossier éligibilité, mais l'utilisateur n'est jamais revenu pour cliquer sur "Créer mon dossier diagnostic". **Cas légitime, pas un bug**.
+- **Groupe B — 3 parcours** : aucune ligne DS, même pas pour `eligibilite`. Tous ont leur `parcours.updated_at` aligné à la milliseconde près sur `parcours_amo_validations.validee_at`. **Anomalie**.
+
+| ID anonymisé | Validation AMO | Phase code à l'époque |
+| --- | --- | --- |
+| #B-1 | 2026-04-02 | avant `ecbe35aa` (auto-progression côté sync) |
+| #B-2 | 2026-04-14 | avant `ecbe35aa` |
+| #B-3 | 2026-05-22 | après le CRON `d080e57e`, **bug encore actif** |
+
+---
+
+## 2. Méthodologie d'enquête
+
+L'absence de logs HTTP (rétention Scalingo dépassée, pas de Sentry/Datadog en prod) a imposé une enquête purement par données. On a procédé par couches d'élimination, sur le parcours #B-3 (le plus récent, le plus susceptible d'être encore actif).
+
+### 2.1 Couches d'analyse
+
+1. **État brut du parcours et user** : créé via FranceConnect, pas via agent (`created_by_agent_id = NULL`), pas archivé, `last_login` 3 semaines avant la validation, RGA simulé.
+2. **Autres parcours / users pour la même personne** : un seul. Pas de duplication.
+3. **Sync runs autour de la validation** : aucun sync_run actif entre 10h et 13h le 22/05 → le CRON n'a pas tourné dans cette fenêtre.
+4. **Tokens AMO** : un seul token, créé à la sélection AMO le 11/04, utilisé à la validation le 22/05. Pas de re-génération.
+5. **Commentaires admin** : aucun. Pas d'intervention manuelle tracée.
+6. **Empreinte Brevo** : `email_clicked_at = 14/04` (3 jours après réception), `email_opened_at = NULL`, validation 38 jours plus tard. Donc l'AMO n'a probablement **pas** cliqué sur le lien email au moment de valider — il a utilisé le backoffice.
+7. **Triggers / rules PostgreSQL** : aucun trigger métier, aucune rule. La table n'est mutée que par le code applicatif.
+
+### 2.2 Hypothèses écartées
+
+| Hypothèse | Écartée par |
+| --- | --- |
+| CRON de sync a fait sauter le step | Couche 3 (aucun sync_run dans la fenêtre) + couche 1 du script audit (aucun `sync_run_entries`) |
+| `skipAmoStep` a été appelé | `choisie_at` ne correspond pas à la date où le skip aurait écrasé le row |
+| Auto-progression `syncDossierStatus` (commit `ecbe35aa`, retiré dans `d080e57e`) | Fenêtre temporelle incompatible avec #B-3 (post-suppression) et avec #B-1/#B-2 (pré-introduction) |
+| Server action `passerEtapeSuivante` | Définie mais **importée nulle part** dans l'UI → Next.js ne l'expose pas comme endpoint client appelable |
+| Crash CRON entre la mutation et l'écriture de `sync_run_entries` | Couche 3 vide |
+| Trigger ou rule PG masqué(e) | Couche 7 vide |
+| Intervention manuelle SQL/Drizzle Studio | Ni prouvable ni réfutable sans audit log — exclue par pragmatisme |
+
+---
+
+## 3. Cause racine
+
+`approveValidation()` et `rejectEligibility()` ([`amo-validation.service.ts`](../../src/features/parcours/amo/services/amo-validation.service.ts)) étaient :
+
+- **Non idempotents** : aucune vérification `valideeAt IS NULL` avant d'agir. Un second appel sur la même validation refaisait toutes les mutations.
+- **Non atomiques** : la mise à jour de la validation, du token, du parcours et la progression étaient des UPDATE séparés, sans transaction. Pas de garantie de cohérence si une étape échouait.
+- **Non conditionnels** : `moveToNextStep` lisait l'état courant et avançait d'une étape, sans vérifier que le step de départ était bien celui attendu.
+
+Combinés, ces trois défauts permettaient à **deux appels concurrents** à `approveValidation` de faire avancer le parcours de deux étapes en cascade :
+
+```
+État initial : CHOIX_AMO / EN_INSTRUCTION
+
+R1 démarre à T+0ms     : lit CHOIX_AMO/EN_INSTRUCTION
+R2 démarre à T+~5ms    : lit CHOIX_AMO/EN_INSTRUCTION (R1 pas encore commit)
+R1 update validation   → valideeAt = NOW
+R1 updateStatus(VALIDE)→ CHOIX_AMO / VALIDE
+R1 moveToNextStep      → relit l'état, voit VALIDE → ELIGIBILITE / TODO
+R2 update validation   → valideeAt = NOW (écrase)
+R2 updateStatus(VALIDE)→ ELIGIBILITE / VALIDE   ← état dérivé du commit de R1
+R2 moveToNextStep      → relit l'état, voit VALIDE → DIAGNOSTIC / TODO
+```
+
+État final : `DIAGNOSTIC / TODO`, sans aucun dossier DS créé.
+
+Le déclencheur le plus probable des deux appels concurrents : **double-clic sur le bouton "Valider" du backoffice espace-agent** ([`ReponseAccompagnement.tsx`](../../src/app/(backoffice)/espace-agent/demandes/[id]/components/ReponseAccompagnement.tsx)). Le bouton était bien protégé par un state `isSubmitting`, mais celui-ci n'est appliqué qu'au re-render React suivant le `onClick` — deux clics très rapprochés (latence réseau lente) passaient les deux la garde côté UI.
+
+Brevo confirme indirectement : pour le cas étudié, `email_clicked_at` est antérieur de 38 jours à la validation. L'AMO a donc validé via le backoffice, pas via le lien email — donc deux appels veulent dire deux clics sur le **même** bouton.
+
+---
+
+## 4. Fix appliqué
+
+Trois niveaux de défense, dans la même PR.
+
+### 4.1 Niveau serveur — idempotence atomique
+
+`approveValidation` et `rejectEligibility` sont maintenant wrappées dans `db.transaction()`, et la mutation de la validation est conditionnelle :
+
+```ts
+const [validation] = await tx
+  .update(parcoursAmoValidations)
+  .set({ statut: LOGEMENT_ELIGIBLE, commentaire, valideeAt: new Date() })
+  .where(and(
+    eq(parcoursAmoValidations.id, validationId),
+    isNull(parcoursAmoValidations.valideeAt),
+  ))
+  .returning({ id, parcoursId });
+
+if (!validation) {
+  // Soit introuvable, soit déjà validée → no-op idempotent
+  // (on lit l'état pour distinguer et retourner alreadyProcessed)
+}
+```
+
+Sous l'isolation `READ COMMITTED` (défaut PostgreSQL), deux UPDATE concurrents sur la même ligne sont sérialisés. Le 2e réévalue la clause `valideeAt IS NULL` après le commit du 1er → retourne 0 ligne → no-op.
+
+### 4.2 Niveau serveur — transition parcours atomique conditionnelle
+
+La progression du parcours n'est plus `updateStatus(VALIDE) + moveToNextStep`. C'est une transition métier unique, conditionnée sur l'état attendu :
+
+```ts
+const [moved] = await tx
+  .update(parcoursPrevention)
+  .set({ currentStep: Step.ELIGIBILITE, currentStatus: Status.TODO })
+  .where(and(
+    eq(parcoursPrevention.id, validation.parcoursId),
+    inArray(parcoursPrevention.currentStep, [Step.CHOIX_AMO, Step.INVITATION]),
+  ))
+  .returning({ id });
+
+if (!moved) {
+  console.warn(`parcours ${validation.parcoursId} déjà progressé hors CHOIX_AMO/INVITATION — step non touché`);
+}
+```
+
+Cela ferme **définitivement** la classe de bugs : même si une seconde mutation passait outre la garde idempotence, elle ne pourrait plus avancer un parcours qui n'est plus à `CHOIX_AMO` ou `INVITATION`.
+
+### 4.3 Niveau UI — garde synchrone anti-double-clic
+
+Dans [`ReponseAccompagnement.tsx`](../../src/app/(backoffice)/espace-agent/demandes/[id]/components/ReponseAccompagnement.tsx), ajout d'un `useRef` qui bloque les clics avant que React n'ait re-rendu le bouton en `disabled` :
+
+```ts
+const submitLockRef = useRef(false);
+
+const handleSubmit = async () => {
+  if (submitLockRef.current) return;
+  submitLockRef.current = true;
+  setIsSubmitting(true);
+  try {
+    // ...
+  } finally {
+    setIsSubmitting(false);
+    submitLockRef.current = false;
+  }
+};
+```
+
+Et gestion explicite du cas `result.data?.alreadyProcessed === true` : on n'affiche pas la modale de confirmation classique, on affiche un message d'info "Demande déjà traitée".
+
+### 4.4 Feedback utilisateur
+
+Le type de retour de `approveValidation` et `rejectEligibility` expose maintenant :
+
+```ts
+{ message: string; alreadyProcessed: boolean; valideeAt: Date }
+```
+
+Permet à l'UI de distinguer "validé à l'instant" (succès normal, modale de confirmation) vs "validé il y a X (jours|secondes)" (lien rouvert, message d'info dédié).
+
+---
+
+## 5. Correction du stock
+
+Le script [`fix-double-progression-amo.ts`](../../scripts/ops/fix-double-progression-amo.ts) détecte lui-même les parcours victimes du bug (même critère que l'audit) et les ramène à `eligibilite/todo`. Il les catégorise en trois :
+
+| Catégorie | Critère | Traitement |
+|---|---|---|
+| **régressable** | aucun dossier DS | régression directe (`--apply`) |
+| **cleanup requis** | dossiers downstream uniquement `en_construction` (brouillons jamais soumis — ex. cas "Edouard" qui a cliqué "Créer mon dossier diagnostic") | suppression des brouillons + régression (`--apply --with-cleanup`) |
+| **à reviewer** | au moins un dossier downstream soumis | jamais touché automatiquement, listé |
+
+Garanties : la régression est un UPDATE conditionnel sur `current_step IN (diagnostic,devis,factures)` (skip si l'état a changé depuis la détection) ; la suppression de brouillon est conditionnée sur `ds_status='en_construction'` ; tout passe en transaction par parcours.
+
+```bash
+tsx scripts/ops/fix-double-progression-amo.ts                         # dry-run
+tsx scripts/ops/fix-double-progression-amo.ts --apply                 # régressables
+tsx scripts/ops/fix-double-progression-amo.ts --apply --with-cleanup  # + cas "Edouard"
+```
+
+Ramener à `eligibilite/todo` est sûr : pour les cas "cleanup requis", on ne supprime que des brouillons DS jamais soumis. Le parcours reprend normalement via l'UI à la prochaine connexion de l'utilisateur, et un dossier diagnostic neuf (avec les bonnes annotations) sera créé le moment venu.
+
+---
+
+## 6. Prévention future
+
+### 6.1 À adopter sur les autres transitions
+
+Le pattern **UPDATE conditionnel sur l'état attendu** doit être généralisé. Toute transition métier qui dépend de l'état courant devrait faire un UPDATE avec un `WHERE` qui inclut les champs lus, et tester le résultat. Sinon, on rouvre la classe de bugs ailleurs.
+
+Candidats à durcir progressivement (non bloquant pour la PR de fix) :
+
+- [`moveToNextStep`](../../src/features/parcours/core/services/parcours-progression.service.ts) — accepte `userId`, relit l'état, fait un UPDATE non conditionnel. À refactorer pour prendre un `expectedFrom: { step, status }` paramètre.
+- [`skipAmoStepForUser`](../../src/features/parcours/amo/services/amo-selection.service.ts) — protégé par un `if` au début, mais la lecture et l'UPDATE ne sont pas atomiques. À mettre en transaction avec UPDATE conditionnel.
+- [`createDiagnosticDossier`](../../src/features/parcours/core/services/diagnostic.service.ts) — l'insertion du dossier en BDD et l'update du statut sont séparés. Peuvent se désynchroniser si une étape échoue. À mettre en transaction.
+
+### 6.2 Observabilité — manquant critique
+
+L'enquête a été coûteuse parce qu'il n'y a aucun audit log des transitions d'état. Pour ne plus avoir à reconstituer ce genre de timeline par corrélation de timestamps, deux options non exclusives :
+
+- **Table applicative `parcours_history`** alimentée par tous les `updateStep` / `updateStatus`. Stocke `parcours_id, from_step, to_step, from_status, to_status, actor, reason, at`.
+- **Trigger PostgreSQL** sur `parcours_prevention` qui logge tout `UPDATE` de `current_step` ou `current_status` dans une table d'audit. Moins flexible (pas d'`actor` applicatif facile) mais imparable côté DB.
+
+À prioriser côté roadmap technique.
+
+### 6.3 Logs HTTP
+
+La rétention par défaut Scalingo couvre seulement quelques jours. Pour les incidents qui se révèlent plusieurs semaines après leur déclenchement (cas de #B-3, découvert 5 jours après le fait, déjà à la limite), considérer :
+
+- Activer `logs-archives` long terme (S3).
+- Configurer Sentry pour les erreurs serveur, et tracer les server actions sensibles (validations AMO, créations de dossier, transitions de step) avec un span dédié.
+
+---
+
+## 7. Références
+
+- Script d'audit (read-only) : [`scripts/ops/audit-parcours-ds-integrity.ts`](../../scripts/ops/audit-parcours-ds-integrity.ts)
+- Script de correction stock : [`scripts/ops/fix-double-progression-amo.ts`](../../scripts/ops/fix-double-progression-amo.ts)
+- Doc nominale du flow : [`FLOW-AND-SYNC.md`](./FLOW-AND-SYNC.md)
+- Service patché : [`src/features/parcours/amo/services/amo-validation.service.ts`](../../src/features/parcours/amo/services/amo-validation.service.ts)
+- UI patchée : [`src/app/(backoffice)/espace-agent/demandes/[id]/components/ReponseAccompagnement.tsx`](../../src/app/(backoffice)/espace-agent/demandes/[id]/components/ReponseAccompagnement.tsx)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "seo:import-catnat": "tsx src/features/seo/catnat/scripts/import-catnat.ts",
     "seed:staging": "tsx scripts/seed/seed-staging.ts",
     "fix:epci": "tsx scripts/ops/fix-missing-epci.ts",
+    "audit:parcours-ds": "tsx scripts/ops/audit-parcours-ds-integrity.ts",
+    "fix:double-progression": "tsx scripts/ops/fix-double-progression-amo.ts",
     "rga:import": "tsx scripts/import/rga-zones/import-rga-zones.ts"
   },
   "dependencies": {

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -48,6 +48,7 @@ Trois niveaux d'engagement croissants :
 
 ```bash
 tsx scripts/ops/fix-double-progression-amo.ts                         # dry-run : affiche le plan
+tsx scripts/ops/fix-double-progression-amo.ts --anonymize             # dry-run, PII masquées (partage)
 tsx scripts/ops/fix-double-progression-amo.ts --apply                 # corrige les régressables (cat. 1)
 tsx scripts/ops/fix-double-progression-amo.ts --apply --with-cleanup  # corrige aussi les cas "Edouard" (cat. 2)
 tsx scripts/ops/fix-double-progression-amo.ts --parcours-id=<uuid>    # cible un seul parcours

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -9,6 +9,7 @@ Utilitaires pour intervenir sur une BDD existante : audit d'intégrité, correct
 | Script | Type | Rôle | Lancement |
 |---|---|---|---|
 | [`audit-parcours-ds-integrity.ts`](#audit-parcours-ds-integrity) | read-only | Détecte les parcours dont l'état interne n'a pas de dossier DS correspondant | `tsx scripts/ops/audit-parcours-ds-integrity.ts` |
+| [`fix-double-progression-amo.ts`](#fix-double-progression-amo) | **écrit** | Détecte et corrige les parcours victimes du bug double-progression AMO (régression vers eligibilite/todo) | `tsx scripts/ops/fix-double-progression-amo.ts` |
 | [`verify-dashboard-stats.ts`](#verify-dashboard-stats) | read-only | Vérifie que les stats du tableau de bord correspondent aux requêtes SQL équivalentes | `tsx scripts/ops/verify-dashboard-stats.ts` |
 | [`fix-missing-epci.ts`](#fix-missing-epci) | **écrit** | Backfill du code EPCI sur les parcours qui en sont dépourvus (via `geo.api.gouv.fr`) | `pnpm fix:epci` |
 | [`debug-matomo-events.ts`](#debug-matomo-events) | read-only | Diagnostic des doublons d'événements Matomo (funnel simulateur) | `tsx scripts/ops/debug-matomo-events.ts` |
@@ -30,6 +31,33 @@ tsx scripts/ops/audit-parcours-ds-integrity.ts --anonymize   # masque les PII
 ```
 
 **Prérequis** : `.env.local` avec `DATABASE_URL` + `DEMARCHES_SIMPLIFIEES_*`.
+
+### fix-double-progression-amo
+
+Détecte et corrige les parcours victimes du bug double-progression AMO (cf. [`../../docs/parcours/INCIDENT-double-progression-amo.md`](../../docs/parcours/INCIDENT-double-progression-amo.md)) : parcours en `diagnostic/devis/factures` sans dossier DS d'éligibilité. Le script détecte les cas lui-même (même critère que l'audit), les catégorise, et ramène les parcours concernés à `eligibilite/todo`. Pas de mapping JSON à produire.
+
+Trois catégories, traitées différemment :
+
+| Catégorie | Critère | Traitement |
+|---|---|---|
+| **régressable** | aucun dossier DS | régression directe (`--apply`) |
+| **cleanup requis** | dossiers downstream uniquement `en_construction` (brouillons DS jamais soumis, ex. cas "Edouard") | suppression des brouillons + régression (`--apply --with-cleanup`) |
+| **à reviewer** | au moins un dossier downstream soumis (`en_instruction`/`accepte`/…) | jamais touché automatiquement — listé pour intervention humaine |
+
+Trois niveaux d'engagement croissants :
+
+```bash
+tsx scripts/ops/fix-double-progression-amo.ts                         # dry-run : affiche le plan
+tsx scripts/ops/fix-double-progression-amo.ts --apply                 # corrige les régressables (cat. 1)
+tsx scripts/ops/fix-double-progression-amo.ts --apply --with-cleanup  # corrige aussi les cas "Edouard" (cat. 2)
+tsx scripts/ops/fix-double-progression-amo.ts --parcours-id=<uuid>    # cible un seul parcours
+```
+
+La régression est un UPDATE conditionnel sur `current_step IN (diagnostic,devis,factures)` (skip si l'état a changé entre la détection et l'apply). La suppression des brouillons est conditionnée sur `ds_status='en_construction'`. Tout passe en transaction par parcours.
+
+**Vérification post-fix** : relancer en dry-run doit afficher 0 régressable / 0 cleanup requis. Relancer à J+3 et J+7 pour confirmer qu'aucun nouveau cas n'apparaît (le fix serveur d'idempotence tient).
+
+**Prérequis** : `.env.local` avec `DATABASE_URL` (l'API DS n'est pas sollicitée).
 
 ### verify-dashboard-stats
 

--- a/scripts/ops/audit-parcours-ds-integrity.ts
+++ b/scripts/ops/audit-parcours-ds-integrity.ts
@@ -40,6 +40,11 @@ import {
 } from "@/shared/database/schema";
 import { Step, STEP_LABELS } from "@/shared/domain/value-objects/step.enum";
 import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
+import {
+  categorizeDoubleProgression,
+  CATEGORY_LABELS,
+  type DoubleProgressionCategory,
+} from "./lib/double-progression";
 
 // --- Args ---
 const args = process.argv.slice(2);
@@ -184,6 +189,7 @@ interface ParcoursReport {
   emailsToSearch: string[];
   dsSearch: Partial<Record<Step, DsSearchHit[] | "skipped" | "error">>;
   anomalies: string[];
+  category: DoubleProgressionCategory;
 }
 
 // --- DS API ---
@@ -449,13 +455,32 @@ async function main() {
       emailsToSearch,
       dsSearch: {},
       anomalies,
+      category: categorizeDoubleProgression(dossiers),
     };
     reports.push(report);
   }
 
-  console.log(`Parcours avec anomalies : ${reports.length}`);
+  console.log(`Parcours à examiner (étape courante sans dossier DS — inclut des cas légitimes) : ${reports.length}`);
+
+  // Tri par catégorie : combien sont des cas légitimes vs de vrais bugs à corriger.
+  const byCategory = {
+    legitime: reports.filter((r) => r.category === "legitime").length,
+    regressable: reports.filter((r) => r.category === "regressable").length,
+    cleanup_requis: reports.filter((r) => r.category === "cleanup_requis").length,
+    a_reviewer: reports.filter((r) => r.category === "a_reviewer").length,
+  };
+  console.log();
+  console.log("Répartition par catégorie (cf. fix-double-progression-amo.ts) :");
+  console.log(`  - légitimes (rien à corriger)         : ${byCategory.legitime}`);
+  console.log(`  - régressables (bug)                  : ${byCategory.regressable}`);
+  console.log(`  - cleanup requis (bug type Edouard)   : ${byCategory.cleanup_requis}`);
+  console.log(`  - à reviewer manuellement             : ${byCategory.a_reviewer}`);
+  const aCorriger = byCategory.regressable + byCategory.cleanup_requis + byCategory.a_reviewer;
+  console.log(`  → ${aCorriger} parcours à corriger, ${byCategory.legitime} légitimes.`);
+  console.log();
+
   if (reports.length === 0) {
-    console.log("\nAucun parcours orphelin. Fin.");
+    console.log("\nAucun parcours à examiner. Fin.");
     await client.end();
     return;
   }
@@ -524,7 +549,7 @@ async function main() {
   console.log("=".repeat(72));
 
   reports.forEach((r, i) => {
-    console.log(`\n--- Parcours orphelin #${i + 1} ---`);
+    console.log(`\n--- Parcours #${i + 1} — ${CATEGORY_LABELS[r.category]} ---`);
     console.log(`  parcoursId         : ${redactUuid(r.parcoursId)}`);
     console.log(`  userId             : ${redactUuid(r.userId)}`);
     console.log(`  user               : ${redactName(r.userNom, r.userPrenom)}`);
@@ -539,7 +564,7 @@ async function main() {
     if (r.archivedAt) {
       console.log(`  archived           : ${r.archivedAt.toISOString()} (${r.archiveReason ?? "sans raison"})`);
     }
-    console.log(`  anomalies          :`);
+    console.log(`  à examiner         :`);
     for (const a of r.anomalies) console.log(`    - ${a}`);
 
     // Lignes DS locales
@@ -725,7 +750,7 @@ async function main() {
   }
 
   console.log("\n" + "=".repeat(72));
-  console.log(`Audit terminé. ${reports.length} parcours à traiter manuellement.`);
+  console.log(`Audit terminé. ${reports.length} parcours à examiner (dont la majorité sont des cas légitimes — voir le fix pour le tri).`);
   console.log("=".repeat(72));
 
   await client.end();

--- a/scripts/ops/fix-double-progression-amo.ts
+++ b/scripts/ops/fix-double-progression-amo.ts
@@ -1,0 +1,361 @@
+/**
+ * Correction du bug "double-progression AMO".
+ *
+ * Contexte : cf docs/parcours/INCIDENT-double-progression-amo.md
+ * Deux appels concurrents à `approveValidation` pouvaient faire avancer un parcours
+ * de deux étapes en cascade (CHOIX_AMO → ELIGIBILITE → DIAGNOSTIC) sans qu'aucun
+ * dossier DS d'éligibilité ne soit créé. Résultat : parcours en diagnostic/devis/factures
+ * sans ligne `dossiers_demarches_simplifiees` step='eligibilite'.
+ *
+ * Ce script DÉTECTE lui-même les cas (même critère que l'audit) et les corrige en
+ * ramenant le parcours à ELIGIBILITE/TODO. Pas de mapping JSON intermédiaire.
+ *
+ * Catégorisation de chaque parcours problématique :
+ *   1. REGRESSABLE        : aucun dossier DS du tout → simple régression.
+ *   2. CLEANUP_REQUIS     : dossiers downstream UNIQUEMENT en_construction (brouillons
+ *                           DS jamais soumis, résidus du bug — ex. l'utilisateur a cliqué
+ *                           "Créer mon dossier diagnostic"). Régression possible APRÈS
+ *                           suppression de ces brouillons. Nécessite --with-cleanup.
+ *   3. A_REVIEWER         : au moins un dossier downstream SOUMIS (en_instruction/accepte/
+ *                           refuse/...). Jamais touché automatiquement — vraie donnée en jeu.
+ *
+ * Niveaux d'engagement :
+ *   (rien)                 dry-run : affiche le plan, aucune écriture
+ *   --apply                corrige la catégorie 1 (régression). Catégorie 2 affichée, pas touchée.
+ *   --apply --with-cleanup corrige aussi la catégorie 2 (DELETE brouillons en_construction
+ *                          downstream + régression, en transaction).
+ *
+ * Filtres :
+ *   --parcours-id=<uuid>   limite à un seul parcours (debug / cas isolé type "Edouard").
+ *
+ * La régression est un UPDATE conditionnel sur `current_step IN (diagnostic,devis,factures)`
+ * pour ne pas écraser un changement concurrent survenu entre la détection et l'apply.
+ *
+ * Usage :
+ *   pnpm tsx scripts/ops/fix-double-progression-amo.ts                          # dry-run
+ *   pnpm tsx scripts/ops/fix-double-progression-amo.ts --apply                  # cat. 1
+ *   pnpm tsx scripts/ops/fix-double-progression-amo.ts --apply --with-cleanup   # cat. 1 + 2
+ *   pnpm tsx scripts/ops/fix-double-progression-amo.ts --parcours-id=<uuid>     # cible
+ *
+ * Prérequis : .env.local avec DATABASE_URL (les DEMARCHES_SIMPLIFIEES_* ne sont pas requis,
+ * ce script ne touche pas à l'API DS).
+ */
+
+import { config } from "dotenv";
+config({ path: ".env.local" });
+config({ path: ".env" });
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import * as schema from "@/shared/database/schema";
+import { parcoursPrevention, users, dossiersDemarchesSimplifiees } from "@/shared/database/schema";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+import { Status } from "@/shared/domain/value-objects/status.enum";
+import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
+
+// --- Args ---
+const args = process.argv.slice(2);
+function getArg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const hit = args.find((a) => a.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : undefined;
+}
+const APPLY = args.includes("--apply");
+const WITH_CLEANUP = args.includes("--with-cleanup");
+const PARCOURS_ID_FILTER = getArg("parcours-id");
+
+if (WITH_CLEANUP && !APPLY) {
+  console.error("--with-cleanup nécessite --apply (rien à nettoyer en dry-run).");
+  process.exit(1);
+}
+
+// --- DB ---
+const connectionString =
+  process.env.DATABASE_URL ??
+  (() => {
+    const { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } = process.env;
+    if (!DB_HOST) throw new Error("DATABASE_URL ou DB_HOST requis");
+    return `postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`;
+  })();
+const client = postgres(connectionString, { max: 5, idle_timeout: 10 });
+const db = drizzle(client, { schema });
+
+// --- Constantes métier ---
+// Étapes en aval de l'éligibilité : un parcours qui y est sans dossier d'éligibilité
+// est un candidat au bug de double-progression.
+const STEPS_AVALES: Step[] = [Step.DIAGNOSTIC, Step.DEVIS, Step.FACTURES];
+const TARGET_STEP = Step.ELIGIBILITE;
+const TARGET_STATUS = Status.TODO;
+
+type Category = "regressable" | "cleanup_requis" | "a_reviewer";
+
+interface LocalDossier {
+  id: string;
+  step: Step;
+  dsStatus: DSStatus;
+  dsNumber: string | null;
+}
+
+interface Case {
+  parcoursId: string;
+  email: string | null;
+  currentStep: Step;
+  currentStatus: Status;
+  dossiers: LocalDossier[];
+  category: Category;
+  // Brouillons en_construction downstream à supprimer (catégorie cleanup_requis).
+  enConstructionToDelete: { id: string; step: Step }[];
+  reviewReason?: string;
+}
+
+async function categorize(): Promise<Case[]> {
+  const whereClauses = [
+    inArray(parcoursPrevention.currentStep, STEPS_AVALES),
+    isNull(parcoursPrevention.archivedAt),
+    isNull(parcoursPrevention.completedAt),
+  ];
+  if (PARCOURS_ID_FILTER) {
+    whereClauses.push(eq(parcoursPrevention.id, PARCOURS_ID_FILTER));
+  }
+
+  const candidates = await db
+    .select({
+      id: parcoursPrevention.id,
+      currentStep: parcoursPrevention.currentStep,
+      currentStatus: parcoursPrevention.currentStatus,
+      email: users.email,
+    })
+    .from(parcoursPrevention)
+    .innerJoin(users, eq(parcoursPrevention.userId, users.id))
+    .where(and(...whereClauses));
+
+  const cases: Case[] = [];
+
+  for (const c of candidates) {
+    const dossiers = (await db
+      .select({
+        id: dossiersDemarchesSimplifiees.id,
+        step: dossiersDemarchesSimplifiees.step,
+        dsStatus: dossiersDemarchesSimplifiees.dsStatus,
+        dsNumber: dossiersDemarchesSimplifiees.dsNumber,
+      })
+      .from(dossiersDemarchesSimplifiees)
+      .where(eq(dossiersDemarchesSimplifiees.parcoursId, c.id))) as LocalDossier[];
+
+    // Si un dossier d'éligibilité existe, ce n'est PAS un cas du bug : le parcours a
+    // bien franchi l'éligibilité. (Cas "groupe A" = utilisateur passif, géré par l'audit.)
+    if (dossiers.some((d) => d.step === Step.ELIGIBILITE)) {
+      continue;
+    }
+
+    let category: Category;
+    let enConstructionToDelete: { id: string; step: Step }[] = [];
+    let reviewReason: string | undefined;
+
+    if (dossiers.length === 0) {
+      category = "regressable";
+    } else if (dossiers.every((d) => d.dsStatus === DSStatus.EN_CONSTRUCTION)) {
+      category = "cleanup_requis";
+      enConstructionToDelete = dossiers.map((d) => ({ id: d.id, step: d.step }));
+    } else {
+      category = "a_reviewer";
+      const soumis = dossiers.filter((d) => d.dsStatus !== DSStatus.EN_CONSTRUCTION);
+      reviewReason = `dossier(s) downstream soumis côté DS : ${soumis
+        .map((d) => `${d.step}=${d.dsStatus}`)
+        .join(", ")}`;
+    }
+
+    cases.push({
+      parcoursId: c.id,
+      email: c.email,
+      currentStep: c.currentStep as Step,
+      currentStatus: c.currentStatus as Status,
+      dossiers,
+      category,
+      enConstructionToDelete,
+      reviewReason,
+    });
+  }
+
+  return cases;
+}
+
+async function regresser(parcoursId: string): Promise<boolean> {
+  const [moved] = await db
+    .update(parcoursPrevention)
+    .set({ currentStep: TARGET_STEP, currentStatus: TARGET_STATUS })
+    .where(
+      and(
+        eq(parcoursPrevention.id, parcoursId),
+        inArray(parcoursPrevention.currentStep, STEPS_AVALES)
+      )
+    )
+    .returning({ id: parcoursPrevention.id });
+  return !!moved;
+}
+
+async function cleanupAndRegresser(c: Case): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    // Suppression conditionnelle : uniquement les brouillons en_construction.
+    // La condition ds_status=en_construction protège contre une soumission survenue
+    // entre la détection et l'apply.
+    for (const d of c.enConstructionToDelete) {
+      await tx
+        .delete(dossiersDemarchesSimplifiees)
+        .where(
+          and(
+            eq(dossiersDemarchesSimplifiees.id, d.id),
+            eq(dossiersDemarchesSimplifiees.dsStatus, DSStatus.EN_CONSTRUCTION)
+          )
+        );
+    }
+
+    const [moved] = await tx
+      .update(parcoursPrevention)
+      .set({ currentStep: TARGET_STEP, currentStatus: TARGET_STATUS })
+      .where(
+        and(
+          eq(parcoursPrevention.id, c.parcoursId),
+          inArray(parcoursPrevention.currentStep, STEPS_AVALES)
+        )
+      )
+      .returning({ id: parcoursPrevention.id });
+
+    return !!moved;
+  });
+}
+
+function dossierLine(d: LocalDossier): string {
+  return `${d.step}=${d.dsStatus}${d.dsNumber ? ` (#${d.dsNumber})` : ""}`;
+}
+
+async function main() {
+  console.log("=".repeat(72));
+  console.log(
+    `FIX DOUBLE-PROGRESSION AMO — ${
+      APPLY ? (WITH_CLEANUP ? "APPLY + CLEANUP" : "APPLY") : "DRY-RUN"
+    }`
+  );
+  console.log("=".repeat(72));
+  console.log(`Cible : régression vers ${TARGET_STEP}/${TARGET_STATUS}`);
+  if (PARCOURS_ID_FILTER) console.log(`Filtre parcours-id : ${PARCOURS_ID_FILTER}`);
+  console.log();
+
+  const cases = await categorize();
+
+  const regressables = cases.filter((c) => c.category === "regressable");
+  const cleanupRequis = cases.filter((c) => c.category === "cleanup_requis");
+  const aReviewer = cases.filter((c) => c.category === "a_reviewer");
+
+  // --- Affichage du plan ---
+  console.log(`Parcours problématiques détectés : ${cases.length}`);
+  console.log(`  - régressables (0 dossier)        : ${regressables.length}`);
+  console.log(`  - cleanup requis (en_construction): ${cleanupRequis.length}`);
+  console.log(`  - à reviewer (dossier soumis)     : ${aReviewer.length}`);
+  console.log();
+
+  if (regressables.length > 0) {
+    console.log("--- RÉGRESSABLES (catégorie 1) ---");
+    for (const c of regressables) {
+      console.log(`  [${c.parcoursId}] ${c.email ?? "<sans email>"} — ${c.currentStep}/${c.currentStatus} → ${TARGET_STEP}/${TARGET_STATUS}`);
+    }
+    console.log();
+  }
+
+  if (cleanupRequis.length > 0) {
+    console.log("--- CLEANUP REQUIS (catégorie 2 — type \"Edouard\") ---");
+    for (const c of cleanupRequis) {
+      console.log(`  [${c.parcoursId}] ${c.email ?? "<sans email>"} — ${c.currentStep}/${c.currentStatus}`);
+      console.log(`      dossiers à supprimer : ${c.dossiers.map(dossierLine).join(", ")}`);
+      console.log(`      → DELETE brouillon(s) + régression à ${TARGET_STEP}/${TARGET_STATUS}`);
+    }
+    if (!WITH_CLEANUP) {
+      console.log(`  (relancer avec --apply --with-cleanup pour traiter ces ${cleanupRequis.length} cas)`);
+    }
+    console.log();
+  }
+
+  if (aReviewer.length > 0) {
+    console.log("--- À REVIEWER MANUELLEMENT (catégorie 3 — jamais touché auto) ---");
+    for (const c of aReviewer) {
+      console.log(`  [${c.parcoursId}] ${c.email ?? "<sans email>"} — ${c.currentStep}/${c.currentStatus}`);
+      console.log(`      ${c.reviewReason}`);
+      console.log(`      dossiers : ${c.dossiers.map(dossierLine).join(", ")}`);
+    }
+    console.log();
+  }
+
+  if (cases.length === 0) {
+    console.log("Aucun cas détecté. Rien à faire.");
+    await client.end();
+    return;
+  }
+
+  if (!APPLY) {
+    console.log("Mode dry-run — aucune écriture. Relancer avec --apply pour corriger.");
+    await client.end();
+    return;
+  }
+
+  // --- Exécution ---
+  console.log("=".repeat(72));
+  console.log("EXÉCUTION");
+  console.log("=".repeat(72));
+
+  let okRegress = 0;
+  let okCleanup = 0;
+  let failed = 0;
+  let skippedState = 0;
+
+  for (const c of regressables) {
+    try {
+      const moved = await regresser(c.parcoursId);
+      if (moved) {
+        okRegress++;
+        console.log(`  OK régressé  ${c.parcoursId}`);
+      } else {
+        skippedState++;
+        console.log(`  SKIP (état modifié depuis la détection) ${c.parcoursId}`);
+      }
+    } catch (err) {
+      failed++;
+      console.error(`  ERR ${c.parcoursId} : ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  if (WITH_CLEANUP) {
+    for (const c of cleanupRequis) {
+      try {
+        const moved = await cleanupAndRegresser(c);
+        if (moved) {
+          okCleanup++;
+          console.log(`  OK cleanup+régressé ${c.parcoursId} (${c.enConstructionToDelete.length} brouillon(s) supprimé(s))`);
+        } else {
+          skippedState++;
+          console.log(`  SKIP (état modifié depuis la détection) ${c.parcoursId}`);
+        }
+      } catch (err) {
+        failed++;
+        console.error(`  ERR ${c.parcoursId} : ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  } else if (cleanupRequis.length > 0) {
+    console.log(`  ${cleanupRequis.length} cas cleanup ignorés (--with-cleanup non fourni)`);
+  }
+
+  console.log();
+  console.log("=".repeat(72));
+  console.log(
+    `Terminé : ${okRegress} régressé(s), ${okCleanup} cleanup+régressé(s), ${skippedState} skip (état), ${failed} échec(s), ${aReviewer.length} à reviewer.`
+  );
+  console.log("=".repeat(72));
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error("Erreur fatale :", err);
+  client.end();
+  process.exit(1);
+});

--- a/scripts/ops/fix-double-progression-amo.ts
+++ b/scripts/ops/fix-double-progression-amo.ts
@@ -25,14 +25,17 @@
  *   --apply --with-cleanup corrige aussi la catégorie 2 (DELETE brouillons en_construction
  *                          downstream + régression, en transaction).
  *
- * Filtres :
+ * Filtres / options :
  *   --parcours-id=<uuid>   limite à un seul parcours (debug / cas isolé type "Edouard").
+ *   --anonymize            masque les PII (id, email, ds_number) dans l'affichage, pour
+ *                          partager le plan sans exposer les identifiants.
  *
  * La régression est un UPDATE conditionnel sur `current_step IN (diagnostic,devis,factures)`
  * pour ne pas écraser un changement concurrent survenu entre la détection et l'apply.
  *
  * Usage :
  *   pnpm tsx scripts/ops/fix-double-progression-amo.ts                          # dry-run
+ *   pnpm tsx scripts/ops/fix-double-progression-amo.ts --anonymize              # dry-run anonymisé
  *   pnpm tsx scripts/ops/fix-double-progression-amo.ts --apply                  # cat. 1
  *   pnpm tsx scripts/ops/fix-double-progression-amo.ts --apply --with-cleanup   # cat. 1 + 2
  *   pnpm tsx scripts/ops/fix-double-progression-amo.ts --parcours-id=<uuid>     # cible
@@ -45,6 +48,7 @@ import { config } from "dotenv";
 config({ path: ".env.local" });
 config({ path: ".env" });
 
+import { createHash } from "node:crypto";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { and, eq, inArray, isNull } from "drizzle-orm";
@@ -53,6 +57,7 @@ import { parcoursPrevention, users, dossiersDemarchesSimplifiees } from "@/share
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import { Status } from "@/shared/domain/value-objects/status.enum";
 import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
+import { categorizeDoubleProgression } from "./lib/double-progression";
 
 // --- Args ---
 const args = process.argv.slice(2);
@@ -63,11 +68,38 @@ function getArg(name: string): string | undefined {
 }
 const APPLY = args.includes("--apply");
 const WITH_CLEANUP = args.includes("--with-cleanup");
+const ANONYMIZE = args.includes("--anonymize");
 const PARCOURS_ID_FILTER = getArg("parcours-id");
 
 if (WITH_CLEANUP && !APPLY) {
   console.error("--with-cleanup nécessite --apply (rien à nettoyer en dry-run).");
   process.exit(1);
+}
+
+// --- Anonymisation (pour partage du plan sans exposer les PII) ---
+// Hash court (6 chars) dérivé d'un sel de session : stable pour un run, imprévisible
+// d'un run à l'autre. Les vraies valeurs (id, email) restent utilisées en interne pour
+// les UPDATE/DELETE ; seuls les AFFICHAGES sont masqués.
+const RUN_SALT = createHash("sha256")
+  .update(String(Date.now()) + Math.random().toString())
+  .digest("hex")
+  .slice(0, 16);
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(RUN_SALT + value).digest("hex").slice(0, 6);
+}
+function redactUuid(id: string): string {
+  return ANONYMIZE ? `<id:${shortHash(id)}>` : id;
+}
+function redactEmail(email: string | null): string {
+  if (!email) return "<sans email>";
+  if (!ANONYMIZE) return email;
+  const tld = email.slice(email.lastIndexOf(".") + 1);
+  return `<email:${shortHash(email)}@***.${tld}>`;
+}
+function redactDsNumber(n: string | null): string {
+  if (!n) return "";
+  return ANONYMIZE ? `#<ds:${shortHash(n)}>` : `#${n}`;
 }
 
 // --- DB ---
@@ -143,23 +175,21 @@ async function categorize(): Promise<Case[]> {
       .from(dossiersDemarchesSimplifiees)
       .where(eq(dossiersDemarchesSimplifiees.parcoursId, c.id))) as LocalDossier[];
 
-    // Si un dossier d'éligibilité existe, ce n'est PAS un cas du bug : le parcours a
-    // bien franchi l'éligibilité. (Cas "groupe A" = utilisateur passif, géré par l'audit.)
-    if (dossiers.some((d) => d.step === Step.ELIGIBILITE)) {
+    // Catégorisation partagée avec l'audit (cf. lib/double-progression.ts).
+    const fullCategory = categorizeDoubleProgression(dossiers);
+
+    // Cas "légitime" (a franchi l'éligibilité) : pas un bug, le fix n'y touche pas.
+    if (fullCategory === "legitime") {
       continue;
     }
 
-    let category: Category;
+    const category: Category = fullCategory;
     let enConstructionToDelete: { id: string; step: Step }[] = [];
     let reviewReason: string | undefined;
 
-    if (dossiers.length === 0) {
-      category = "regressable";
-    } else if (dossiers.every((d) => d.dsStatus === DSStatus.EN_CONSTRUCTION)) {
-      category = "cleanup_requis";
+    if (category === "cleanup_requis") {
       enConstructionToDelete = dossiers.map((d) => ({ id: d.id, step: d.step }));
-    } else {
-      category = "a_reviewer";
+    } else if (category === "a_reviewer") {
       const soumis = dossiers.filter((d) => d.dsStatus !== DSStatus.EN_CONSTRUCTION);
       reviewReason = `dossier(s) downstream soumis côté DS : ${soumis
         .map((d) => `${d.step}=${d.dsStatus}`)
@@ -227,7 +257,7 @@ async function cleanupAndRegresser(c: Case): Promise<boolean> {
 }
 
 function dossierLine(d: LocalDossier): string {
-  return `${d.step}=${d.dsStatus}${d.dsNumber ? ` (#${d.dsNumber})` : ""}`;
+  return `${d.step}=${d.dsStatus}${d.dsNumber ? ` (${redactDsNumber(d.dsNumber)})` : ""}`;
 }
 
 async function main() {
@@ -235,11 +265,11 @@ async function main() {
   console.log(
     `FIX DOUBLE-PROGRESSION AMO — ${
       APPLY ? (WITH_CLEANUP ? "APPLY + CLEANUP" : "APPLY") : "DRY-RUN"
-    }`
+    }${ANONYMIZE ? " (anonymisé)" : ""}`
   );
   console.log("=".repeat(72));
   console.log(`Cible : régression vers ${TARGET_STEP}/${TARGET_STATUS}`);
-  if (PARCOURS_ID_FILTER) console.log(`Filtre parcours-id : ${PARCOURS_ID_FILTER}`);
+  if (PARCOURS_ID_FILTER) console.log(`Filtre parcours-id : ${redactUuid(PARCOURS_ID_FILTER)}`);
   console.log();
 
   const cases = await categorize();
@@ -258,7 +288,7 @@ async function main() {
   if (regressables.length > 0) {
     console.log("--- RÉGRESSABLES (catégorie 1) ---");
     for (const c of regressables) {
-      console.log(`  [${c.parcoursId}] ${c.email ?? "<sans email>"} — ${c.currentStep}/${c.currentStatus} → ${TARGET_STEP}/${TARGET_STATUS}`);
+      console.log(`  [${redactUuid(c.parcoursId)}] ${redactEmail(c.email)} — ${c.currentStep}/${c.currentStatus} → ${TARGET_STEP}/${TARGET_STATUS}`);
     }
     console.log();
   }
@@ -266,7 +296,7 @@ async function main() {
   if (cleanupRequis.length > 0) {
     console.log("--- CLEANUP REQUIS (catégorie 2 — type \"Edouard\") ---");
     for (const c of cleanupRequis) {
-      console.log(`  [${c.parcoursId}] ${c.email ?? "<sans email>"} — ${c.currentStep}/${c.currentStatus}`);
+      console.log(`  [${redactUuid(c.parcoursId)}] ${redactEmail(c.email)} — ${c.currentStep}/${c.currentStatus}`);
       console.log(`      dossiers à supprimer : ${c.dossiers.map(dossierLine).join(", ")}`);
       console.log(`      → DELETE brouillon(s) + régression à ${TARGET_STEP}/${TARGET_STATUS}`);
     }
@@ -279,7 +309,7 @@ async function main() {
   if (aReviewer.length > 0) {
     console.log("--- À REVIEWER MANUELLEMENT (catégorie 3 — jamais touché auto) ---");
     for (const c of aReviewer) {
-      console.log(`  [${c.parcoursId}] ${c.email ?? "<sans email>"} — ${c.currentStep}/${c.currentStatus}`);
+      console.log(`  [${redactUuid(c.parcoursId)}] ${redactEmail(c.email)} — ${c.currentStep}/${c.currentStatus}`);
       console.log(`      ${c.reviewReason}`);
       console.log(`      dossiers : ${c.dossiers.map(dossierLine).join(", ")}`);
     }
@@ -313,14 +343,14 @@ async function main() {
       const moved = await regresser(c.parcoursId);
       if (moved) {
         okRegress++;
-        console.log(`  OK régressé  ${c.parcoursId}`);
+        console.log(`  OK régressé  ${redactUuid(c.parcoursId)}`);
       } else {
         skippedState++;
-        console.log(`  SKIP (état modifié depuis la détection) ${c.parcoursId}`);
+        console.log(`  SKIP (état modifié depuis la détection) ${redactUuid(c.parcoursId)}`);
       }
     } catch (err) {
       failed++;
-      console.error(`  ERR ${c.parcoursId} : ${err instanceof Error ? err.message : String(err)}`);
+      console.error(`  ERR ${redactUuid(c.parcoursId)} : ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -330,14 +360,14 @@ async function main() {
         const moved = await cleanupAndRegresser(c);
         if (moved) {
           okCleanup++;
-          console.log(`  OK cleanup+régressé ${c.parcoursId} (${c.enConstructionToDelete.length} brouillon(s) supprimé(s))`);
+          console.log(`  OK cleanup+régressé ${redactUuid(c.parcoursId)} (${c.enConstructionToDelete.length} brouillon(s) supprimé(s))`);
         } else {
           skippedState++;
-          console.log(`  SKIP (état modifié depuis la détection) ${c.parcoursId}`);
+          console.log(`  SKIP (état modifié depuis la détection) ${redactUuid(c.parcoursId)}`);
         }
       } catch (err) {
         failed++;
-        console.error(`  ERR ${c.parcoursId} : ${err instanceof Error ? err.message : String(err)}`);
+        console.error(`  ERR ${redactUuid(c.parcoursId)} : ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   } else if (cleanupRequis.length > 0) {

--- a/scripts/ops/lib/double-progression.ts
+++ b/scripts/ops/lib/double-progression.ts
@@ -1,0 +1,61 @@
+/**
+ * Logique partagée de catégorisation du bug "double-progression AMO".
+ * Utilisée par `audit-parcours-ds-integrity.ts` (affichage) et
+ * `fix-double-progression-amo.ts` (correction), pour que les deux scripts
+ * disent EXACTEMENT la même chose.
+ *
+ * Contexte : docs/parcours/INCIDENT-double-progression-amo.md
+ */
+
+import { Step } from "@/shared/domain/value-objects/step.enum";
+import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
+
+export type DoubleProgressionCategory =
+  | "legitime"
+  | "regressable"
+  | "cleanup_requis"
+  | "a_reviewer";
+
+/** Forme minimale d'un dossier DS suffisante pour catégoriser. */
+export interface DossierForCategory {
+  step: string;
+  dsStatus: string;
+}
+
+/**
+ * Catégorise un parcours actuellement en `diagnostic`/`devis`/`factures`,
+ * selon ses dossiers DS, du point de vue du bug double-progression AMO.
+ *
+ * - `legitime`       : possède un dossier `eligibilite` → a franchi l'éligibilité
+ *                      normalement. Cas typique de l'utilisateur passif qui n'a pas
+ *                      (encore) créé le dossier de son étape courante. **Rien à corriger.**
+ * - `regressable`    : aucun dossier DS → propulsé sans rien créer (bug). Régression simple.
+ * - `cleanup_requis` : dossiers downstream UNIQUEMENT `en_construction` (brouillons DS
+ *                      jamais soumis, ex. cas "Edouard"). Régression après suppression des brouillons.
+ * - `a_reviewer`     : au moins un dossier downstream SOUMIS sans dossier d'éligibilité.
+ *                      Vraie donnée en jeu → intervention humaine.
+ *
+ * Pré-condition : à n'appeler que sur des parcours dont `current_step` est en aval
+ * de l'éligibilité (diagnostic/devis/factures).
+ */
+export function categorizeDoubleProgression(
+  dossiers: DossierForCategory[]
+): DoubleProgressionCategory {
+  if (dossiers.some((d) => d.step === Step.ELIGIBILITE)) return "legitime";
+  if (dossiers.length === 0) return "regressable";
+  if (dossiers.every((d) => d.dsStatus === DSStatus.EN_CONSTRUCTION)) return "cleanup_requis";
+  return "a_reviewer";
+}
+
+/** Libellés courts pour l'affichage. */
+export const CATEGORY_LABELS: Record<DoubleProgressionCategory, string> = {
+  legitime: "LÉGITIME (utilisateur passif — a franchi l'éligibilité, rien à corriger)",
+  regressable: "À CORRIGER — régressable (aucun dossier DS)",
+  cleanup_requis: "À CORRIGER — cleanup requis (brouillon downstream en_construction)",
+  a_reviewer: "À REVIEWER (dossier downstream soumis côté DS)",
+};
+
+/** True si la catégorie relève du bug (par opposition aux cas légitimes). */
+export function isBugCategory(category: DoubleProgressionCategory): boolean {
+  return category !== "legitime";
+}

--- a/src/app/(backoffice)/espace-agent/demandes/[id]/components/ReponseAccompagnement.tsx
+++ b/src/app/(backoffice)/espace-agent/demandes/[id]/components/ReponseAccompagnement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { StatutValidationAmo } from "@/features/parcours/amo/domain/value-objects";
 import { RAISONS_INELIGIBILITE } from "@/features/backoffice/espace-agent/prospects/domain/types";
 import {
@@ -27,6 +27,11 @@ export function ReponseAccompagnement({ demandeId, statutActuel }: ReponseAccomp
   const [precisionAutre, setPrecisionAutre] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Garde synchrone contre le double-clic : `disabled` lié à `isSubmitting`
+  // n'est appliqué qu'au re-render suivant. Cette ref bloque les clics arrivés
+  // avant que React n'ait re-rendu, source de la race observée en prod
+  // (deux approveValidation concurrents → saut de 2 étapes).
+  const submitLockRef = useRef(false);
 
   // États pour la modale de confirmation
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -36,6 +41,9 @@ export function ReponseAccompagnement({ demandeId, statutActuel }: ReponseAccomp
   const alreadyProcessed = statutActuel !== StatutValidationAmo.EN_ATTENTE;
 
   const handleSubmit = async () => {
+    // Garde synchrone : si une soumission est déjà en vol, ignorer le clic.
+    if (submitLockRef.current) return;
+
     if (!choix) {
       setError("Veuillez sélectionner une réponse");
       return;
@@ -57,6 +65,7 @@ export function ReponseAccompagnement({ demandeId, statutActuel }: ReponseAccomp
       }
     }
 
+    submitLockRef.current = true;
     setIsSubmitting(true);
     setError(null);
 
@@ -73,6 +82,15 @@ export function ReponseAccompagnement({ demandeId, statutActuel }: ReponseAccomp
       }
 
       if (result?.success) {
+        // Si la demande était déjà traitée (race serveur), on n'ouvre pas la modale
+        // de confirmation classique : on affiche un message d'info à la place.
+        if (result.data?.alreadyProcessed) {
+          setError(
+            "Cette demande a déjà été traitée. Rafraîchissez la page pour voir l'état à jour."
+          );
+          return;
+        }
+
         // Récupérer le prochain demandeur en attente
         const nextResult = await getNextDemandeurEnAttente(demandeId);
         if (nextResult.success && nextResult.data) {
@@ -90,6 +108,7 @@ export function ReponseAccompagnement({ demandeId, statutActuel }: ReponseAccomp
       setError("Une erreur est survenue lors de la réponse");
     } finally {
       setIsSubmitting(false);
+      submitLockRef.current = false;
     }
   };
 

--- a/src/features/backoffice/espace-agent/demandes/actions/demande-detail.actions.test.ts
+++ b/src/features/backoffice/espace-agent/demandes/actions/demande-detail.actions.test.ts
@@ -147,7 +147,7 @@ describe("demande-detail.actions", () => {
 
       vi.mocked(approveValidation).mockResolvedValue({
         success: true,
-        data: { message: "Validation acceptée" },
+        data: { message: "Validation acceptée", alreadyProcessed: false, valideeAt: new Date() },
       });
 
       const result = await accepterAccompagnement("demande-123", "Commentaire test");
@@ -194,7 +194,7 @@ describe("demande-detail.actions", () => {
 
       vi.mocked(rejectEligibility).mockResolvedValue({
         success: true,
-        data: { message: "Demande refusée" },
+        data: { message: "Demande refusée", alreadyProcessed: false, valideeAt: new Date() },
       });
 
       const result = await refuserDemandeNonEligible("demande-123", "Le logement n'est pas dans une zone RGA");

--- a/src/features/backoffice/espace-agent/demandes/actions/demande-detail.actions.ts
+++ b/src/features/backoffice/espace-agent/demandes/actions/demande-detail.actions.ts
@@ -79,7 +79,7 @@ export async function getDemandeDetailAction(demandeId: string): Promise<ActionR
 export async function accepterAccompagnement(
   demandeId: string,
   commentaire?: string
-): Promise<ActionResult<{ message: string }>> {
+): Promise<ActionResult<{ message: string; alreadyProcessed: boolean; valideeAt: Date }>> {
   try {
     const readOnlyError = await assertNotSuperAdminReadOnly();
     if (readOnlyError) return { success: false, error: readOnlyError };
@@ -107,7 +107,7 @@ export async function accepterAccompagnement(
 export async function refuserDemandeNonEligible(
   demandeId: string,
   commentaire: string
-): Promise<ActionResult<{ message: string }>> {
+): Promise<ActionResult<{ message: string; alreadyProcessed: boolean; valideeAt: Date }>> {
   try {
     const readOnlyError = await assertNotSuperAdminReadOnly();
     if (readOnlyError) return { success: false, error: readOnlyError };

--- a/src/features/parcours/amo/actions/amo-validation.actions.test.ts
+++ b/src/features/parcours/amo/actions/amo-validation.actions.test.ts
@@ -85,7 +85,7 @@ describe("amo-validation.actions - Sécurité", () => {
         mockUser(UserRole.SUPER_ADMINISTRATEUR);
         vi.mocked(approveValidation).mockResolvedValue({
           success: true,
-          data: { message: "OK" },
+          data: { message: "OK", alreadyProcessed: false, valideeAt: new Date() },
         });
 
         const result = await validerLogementEligible("validation-123");
@@ -100,7 +100,7 @@ describe("amo-validation.actions - Sécurité", () => {
         mockUser(UserRole.ADMINISTRATEUR);
         vi.mocked(approveValidation).mockResolvedValue({
           success: true,
-          data: { message: "OK" },
+          data: { message: "OK", alreadyProcessed: false, valideeAt: new Date() },
         });
 
         const result = await validerLogementEligible("validation-123", "Commentaire");
@@ -116,7 +116,7 @@ describe("amo-validation.actions - Sécurité", () => {
         mockValidationInDb("entreprise-123");
         vi.mocked(approveValidation).mockResolvedValue({
           success: true,
-          data: { message: "OK" },
+          data: { message: "OK", alreadyProcessed: false, valideeAt: new Date() },
         });
 
         const result = await validerLogementEligible("validation-123");
@@ -212,7 +212,7 @@ describe("amo-validation.actions - Sécurité", () => {
       mockValidationInDb("entreprise-123");
       vi.mocked(rejectEligibility).mockResolvedValue({
         success: true,
-        data: { message: "Refusé" },
+        data: { message: "Refusé", alreadyProcessed: false, valideeAt: new Date() },
       });
 
       const result = await refuserLogementNonEligible(

--- a/src/features/parcours/amo/actions/amo-validation.actions.ts
+++ b/src/features/parcours/amo/actions/amo-validation.actions.ts
@@ -61,7 +61,7 @@ async function verifyAmoOwnership(validationId: string): Promise<ActionResult<{ 
 export async function validerLogementEligible(
   validationId: string,
   commentaire?: string
-): Promise<ActionResult<{ message: string }>> {
+): Promise<ActionResult<{ message: string; alreadyProcessed: boolean; valideeAt: Date }>> {
   try {
     // Vérifier que l'agent AMO est propriétaire de cette validation
     const ownershipCheck = await verifyAmoOwnership(validationId);
@@ -86,7 +86,7 @@ export async function validerLogementEligible(
 export async function refuserLogementNonEligible(
   validationId: string,
   commentaire: string
-): Promise<ActionResult<{ message: string }>> {
+): Promise<ActionResult<{ message: string; alreadyProcessed: boolean; valideeAt: Date }>> {
   try {
     // Vérifier que l'agent AMO est propriétaire de cette validation
     const ownershipCheck = await verifyAmoOwnership(validationId);

--- a/src/features/parcours/amo/services/amo-validation.service.test.ts
+++ b/src/features/parcours/amo/services/amo-validation.service.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { approveValidation, rejectEligibility, getValidationByToken } from "./amo-validation.service";
 import { db } from "@/shared/database/client";
-import { parcoursRepo } from "@/shared/database/repositories";
 import { getAmoById } from "./amo-query.service";
-import { moveToNextStep } from "../../core/services";
-import { Status, Step } from "../../core";
-import { SituationParticulier } from "@/shared/domain/value-objects/situation-particulier.enum";
 import type { StatutValidationAmo } from "../domain/value-objects";
 
 // Mock des dépendances
@@ -14,14 +10,7 @@ vi.mock("@/shared/database/client", () => ({
     select: vi.fn(),
     insert: vi.fn(),
     update: vi.fn(),
-  },
-}));
-
-vi.mock("@/shared/database/repositories", () => ({
-  parcoursRepo: {
-    findByUserId: vi.fn(),
-    findById: vi.fn(),
-    updateStatus: vi.fn(),
+    transaction: vi.fn(),
   },
 }));
 
@@ -34,25 +23,200 @@ vi.mock("@/shared/email/actions/send-email.actions", () => ({
   sendValidationAmoEmail: vi.fn(),
 }));
 
-vi.mock("../../core/services", () => ({
-  moveToNextStep: vi.fn(),
-}));
-
 // Mock de crypto.randomUUID
 vi.stubGlobal("crypto", {
   randomUUID: vi.fn(() => "mock-uuid-token"),
 });
 
+/**
+ * Helper : configure `db.transaction` pour appeler le callback avec un tx mocké.
+ * `tx` est juste `db` lui-même — les tests configurent ensuite `db.update` et `db.select`.
+ */
+function mockTransactionPassthrough() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(db));
+}
+
+/**
+ * Helper : configure la chaîne `db.update(...).set(...).where(...).returning(...)` pour
+ * retourner le résultat fourni. Utiliser `mockReturnValueOnce` permet de chaîner plusieurs
+ * appels successifs.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockUpdateReturning(rows: any[]) {
+  vi.mocked(db.update).mockReturnValueOnce({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+/**
+ * Helper : configure une chaîne `db.update(...).set(...).where(...)` sans `.returning()`
+ * (cas du UPDATE token et du UPDATE parcours sans condition de retour).
+ */
+function mockUpdateNoReturning() {
+  vi.mocked(db.update).mockReturnValueOnce({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+/**
+ * Helper : configure une chaîne `db.select(...).from(...).where(...).limit(...)`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockSelectLimit(rows: any[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
 describe("amo-validation.service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockTransactionPassthrough();
+  });
+
+  describe("approveValidation", () => {
+    const validationId = "validation-001";
+    const parcoursId = "parcours-789";
+
+    it("approuve une validation et fait avancer le parcours à ELIGIBILITE/TODO", async () => {
+      // 1. UPDATE validation conditional → retourne la row mise à jour
+      mockUpdateReturning([{ id: validationId, parcoursId }]);
+      // 2. UPDATE token → no returning
+      mockUpdateNoReturning();
+      // 3. UPDATE parcours conditional → retourne le parcours mis à jour
+      mockUpdateReturning([{ id: parcoursId }]);
+
+      const result = await approveValidation(validationId, "commentaire test");
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.message).toBe("Logement validé comme éligible");
+        expect(result.data.alreadyProcessed).toBe(false);
+        expect(result.data.valideeAt).toBeInstanceOf(Date);
+      }
+      expect(db.transaction).toHaveBeenCalledTimes(1);
+      expect(db.update).toHaveBeenCalledTimes(3);
+    });
+
+    it("est idempotent : un second appel sur une validation déjà traitée retourne alreadyProcessed:true", async () => {
+      const alreadyValideeAt = new Date("2026-05-22T11:37:00Z");
+      // 1. UPDATE validation conditional → 0 row (déjà validée)
+      mockUpdateReturning([]);
+      // 2. SELECT validation → trouve la row déjà validée
+      mockSelectLimit([{ id: validationId, valideeAt: alreadyValideeAt }]);
+
+      const result = await approveValidation(validationId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.alreadyProcessed).toBe(true);
+        expect(result.data.valideeAt).toEqual(alreadyValideeAt);
+        expect(result.data.message).toBe("Demande déjà traitée");
+      }
+      // Pas d'UPDATE supplémentaire (ni token ni parcours)
+      expect(db.update).toHaveBeenCalledTimes(1);
+    });
+
+    it("retourne 'Validation non trouvée' si l'ID n'existe pas", async () => {
+      mockUpdateReturning([]); // UPDATE conditional 0 row
+      mockSelectLimit([]); // SELECT confirme : aucune row
+
+      const result = await approveValidation(validationId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Validation non trouvée");
+      }
+    });
+
+    it("warn et continue si le parcours n'est plus à CHOIX_AMO/INVITATION (skip transition step)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      mockUpdateReturning([{ id: validationId, parcoursId }]); // validation OK
+      mockUpdateNoReturning(); // token OK
+      mockUpdateReturning([]); // parcours conditional 0 row (déjà avancé)
+
+      const result = await approveValidation(validationId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.alreadyProcessed).toBe(false);
+      }
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("déjà progressé hors CHOIX_AMO/INVITATION")
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("rejectEligibility", () => {
+    const validationId = "validation-001";
+    const parcoursId = "parcours-789";
+    const commentaire = "Logement hors zone à risque";
+
+    it("refuse une validation et remet le parcours en TODO sur CHOIX_AMO", async () => {
+      mockUpdateReturning([{ id: validationId, parcoursId }]);
+      mockUpdateNoReturning(); // token
+      mockUpdateNoReturning(); // parcours (pas de returning ici)
+
+      const result = await rejectEligibility(validationId, commentaire);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.message).toBe("Logement refusé : non éligible");
+        expect(result.data.alreadyProcessed).toBe(false);
+      }
+      expect(db.update).toHaveBeenCalledTimes(3);
+    });
+
+    it("est idempotent : un second appel retourne alreadyProcessed:true", async () => {
+      const alreadyValideeAt = new Date("2026-05-22T11:37:00Z");
+      mockUpdateReturning([]); // UPDATE conditional 0 row
+      mockSelectLimit([{ id: validationId, valideeAt: alreadyValideeAt }]);
+
+      const result = await rejectEligibility(validationId, commentaire);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.alreadyProcessed).toBe(true);
+        expect(result.data.valideeAt).toEqual(alreadyValideeAt);
+      }
+      expect(db.update).toHaveBeenCalledTimes(1);
+    });
+
+    it("retourne 'Validation non trouvée' si l'ID n'existe pas", async () => {
+      mockUpdateReturning([]);
+      mockSelectLimit([]);
+
+      const result = await rejectEligibility(validationId, commentaire);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Validation non trouvée");
+      }
+    });
   });
 
   describe("getValidationByToken", () => {
     const validToken = "valid-token-123";
     const mockTokenData = {
       tokenId: "token-001",
-      expiresAt: new Date("2025-12-31T23:59:59Z"),
+      expiresAt: new Date("2027-12-31T23:59:59Z"),
       usedAt: null,
       validationId: "validation-001",
       statut: "en_attente" as StatutValidationAmo,
@@ -64,11 +228,7 @@ describe("amo-validation.service", () => {
       userTelephone: "0123456789",
       adresseLogement: "123 rue de la Paix",
       parcoursId: "parcours-789",
-      rgaSimulationData: {
-        logement: {
-          commune: "75001",
-        },
-      },
+      rgaSimulationData: { logement: { commune: "75001" } },
     };
 
     const mockAmo = {
@@ -81,432 +241,71 @@ describe("amo-validation.service", () => {
       adresse: "1 rue AMO",
     };
 
-    beforeEach(() => {
-      vi.setSystemTime(new Date("2025-01-15T10:00:00Z"));
-
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function mockTokenSelect(rows: any) {
+      const arr = Array.isArray(rows) ? rows : [rows];
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           innerJoin: vi.fn().mockReturnThis(),
           where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([mockTokenData]),
+            limit: vi.fn().mockResolvedValue(arr),
           }),
         }),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
+    }
 
+    beforeEach(() => {
+      vi.setSystemTime(new Date("2025-01-15T10:00:00Z"));
+      mockTokenSelect(mockTokenData);
       vi.mocked(getAmoById).mockResolvedValue(mockAmo);
     });
 
-    it("devrait réussir avec un token valide", async () => {
+    it("réussit avec un token valide", async () => {
       const result = await getValidationByToken(validToken);
-
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data).toEqual({
-          validationId: mockTokenData.validationId,
-          entrepriseAmo: mockAmo,
-          demandeur: {
-            codeInsee: "75001",
-            nom: mockTokenData.userNom,
-            prenom: mockTokenData.userPrenom,
-            adresseLogement: mockTokenData.adresseLogement,
-            email: mockTokenData.userEmail,
-            telephone: mockTokenData.userTelephone,
-          },
-          statut: mockTokenData.statut,
-          choisieAt: mockTokenData.choisieAt,
-          usedAt: null,
-          isExpired: false,
-          isUsed: false,
-        });
+        expect(result.data.validationId).toBe(mockTokenData.validationId);
+        expect(result.data.demandeur.codeInsee).toBe("75001");
+        expect(result.data.isExpired).toBe(false);
+        expect(result.data.isUsed).toBe(false);
       }
     });
 
-    it("devrait échouer si le token est introuvable", async () => {
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          innerJoin: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([]),
-          }),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
+    it("échoue si le token est introuvable", async () => {
+      mockTokenSelect([]);
       const result = await getValidationByToken("invalid-token");
-
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error).toBe("Token invalide ou introuvable");
       }
     });
 
-    it("devrait échouer si le token est expiré", async () => {
-      const expiredTokenData = {
-        ...mockTokenData,
-        expiresAt: new Date("2020-01-01T00:00:00Z"),
-      };
-
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          innerJoin: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([expiredTokenData]),
-          }),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
+    it("échoue si le token est expiré", async () => {
+      mockTokenSelect({ ...mockTokenData, expiresAt: new Date("2020-01-01T00:00:00Z") });
       const result = await getValidationByToken(validToken);
-
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error).toBe("Ce token a expiré");
       }
     });
 
-    it("devrait détecter correctement un token utilisé", async () => {
-      const usedTokenData = {
-        ...mockTokenData,
-        usedAt: new Date("2025-01-14T10:00:00Z"),
-      };
-
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          innerJoin: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([usedTokenData]),
-          }),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
+    it("détecte un token utilisé", async () => {
+      mockTokenSelect({ ...mockTokenData, usedAt: new Date("2025-01-14T10:00:00Z") });
       const result = await getValidationByToken(validToken);
-
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.isUsed).toBe(true);
-        expect(result.data.usedAt).toEqual(usedTokenData.usedAt);
       }
     });
 
-    it("devrait échouer si l'AMO n'est pas trouvée", async () => {
+    it("échoue si l'AMO n'est pas trouvée", async () => {
       vi.mocked(getAmoById).mockResolvedValue(null);
-
       const result = await getValidationByToken(validToken);
-
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error).toBe("AMO non trouvée");
       }
     });
-
-    it("devrait gérer les données personnelles manquantes", async () => {
-      const tokenDataWithNulls = {
-        ...mockTokenData,
-        userNom: null,
-        userPrenom: null,
-        userEmail: null,
-        userTelephone: null,
-        adresseLogement: null,
-        rgaSimulationData: null,
-      };
-
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          innerJoin: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([tokenDataWithNulls]),
-          }),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
-      const result = await getValidationByToken(validToken);
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.demandeur).toEqual({
-          codeInsee: "",
-          nom: "",
-          prenom: "",
-          adresseLogement: "",
-          email: "",
-          telephone: "",
-        });
-      }
-    });
   });
-
-  describe("approveValidation", () => {
-    const validationId = "validation-001";
-    const parcoursId = "parcours-789";
-    const userId = "user-123";
-
-    const mockValidation = {
-      id: validationId,
-      parcoursId,
-    };
-
-    const mockParcours = {
-      id: parcoursId,
-      createdAt: new Date("2025-01-01T00:00:00Z"),
-      updatedAt: new Date("2025-01-01T00:00:00Z"),
-      userId,
-      currentStep: Step.CHOIX_AMO,
-      currentStatus: Status.EN_INSTRUCTION,
-      completedAt: null,
-      rgaSimulationData: null,
-      rgaSimulationCompletedAt: null,
-      rgaDataDeletedAt: null,
-      rgaDataDeletionReason: null,
-      situationParticulier: SituationParticulier.PROSPECT,
-      rgaSimulationDataAgent: null,
-      rgaSimulationAgentEditedAt: null,
-      rgaSimulationAgentEditedBy: null,
-      archivedAt: null,
-      archiveReason: null,
-      archivedBy: null,
-      createdByAgentId: null,
-    };
-
-    beforeEach(() => {
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([mockValidation]),
-          }),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
-      vi.mocked(parcoursRepo.findById).mockResolvedValue(mockParcours);
-
-      vi.mocked(db.update).mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
-      vi.mocked(parcoursRepo.updateStatus).mockResolvedValue(mockParcours);
-
-      vi.mocked(moveToNextStep).mockResolvedValue({
-        success: true,
-        data: {
-          state: {
-            step: Step.ELIGIBILITE,
-            status: Status.TODO,
-          },
-          complete: false,
-        },
-      });
-    });
-
-    it("devrait approuver la validation avec succès", async () => {
-      const result = await approveValidation(validationId);
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.message).toBe("Logement validé comme éligible");
-      }
-    });
-
-    it("devrait mettre à jour le statut à logement_eligible", async () => {
-      await approveValidation(validationId);
-
-      expect(db.update).toHaveBeenCalled();
-      const updateCall = vi.mocked(db.update).mock.results[0];
-      expect(updateCall.value.set).toHaveBeenCalledWith(
-        expect.objectContaining({
-          statut: "logement_eligible",
-          valideeAt: expect.any(Date),
-        })
-      );
-    });
-
-    it("devrait sauvegarder le commentaire optionnel", async () => {
-      const commentaire = "Excellent dossier, logement conforme";
-
-      await approveValidation(validationId, commentaire);
-
-      const updateCall = vi.mocked(db.update).mock.results[0];
-      expect(updateCall.value.set).toHaveBeenCalledWith(
-        expect.objectContaining({
-          commentaire,
-        })
-      );
-    });
-
-    it("devrait marquer le token comme utilisé", async () => {
-      await approveValidation(validationId);
-
-      expect(db.update).toHaveBeenCalled();
-    });
-
-    it("devrait supprimer les données personnelles (RGPD)", async () => {
-      await approveValidation(validationId);
-
-      expect(db.update).toHaveBeenCalled();
-    });
-
-    it("devrait passer le parcours en VALIDE", async () => {
-      await approveValidation(validationId);
-
-      expect(parcoursRepo.updateStatus).toHaveBeenCalledWith(parcoursId, Status.VALIDE);
-    });
-
-    it("devrait faire progresser vers l'étape ELIGIBILITE", async () => {
-      await approveValidation(validationId);
-
-      expect(moveToNextStep).toHaveBeenCalledWith(userId);
-    });
-
-    it("devrait échouer si la validation n'est pas trouvée", async () => {
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([]),
-          }),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
-      const result = await approveValidation(validationId);
-
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toBe("Validation non trouvée");
-      }
-    });
-
-    it("devrait échouer si le parcours n'est pas trouvé", async () => {
-      vi.mocked(parcoursRepo.findById).mockResolvedValue(null);
-
-      const result = await approveValidation(validationId);
-
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toBe("Parcours non trouvé");
-      }
-    });
-
-    it("devrait échouer si la progression vers l'étape suivante échoue", async () => {
-      vi.mocked(moveToNextStep).mockResolvedValue({
-        success: false,
-        error: "Erreur progression",
-      });
-
-      const result = await approveValidation(validationId);
-
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toBe("Erreur lors de la progression vers l'éligibilité");
-      }
-    });
-  });
-
-  describe("rejectEligibility", () => {
-    const validationId = "validation-001";
-    const commentaire = "Le logement n'est pas dans une zone à risque";
-
-    const mockValidation = {
-      id: validationId,
-      parcoursId: "parcours-789",
-      statut: "logement_non_eligible" as StatutValidationAmo,
-    };
-
-    const mockParcours = {
-      id: "parcours-789",
-      createdAt: new Date("2025-01-01T00:00:00Z"),
-      updatedAt: new Date("2025-01-01T00:00:00Z"),
-      userId: "user-123",
-      currentStep: Step.CHOIX_AMO,
-      currentStatus: Status.EN_INSTRUCTION,
-      completedAt: null,
-      rgaSimulationData: null,
-      rgaSimulationCompletedAt: null,
-      rgaDataDeletedAt: null,
-      rgaDataDeletionReason: null,
-      situationParticulier: SituationParticulier.PROSPECT,
-      rgaSimulationDataAgent: null,
-      rgaSimulationAgentEditedAt: null,
-      rgaSimulationAgentEditedBy: null,
-      archivedAt: null,
-      archiveReason: null,
-      archivedBy: null,
-      createdByAgentId: null,
-    };
-
-    beforeEach(() => {
-      vi.mocked(db.update).mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([mockValidation]),
-          }),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
-      vi.mocked(parcoursRepo.updateStatus).mockResolvedValue(mockParcours);
-    });
-
-    it("devrait refuser l'éligibilité avec succès", async () => {
-      const result = await rejectEligibility(validationId, commentaire);
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.message).toBe("Logement refusé : non éligible");
-      }
-    });
-
-    it("devrait mettre à jour le statut à logement_non_eligible", async () => {
-      await rejectEligibility(validationId, commentaire);
-
-      expect(db.update).toHaveBeenCalled();
-      const updateCall = vi.mocked(db.update).mock.results[0];
-      expect(updateCall.value.set).toHaveBeenCalledWith({
-        statut: "logement_non_eligible",
-        commentaire,
-        valideeAt: expect.any(Date),
-      });
-    });
-
-    it("devrait marquer le token comme utilisé", async () => {
-      await rejectEligibility(validationId, commentaire);
-
-      expect(db.update).toHaveBeenCalled();
-    });
-
-    it("devrait supprimer les données personnelles (RGPD)", async () => {
-      await rejectEligibility(validationId, commentaire);
-
-      expect(db.update).toHaveBeenCalled();
-    });
-
-    it("devrait repasser le parcours en TODO", async () => {
-      await rejectEligibility(validationId, commentaire);
-
-      expect(parcoursRepo.updateStatus).toHaveBeenCalledWith(mockValidation.parcoursId, Status.TODO);
-    });
-
-    it("devrait échouer si la validation n'est pas trouvée", async () => {
-      vi.mocked(db.update).mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([]),
-          }),
-        }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
-      const result = await rejectEligibility(validationId, commentaire);
-
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toBe("Validation non trouvée");
-      }
-    });
-  });
-
 });

--- a/src/features/parcours/amo/services/amo-validation.service.ts
+++ b/src/features/parcours/amo/services/amo-validation.service.ts
@@ -1,117 +1,243 @@
-import { eq } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { db } from "@/shared/database/client";
 import { amoValidationTokens, parcoursAmoValidations, parcoursPrevention } from "@/shared/database/schema";
-import { parcoursRepo } from "@/shared/database/repositories";
 
 import { getAmoById } from "./amo-query.service";
 import { ActionResult } from "@/shared/types/action-result.types";
 import { StatutValidationAmo } from "../domain/value-objects";
 import { ValidationAmoData } from "../domain/entities";
-import { Status } from "../../core";
-import { moveToNextStep } from "../../core/services";
+import { Status, Step } from "../../core";
 import { normalizeCodeInsee } from "../utils/amo.utils";
 
 /**
  * Service de gestion des validations AMO (approve/reject/get)
  * La sélection AMO est dans amo-selection.service.ts
+ *
+ * Garanties :
+ * - **Idempotence** : un second appel sur une validation déjà traitée (valideeAt
+ *   non null) retourne `success: true, alreadyProcessed: true` sans muter la BDD.
+ * - **Transition atomique** : la mise à jour de la validation, du token et du
+ *   parcours est faite dans une seule transaction. La transition du parcours
+ *   est conditionnée sur l'état attendu (CHOIX_AMO/INVITATION) — un parcours
+ *   déjà progressé ne sera pas re-poussé.
+ *
+ * Ces deux propriétés ferment la race observée en prod où deux appels
+ * concurrents à approveValidation faisaient avancer le parcours de DEUX étapes
+ * (CHOIX_AMO → ELIGIBILITE → DIAGNOSTIC) au lieu d'une seule.
  */
 
+interface ApproveValidationData {
+  message: string;
+  alreadyProcessed: boolean;
+  valideeAt: Date;
+}
+
 /**
- * Approuve la validation (logement éligible)
+ * Approuve la validation (logement éligible).
+ *
+ * Transition métier : `CHOIX_AMO/EN_INSTRUCTION → ELIGIBILITE/TODO`
+ * (ou no-op sur le step si le parcours n'est plus à CHOIX_AMO/INVITATION).
  */
 export async function approveValidation(
   validationId: string,
   commentaire?: string
-): Promise<ActionResult<{ message: string }>> {
-  // Récupérer la validation
-  const [validation] = await db
-    .select({
-      id: parcoursAmoValidations.id,
-      parcoursId: parcoursAmoValidations.parcoursId,
-    })
-    .from(parcoursAmoValidations)
-    .where(eq(parcoursAmoValidations.id, validationId))
-    .limit(1);
+): Promise<ActionResult<ApproveValidationData>> {
+  try {
+    return await db.transaction(async (tx) => {
+      const now = new Date();
 
-  if (!validation) {
-    return { success: false, error: "Validation non trouvée" };
-  }
+      // 1. UPDATE conditionnel : ne marque la validation comme validée que si
+      //    elle ne l'est pas déjà. Sous READ COMMITTED, deux UPDATE concurrents
+      //    sur la même ligne sont sérialisés ; le 2e réévalue valideeAt IS NULL
+      //    après le commit du 1er → retourne 0 row.
+      const [validation] = await tx
+        .update(parcoursAmoValidations)
+        .set({
+          statut: StatutValidationAmo.LOGEMENT_ELIGIBLE,
+          commentaire: commentaire || null,
+          valideeAt: now,
+        })
+        .where(
+          and(
+            eq(parcoursAmoValidations.id, validationId),
+            isNull(parcoursAmoValidations.valideeAt)
+          )
+        )
+        .returning({
+          id: parcoursAmoValidations.id,
+          parcoursId: parcoursAmoValidations.parcoursId,
+        });
 
-  // Récupérer le parcours
-  const parcours = await parcoursRepo.findById(validation.parcoursId);
-  if (!parcours) {
-    return { success: false, error: "Parcours non trouvé" };
-  }
+      if (!validation) {
+        // Soit la validation n'existe pas, soit elle est déjà validée.
+        // On lit l'état pour distinguer et donner le bon feedback.
+        const [existing] = await tx
+          .select({
+            id: parcoursAmoValidations.id,
+            valideeAt: parcoursAmoValidations.valideeAt,
+          })
+          .from(parcoursAmoValidations)
+          .where(eq(parcoursAmoValidations.id, validationId))
+          .limit(1);
 
-  // Mettre à jour la validation AMO
-  await db
-    .update(parcoursAmoValidations)
-    .set({
-      statut: StatutValidationAmo.LOGEMENT_ELIGIBLE,
-      commentaire: commentaire || null,
-      valideeAt: new Date(),
-    })
-    .where(eq(parcoursAmoValidations.id, validationId));
+        if (!existing) {
+          return { success: false, error: "Validation non trouvée" };
+        }
 
-  // Marquer le token comme utilisé
-  await db
-    .update(amoValidationTokens)
-    .set({ usedAt: new Date() })
-    .where(eq(amoValidationTokens.parcoursAmoValidationId, validationId));
+        return {
+          success: true,
+          data: {
+            message: "Demande déjà traitée",
+            alreadyProcessed: true,
+            valideeAt: existing.valideeAt as Date,
+          },
+        };
+      }
 
-  // Passer le parcours en VALIDE
-  await parcoursRepo.updateStatus(validation.parcoursId, Status.VALIDE);
+      // 2. Marquer le token comme utilisé (idempotent : un même UPDATE deux fois
+      //    écrit la même valeur).
+      await tx
+        .update(amoValidationTokens)
+        .set({ usedAt: now })
+        .where(eq(amoValidationTokens.parcoursAmoValidationId, validationId));
 
-  // Faire progresser vers l'étape ELIGIBILITE
-  const progressResult = await moveToNextStep(parcours.userId);
+      // 3. Transition atomique du parcours : CHOIX_AMO → ELIGIBILITE/TODO.
+      //    Conditionnée sur (currentStep IN [CHOIX_AMO, INVITATION]) pour ne PAS
+      //    re-progresser un parcours qui est déjà ailleurs (sécurité face à un
+      //    code path concurrent qui aurait déjà avancé le step).
+      const [parcoursUpdated] = await tx
+        .update(parcoursPrevention)
+        .set({
+          currentStep: Step.ELIGIBILITE,
+          currentStatus: Status.TODO,
+        })
+        .where(
+          and(
+            eq(parcoursPrevention.id, validation.parcoursId),
+            inArray(parcoursPrevention.currentStep, [Step.CHOIX_AMO, Step.INVITATION])
+          )
+        )
+        .returning({ id: parcoursPrevention.id });
 
-  if (!progressResult.success) {
+      if (!parcoursUpdated) {
+        console.warn(
+          `[approveValidation] parcours ${validation.parcoursId} déjà progressé hors CHOIX_AMO/INVITATION — step non touché`
+        );
+      }
+
+      return {
+        success: true,
+        data: {
+          message: "Logement validé comme éligible",
+          alreadyProcessed: false,
+          valideeAt: now,
+        },
+      };
+    });
+  } catch (error) {
+    console.error("Erreur approveValidation:", error);
     return {
       success: false,
-      error: "Erreur lors de la progression vers l'éligibilité",
+      error: error instanceof Error ? error.message : "Erreur lors de la validation",
     };
   }
+}
 
-  return {
-    success: true,
-    data: { message: "Logement validé comme éligible" },
-  };
+interface RejectValidationData {
+  message: string;
+  alreadyProcessed: boolean;
+  valideeAt: Date;
 }
 
 /**
- * Refuse l'éligibilité du logement
+ * Refuse l'éligibilité du logement.
+ *
+ * Transition métier : `CHOIX_AMO/EN_INSTRUCTION → CHOIX_AMO/TODO`
+ * (le step reste, le status repasse à TODO pour permettre une nouvelle sélection AMO).
  */
 export async function rejectEligibility(
   validationId: string,
   commentaire: string
-): Promise<ActionResult<{ message: string }>> {
-  const [validation] = await db
-    .update(parcoursAmoValidations)
-    .set({
-      statut: StatutValidationAmo.LOGEMENT_NON_ELIGIBLE,
-      commentaire,
-      valideeAt: new Date(),
-    })
-    .where(eq(parcoursAmoValidations.id, validationId))
-    .returning();
+): Promise<ActionResult<RejectValidationData>> {
+  try {
+    return await db.transaction(async (tx) => {
+      const now = new Date();
 
-  if (!validation) {
-    return { success: false, error: "Validation non trouvée" };
+      const [validation] = await tx
+        .update(parcoursAmoValidations)
+        .set({
+          statut: StatutValidationAmo.LOGEMENT_NON_ELIGIBLE,
+          commentaire,
+          valideeAt: now,
+        })
+        .where(
+          and(
+            eq(parcoursAmoValidations.id, validationId),
+            isNull(parcoursAmoValidations.valideeAt)
+          )
+        )
+        .returning({
+          id: parcoursAmoValidations.id,
+          parcoursId: parcoursAmoValidations.parcoursId,
+        });
+
+      if (!validation) {
+        const [existing] = await tx
+          .select({
+            id: parcoursAmoValidations.id,
+            valideeAt: parcoursAmoValidations.valideeAt,
+          })
+          .from(parcoursAmoValidations)
+          .where(eq(parcoursAmoValidations.id, validationId))
+          .limit(1);
+
+        if (!existing) {
+          return { success: false, error: "Validation non trouvée" };
+        }
+
+        return {
+          success: true,
+          data: {
+            message: "Demande déjà traitée",
+            alreadyProcessed: true,
+            valideeAt: existing.valideeAt as Date,
+          },
+        };
+      }
+
+      await tx
+        .update(amoValidationTokens)
+        .set({ usedAt: now })
+        .where(eq(amoValidationTokens.parcoursAmoValidationId, validationId));
+
+      // Reset du status parcours à TODO, conditionné sur step = CHOIX_AMO pour
+      // ne pas perturber un parcours qui aurait été progressé par ailleurs.
+      await tx
+        .update(parcoursPrevention)
+        .set({ currentStatus: Status.TODO })
+        .where(
+          and(
+            eq(parcoursPrevention.id, validation.parcoursId),
+            eq(parcoursPrevention.currentStep, Step.CHOIX_AMO)
+          )
+        );
+
+      return {
+        success: true,
+        data: {
+          message: "Logement refusé : non éligible",
+          alreadyProcessed: false,
+          valideeAt: now,
+        },
+      };
+    });
+  } catch (error) {
+    console.error("Erreur rejectEligibility:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Erreur lors du refus",
+    };
   }
-
-  // Marquer le token comme utilisé
-  await db
-    .update(amoValidationTokens)
-    .set({ usedAt: new Date() })
-    .where(eq(amoValidationTokens.parcoursAmoValidationId, validationId));
-
-  // Repasser le parcours en TODO
-  await parcoursRepo.updateStatus(validation.parcoursId, Status.TODO);
-
-  return {
-    success: true,
-    data: { message: "Logement refusé : non éligible" },
-  };
 }
 
 /**


### PR DESCRIPTION
Corrige le bug de double-progression AMO : deux validations concurrentes faisaient sauter une étape sans dossier DS. approveValidation/rejectEligibility rendus idempotents + atomiques, garde anti-double-clic côté UI.

Ajoute l'outillage d'audit et de correction du stock (scripts ops + runbook) et le doc d'incident.