### PR TITLE
feat(espace-agent): persiste les filtres dossiers dans l'URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fonds-prevention-argile",
   "version": "1.13.1",
   "private": true,
-  "packageManager": "pnpm@11.5.0",
+  "packageManager": "pnpm@11.5.2",
   "engines": {
     "node": "24.x"
   },

--- a/src/app/(backoffice)/espace-agent/dossiers/components/DossiersPanel.tsx
+++ b/src/app/(backoffice)/espace-agent/dossiers/components/DossiersPanel.tsx
@@ -2,23 +2,20 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { parseDossiersFilters, serializeDossiersFilters, type Scope } from "./dossiers-filters-url";
 import {
   getDossiersTerritoireDataAction,
   type DossiersTerritoireData,
 } from "@/features/backoffice/espace-agent/dossiers/actions/get-dossiers-territoire-data.action";
 import type { DossierItem } from "@/features/backoffice/espace-agent/dossiers/domain/types";
-import {
-  getDossierStepLabel,
-  getResponsableDisplayName,
-} from "@/features/backoffice/espace-agent/dossiers/domain";
+import { getDossierStepLabel, getResponsableDisplayName } from "@/features/backoffice/espace-agent/dossiers/domain";
 import type { DossierEtat } from "@/features/parcours/core/domain/services/dossier-etat.service";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import { DossiersSuivisHeader } from "./DossiersSuivisHeader";
 import { DossiersSuivisTable } from "./DossiersSuivisTable";
 import { DossiersKpiCards, type DossiersKpiCounters } from "./DossiersKpiCards";
 import { Pagination } from "@/shared/components/Pagination/Pagination";
-
-type Scope = "mine" | "all";
 
 interface DossiersPanelProps {
   /** Affiche le bouton "+ Nouveau dossier" (rôles AMO et/ou Aller-vers). */
@@ -63,25 +60,62 @@ const EN_ATTENTE_FILTRABLES: ReadonlyArray<{ value: DossierEtat; label: string }
 /**
  * Panel unifié des dossiers — tags Mes/Tous, filtre EPCI et recherche.
  */
-export function DossiersPanel({
-  canCreateDossier = false,
-  defaultScope = "all",
-  prenom,
-}: DossiersPanelProps) {
+export function DossiersPanel({ canCreateDossier = false, defaultScope = "all", prenom }: DossiersPanelProps) {
   const [data, setData] = useState<DossiersTerritoireData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  const [activeScope, setActiveScope] = useState<Scope>(defaultScope);
-  const [epciFilter, setEpciFilter] = useState<string>("");
-  const [search, setSearch] = useState<string>("");
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(20);
+  // État initial des filtres lu une seule fois depuis l'URL (query string).
+  // Permet de restaurer les filtres au retour « Précédent » et de partager une
+  // vue filtrée. La synchro état → URL est faite par l'effet plus bas.
+  const searchParams = useSearchParams();
+  const [initialFilters] = useState(() =>
+    parseDossiersFilters(new URLSearchParams(searchParams.toString()), defaultScope)
+  );
+
+  const [activeScope, setActiveScope] = useState<Scope>(initialFilters.scope);
+  const [epciFilter, setEpciFilter] = useState<string>(initialFilters.epci);
+  const [search, setSearch] = useState<string>(initialFilters.search);
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">(initialFilters.sort);
+  const [page, setPage] = useState(initialFilters.page);
+  const [pageSize, setPageSize] = useState(initialFilters.pageSize);
   // Filtres par colonne (multi-sélection, live).
-  const [responsableFilter, setResponsableFilter] = useState<Set<string>>(new Set());
-  const [etapeFilter, setEtapeFilter] = useState<Set<string>>(new Set());
-  const [enAttenteFilter, setEnAttenteFilter] = useState<Set<string>>(new Set());
+  const [responsableFilter, setResponsableFilter] = useState<Set<string>>(initialFilters.responsable);
+  const [etapeFilter, setEtapeFilter] = useState<Set<string>>(initialFilters.etape);
+  const [enAttenteFilter, setEnAttenteFilter] = useState<Set<string>>(initialFilters.enAttente);
+
+  // Synchronise les filtres dans l'URL à chaque changement, via l'History API
+  // (replaceState) plutôt que router.replace : on évite un refetch RSC à chaque
+  // frappe tout en gardant l'URL à jour pour le partage et le « Précédent ».
+  useEffect(() => {
+    const qs = serializeDossiersFilters(
+      {
+        scope: activeScope,
+        search,
+        epci: epciFilter,
+        sort: sortOrder,
+        page,
+        pageSize,
+        responsable: responsableFilter,
+        etape: etapeFilter,
+        enAttente: enAttenteFilter,
+      },
+      defaultScope
+    );
+    const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+    window.history.replaceState(null, "", url);
+  }, [
+    activeScope,
+    search,
+    epciFilter,
+    sortOrder,
+    page,
+    pageSize,
+    responsableFilter,
+    etapeFilter,
+    enAttenteFilter,
+    defaultScope,
+  ]);
 
   const loadData = useCallback(async () => {
     try {
@@ -185,9 +219,10 @@ export function DossiersPanel({
     return {
       responsables: toOptions(responsables),
       etapes: toEtapeOptions(etapes),
-      enAttente: EN_ATTENTE_FILTRABLES.filter((opt) => etatsPresents.has(opt.value)).map(
-        ({ value, label }) => ({ value, label })
-      ),
+      enAttente: EN_ATTENTE_FILTRABLES.filter((opt) => etatsPresents.has(opt.value)).map(({ value, label }) => ({
+        value,
+        label,
+      })),
     };
   }, [visible]);
 
@@ -368,10 +403,7 @@ export function DossiersPanel({
               {activeScope === "mine" && (
                 <>
                   {" "}
-                  <button
-                    type="button"
-                    className="fr-link"
-                    onClick={() => handleScopeChange("all")}>
+                  <button type="button" className="fr-link" onClick={() => handleScopeChange("all")}>
                     Élargir la recherche à tous les dossiers
                   </button>
                 </>

--- a/src/app/(backoffice)/espace-agent/dossiers/components/DossiersPanel.tsx
+++ b/src/app/(backoffice)/espace-agent/dossiers/components/DossiersPanel.tsx
@@ -2,8 +2,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { parseDossiersFilters, serializeDossiersFilters, type Scope } from "./dossiers-filters-url";
+import { usePathname, useSearchParams } from "next/navigation";
+import {
+  parseDossiersFilters,
+  serializeDossiersFilters,
+  type DossiersFiltersState,
+  type Scope,
+} from "./dossiers-filters-url";
 import {
   getDossiersTerritoireDataAction,
   type DossiersTerritoireData,
@@ -65,57 +70,51 @@ export function DossiersPanel({ canCreateDossier = false, defaultScope = "all", 
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // État initial des filtres lu une seule fois depuis l'URL (query string).
-  // Permet de restaurer les filtres au retour « Précédent » et de partager une
-  // vue filtrée. La synchro état → URL est faite par l'effet plus bas.
+  // Source de vérité unique : l'URL. Les filtres sont DÉRIVÉS de la query string
+  // (pas de copie dans un useState), donc back/forward du navigateur les restaure
+  // sans risque de désynchronisation état/URL.
   const searchParams = useSearchParams();
-  const [initialFilters] = useState(() =>
-    parseDossiersFilters(new URLSearchParams(searchParams.toString()), defaultScope)
+  const pathname = usePathname();
+
+  const filters = useMemo(
+    () => parseDossiersFilters(new URLSearchParams(searchParams.toString()), defaultScope),
+    [searchParams, defaultScope]
   );
 
-  const [activeScope, setActiveScope] = useState<Scope>(initialFilters.scope);
-  const [epciFilter, setEpciFilter] = useState<string>(initialFilters.epci);
-  const [search, setSearch] = useState<string>(initialFilters.search);
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc">(initialFilters.sort);
-  const [page, setPage] = useState(initialFilters.page);
-  const [pageSize, setPageSize] = useState(initialFilters.pageSize);
-  // Filtres par colonne (multi-sélection, live).
-  const [responsableFilter, setResponsableFilter] = useState<Set<string>>(initialFilters.responsable);
-  const [etapeFilter, setEtapeFilter] = useState<Set<string>>(initialFilters.etape);
-  const [enAttenteFilter, setEnAttenteFilter] = useState<Set<string>>(initialFilters.enAttente);
+  // Écrit un sous-ensemble de filtres dans l'URL via l'History API (replaceState) :
+  // pas de refetch RSC, et une seule entrée d'historique pour la liste (« Précédent »
+  // sort de la liste ; le bouton « Réinitialiser » vide les filtres). Next.js patche
+  // replaceState pour mettre à jour `useSearchParams`, ce qui re-rend le composant.
+  const setFilters = useCallback(
+    (patch: Partial<DossiersFiltersState>) => {
+      const qs = serializeDossiersFilters({ ...filters, ...patch }, defaultScope);
+      window.history.replaceState(null, "", qs ? `${pathname}?${qs}` : pathname);
+    },
+    [filters, defaultScope, pathname]
+  );
 
-  // Synchronise les filtres dans l'URL à chaque changement, via l'History API
-  // (replaceState) plutôt que router.replace : on évite un refetch RSC à chaque
-  // frappe tout en gardant l'URL à jour pour le partage et le « Précédent ».
+  // Alias en lecture pour garder le reste du composant lisible.
+  const activeScope = filters.scope;
+  const epciFilter = filters.epci;
+  const sortOrder = filters.sort;
+  const page = filters.page;
+  const pageSize = filters.pageSize;
+  const responsableFilter = filters.responsable;
+  const etapeFilter = filters.etape;
+  const enAttenteFilter = filters.enAttente;
+
+  // Recherche : état local pour une saisie fluide et un filtrage instantané,
+  // poussé vers l'URL en différé (debounce) et re-semé quand l'URL change depuis
+  // l'extérieur (back/forward, réinitialisation).
+  const [search, setSearch] = useState(filters.search);
   useEffect(() => {
-    const qs = serializeDossiersFilters(
-      {
-        scope: activeScope,
-        search,
-        epci: epciFilter,
-        sort: sortOrder,
-        page,
-        pageSize,
-        responsable: responsableFilter,
-        etape: etapeFilter,
-        enAttente: enAttenteFilter,
-      },
-      defaultScope
-    );
-    const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
-    window.history.replaceState(null, "", url);
-  }, [
-    activeScope,
-    search,
-    epciFilter,
-    sortOrder,
-    page,
-    pageSize,
-    responsableFilter,
-    etapeFilter,
-    enAttenteFilter,
-    defaultScope,
-  ]);
+    setSearch(filters.search);
+  }, [filters.search]);
+  useEffect(() => {
+    if (search === filters.search) return;
+    const timeout = setTimeout(() => setFilters({ search, page: 1 }), 300);
+    return () => clearTimeout(timeout);
+  }, [search, filters.search, setFilters]);
 
   const loadData = useCallback(async () => {
     try {
@@ -251,25 +250,20 @@ export function DossiersPanel({ canCreateDossier = false, defaultScope = "all", 
     return map;
   }, [data]);
 
-  const paginated = visible.slice((page - 1) * pageSize, page * pageSize);
+  // Page bornée au nombre de pages réel : évite une page vide quand un filtre
+  // (ou la recherche instantanée) réduit les résultats sous la page courante.
+  const totalPages = Math.max(1, Math.ceil(visible.length / pageSize));
+  const currentPage = Math.min(page, totalPages);
+  const paginated = visible.slice((currentPage - 1) * pageSize, currentPage * pageSize);
 
-  const handleScopeChange = (next: Scope) => {
-    setActiveScope(next);
-    setPage(1);
-  };
+  const handleScopeChange = (next: Scope) => setFilters({ scope: next, page: 1 });
 
-  // Réinitialise tous les filtres à leurs valeurs par défaut. L'effet de synchro
-  // vide alors la query string : recharger la page repart d'une liste non filtrée.
+  // Réinitialise tous les filtres : on vide simplement la query string. Les
+  // filtres dérivés repartent sur leurs valeurs par défaut, et le champ de
+  // recherche local est re-semé par l'effet de synchro.
   const resetFilters = () => {
-    setActiveScope(defaultScope);
-    setEpciFilter("");
+    window.history.replaceState(null, "", pathname);
     setSearch("");
-    setSortOrder("desc");
-    setPage(1);
-    setPageSize(20);
-    setResponsableFilter(new Set());
-    setEtapeFilter(new Set());
-    setEnAttenteFilter(new Set());
   };
 
   // Bandeau « X résultat(s) dans vos/tous les dossiers » — affiché dès qu'un
@@ -375,10 +369,7 @@ export function DossiersPanel({ canCreateDossier = false, defaultScope = "all", 
                 type="search"
                 placeholder="Rechercher (nom, commune...)"
                 value={search}
-                onChange={(e) => {
-                  setSearch(e.target.value);
-                  setPage(1);
-                }}
+                onChange={(e) => setSearch(e.target.value)}
                 style={{
                   backgroundImage:
                     "url(\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='%23161616' d='M18.031 16.617l4.283 4.282-1.415 1.415-4.282-4.283A8.96 8.96 0 0 1 11 20c-4.968 0-9-4.032-9-9s4.032-9 9-9 9 4.032 9 9a8.96 8.96 0 0 1-1.969 5.617zm-2.006-.742A6.977 6.977 0 0 0 18 11c0-3.867-3.133-7-7-7-3.867 0-7 3.133-7 7 0 3.867 3.133 7 7 7a6.977 6.977 0 0 0 4.875-1.975l.15-.15z'/></svg>\")",
@@ -397,10 +388,7 @@ export function DossiersPanel({ canCreateDossier = false, defaultScope = "all", 
                 className="fr-select"
                 id="dossiers-epci"
                 value={epciFilter}
-                onChange={(e) => {
-                  setEpciFilter(e.target.value);
-                  setPage(1);
-                }}>
+                onChange={(e) => setFilters({ epci: e.target.value, page: 1 })}>
                 <option value="">EPCI</option>
                 {availableEpcis.map((epci) => (
                   <option key={epci.code} value={epci.code}>
@@ -445,35 +433,23 @@ export function DossiersPanel({ canCreateDossier = false, defaultScope = "all", 
                 dossiers={paginated}
                 onRefresh={loadData}
                 sortOrder={sortOrder}
-                onToggleSort={() => setSortOrder((o) => (o === "asc" ? "desc" : "asc"))}
+                onToggleSort={() => setFilters({ sort: sortOrder === "asc" ? "desc" : "asc" })}
                 responsableOptions={filterOptions.responsables}
                 etapeOptions={filterOptions.etapes}
                 enAttenteOptions={filterOptions.enAttente}
                 responsableFilter={responsableFilter}
                 etapeFilter={etapeFilter}
                 enAttenteFilter={enAttenteFilter}
-                onResponsableFilterChange={(next) => {
-                  setResponsableFilter(next);
-                  setPage(1);
-                }}
-                onEtapeFilterChange={(next) => {
-                  setEtapeFilter(next);
-                  setPage(1);
-                }}
-                onEnAttenteFilterChange={(next) => {
-                  setEnAttenteFilter(next);
-                  setPage(1);
-                }}
+                onResponsableFilterChange={(next) => setFilters({ responsable: next, page: 1 })}
+                onEtapeFilterChange={(next) => setFilters({ etape: next, page: 1 })}
+                onEnAttenteFilterChange={(next) => setFilters({ enAttente: next, page: 1 })}
               />
               <Pagination
-                currentPage={page}
+                currentPage={currentPage}
                 totalItems={visible.length}
                 pageSize={pageSize}
-                onPageChange={setPage}
-                onPageSizeChange={(size) => {
-                  setPageSize(size);
-                  setPage(1);
-                }}
+                onPageChange={(p) => setFilters({ page: p })}
+                onPageSizeChange={(size) => setFilters({ pageSize: size, page: 1 })}
               />
             </>
           )}

--- a/src/app/(backoffice)/espace-agent/dossiers/components/DossiersPanel.tsx
+++ b/src/app/(backoffice)/espace-agent/dossiers/components/DossiersPanel.tsx
@@ -258,6 +258,20 @@ export function DossiersPanel({ canCreateDossier = false, defaultScope = "all", 
     setPage(1);
   };
 
+  // Réinitialise tous les filtres à leurs valeurs par défaut. L'effet de synchro
+  // vide alors la query string : recharger la page repart d'une liste non filtrée.
+  const resetFilters = () => {
+    setActiveScope(defaultScope);
+    setEpciFilter("");
+    setSearch("");
+    setSortOrder("desc");
+    setPage(1);
+    setPageSize(20);
+    setResponsableFilter(new Set());
+    setEtapeFilter(new Set());
+    setEnAttenteFilter(new Set());
+  };
+
   // Bandeau « X résultat(s) dans vos/tous les dossiers » — affiché dès qu'un
   // filtre est actif (recherche, EPCI ou filtre par colonne). Le scope habille
   // le texte (« dans vos dossiers » vs « dans tous les dossiers ») et le lien
@@ -396,6 +410,15 @@ export function DossiersPanel({ canCreateDossier = false, defaultScope = "all", 
               </select>
             </div>
           </div>
+
+          {(hasActiveFilter || activeScope !== defaultScope) && (
+            <button
+              type="button"
+              className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-refresh-line fr-btn--icon-left fr-mb-2w"
+              onClick={resetFilters}>
+              Réinitialiser les filtres
+            </button>
+          )}
 
           {hasActiveFilter && (
             <p className="fr-mb-2w">

--- a/src/app/(backoffice)/espace-agent/dossiers/components/dossiers-filters-url.test.ts
+++ b/src/app/(backoffice)/espace-agent/dossiers/components/dossiers-filters-url.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { parseDossiersFilters, serializeDossiersFilters, type DossiersFiltersState } from "./dossiers-filters-url";
+
+const baseState: DossiersFiltersState = {
+  scope: "all",
+  search: "",
+  epci: "",
+  sort: "desc",
+  page: 1,
+  pageSize: 20,
+  responsable: new Set(),
+  etape: new Set(),
+  enAttente: new Set(),
+};
+
+describe("parseDossiersFilters", () => {
+  it("retombe sur les défauts quand l'URL est vide", () => {
+    const result = parseDossiersFilters(new URLSearchParams(""), "mine");
+    expect(result).toEqual({ ...baseState, scope: "mine" });
+  });
+
+  it("lit toutes les valeurs présentes", () => {
+    const params = new URLSearchParams(
+      "scope=all&q=dupont&epci=200054807&sort=asc&page=3&size=50&resp=AMO+A&resp=AMO+B&etape=Devis&attente=DDT"
+    );
+    const result = parseDossiersFilters(params, "mine");
+    expect(result).toEqual({
+      scope: "all",
+      search: "dupont",
+      epci: "200054807",
+      sort: "asc",
+      page: 3,
+      pageSize: 50,
+      responsable: new Set(["AMO A", "AMO B"]),
+      etape: new Set(["Devis"]),
+      enAttente: new Set(["DDT"]),
+    });
+  });
+
+  it("ignore un scope invalide et garde le défaut", () => {
+    expect(parseDossiersFilters(new URLSearchParams("scope=bogus"), "mine").scope).toBe("mine");
+  });
+
+  it("ignore une page ou une taille invalides", () => {
+    const result = parseDossiersFilters(new URLSearchParams("page=0&size=999"), "all");
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(20);
+  });
+});
+
+describe("serializeDossiersFilters", () => {
+  it("retourne une chaîne vide quand tout est au défaut", () => {
+    expect(serializeDossiersFilters({ ...baseState, scope: "mine" }, "mine")).toBe("");
+  });
+
+  it("omet le scope quand il vaut le défaut, l'écrit sinon", () => {
+    expect(serializeDossiersFilters({ ...baseState, scope: "all" }, "all")).toBe("");
+    expect(serializeDossiersFilters({ ...baseState, scope: "all" }, "mine")).toBe("scope=all");
+  });
+
+  it("sérialise les Set en clés répétées", () => {
+    const qs = serializeDossiersFilters(
+      { ...baseState, responsable: new Set(["AMO A", "AMO B"]), enAttente: new Set(["DDT"]) },
+      "all"
+    );
+    const params = new URLSearchParams(qs);
+    expect(params.getAll("resp")).toEqual(["AMO A", "AMO B"]);
+    expect(params.getAll("attente")).toEqual(["DDT"]);
+  });
+
+  it("est l'inverse de parse (round-trip)", () => {
+    const state: DossiersFiltersState = {
+      scope: "all",
+      search: "marc, à côté",
+      epci: "200054807",
+      sort: "asc",
+      page: 2,
+      pageSize: 100,
+      responsable: new Set(["AMO A", "AMO B"]),
+      etape: new Set(["Éligibilité"]),
+      enAttente: new Set(["AMO", "DDT"]),
+    };
+    const qs = serializeDossiersFilters(state, "mine");
+    expect(parseDossiersFilters(new URLSearchParams(qs), "mine")).toEqual(state);
+  });
+});

--- a/src/app/(backoffice)/espace-agent/dossiers/components/dossiers-filters-url.ts
+++ b/src/app/(backoffice)/espace-agent/dossiers/components/dossiers-filters-url.ts
@@ -1,0 +1,77 @@
+/**
+ * (Dé)sérialisation des filtres du suivi des dossiers vers/depuis l'URL.
+ *
+ * Permet de persister l'état de filtrage dans la query string : l'agent peut
+ * filtrer, ouvrir un dossier, puis revenir (bouton « Précédent ») sans perdre
+ * ses filtres. La vue filtrée devient aussi partageable / bookmarkable.
+ *
+ * Fonctions pures (pas de dépendance React/DOM) pour rester testables. Les clés
+ * d'URL sont volontairement courtes (`q`, `epci`, `resp`...) ; les valeurs par
+ * défaut ne sont PAS écrites pour garder l'URL propre.
+ */
+
+export type Scope = "mine" | "all";
+
+export interface DossiersFiltersState {
+  scope: Scope;
+  search: string;
+  epci: string;
+  sort: "asc" | "desc";
+  page: number;
+  pageSize: number;
+  responsable: Set<string>;
+  etape: Set<string>;
+  enAttente: Set<string>;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+const PAGE_SIZE_OPTIONS = [20, 50, 100];
+
+/**
+ * Reconstruit l'état des filtres depuis la query string. Toute valeur absente
+ * ou invalide retombe sur son défaut (`defaultScope` dépend du rôle de l'agent).
+ */
+export function parseDossiersFilters(params: URLSearchParams, defaultScope: Scope): DossiersFiltersState {
+  const scopeParam = params.get("scope");
+  const scope: Scope = scopeParam === "mine" || scopeParam === "all" ? scopeParam : defaultScope;
+
+  const pageParam = Number(params.get("page"));
+  const page = Number.isInteger(pageParam) && pageParam >= 1 ? pageParam : 1;
+
+  const sizeParam = Number(params.get("size"));
+  const pageSize = PAGE_SIZE_OPTIONS.includes(sizeParam) ? sizeParam : DEFAULT_PAGE_SIZE;
+
+  return {
+    scope,
+    search: params.get("q") ?? "",
+    epci: params.get("epci") ?? "",
+    sort: params.get("sort") === "asc" ? "asc" : "desc",
+    page,
+    pageSize,
+    responsable: new Set(params.getAll("resp")),
+    etape: new Set(params.getAll("etape")),
+    enAttente: new Set(params.getAll("attente")),
+  };
+}
+
+/**
+ * Sérialise l'état des filtres en query string (sans le `?` initial). Les valeurs
+ * par défaut sont omises ; les filtres multi-valeurs (Set) sont écrits en clés
+ * répétées (`resp=A&resp=B`) pour éviter tout souci de séparateur dans les noms.
+ */
+export function serializeDossiersFilters(state: DossiersFiltersState, defaultScope: Scope): string {
+  const params = new URLSearchParams();
+
+  if (state.scope !== defaultScope) params.set("scope", state.scope);
+  if (state.search.trim()) params.set("q", state.search);
+  if (state.epci) params.set("epci", state.epci);
+  if (state.sort !== "desc") params.set("sort", state.sort);
+  if (state.page > 1) params.set("page", String(state.page));
+  if (state.pageSize !== DEFAULT_PAGE_SIZE) params.set("size", String(state.pageSize));
+
+  for (const v of state.responsable) params.append("resp", v);
+  for (const v of state.etape) params.append("etape", v);
+  for (const v of state.enAttente) params.append("attente", v);
+
+  return params.toString();
+}

--- a/src/app/(backoffice)/espace-agent/dossiers/page.tsx
+++ b/src/app/(backoffice)/espace-agent/dossiers/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { DossiersPanel } from "./components/DossiersPanel";
 import { resolveEspaceAgentAccess } from "@/features/backoffice/shared/actions/super-admin-access";
 import { getCurrentUser } from "@/features/auth/services/user.service";
@@ -21,10 +22,12 @@ export default async function DossiersAgentPage() {
     role === UserRole.AMO || role === UserRole.AMO_ET_ALLERS_VERS || role === UserRole.ALLERS_VERS;
 
   return (
-    <DossiersPanel
-      canCreateDossier={isAgentResponsable}
-      defaultScope={isAgentResponsable ? "mine" : "all"}
-      prenom={user?.firstName ?? null}
-    />
+    <Suspense>
+      <DossiersPanel
+        canCreateDossier={isAgentResponsable}
+        defaultScope={isAgentResponsable ? "mine" : "all"}
+        prenom={user?.firstName ?? null}
+      />
+    </Suspense>
   );
 }


### PR DESCRIPTION
Conserve les filtres au retour « Précédent » et rend la vue filtrée partageable.
