### PR TITLE
fix(simulateur): rend non éligible un logement hors zone argileuse

### DIFF
--- a/src/features/rga-map/components/RgaMapLegend.tsx
+++ b/src/features/rga-map/components/RgaMapLegend.tsx
@@ -9,7 +9,7 @@ const LEGEND_ITEMS = [
 export function RgaMapLegend() {
   return (
     <div className="flex items-center justify-start space-x-1.5">
-      <span className="text-xs fr-text--bold">Risque argile :</span>
+      <span className="text-xs fr-text--bold">Exposition RGA :</span>
       {LEGEND_ITEMS.map(({ level, color }) => (
         <span
           key={level}

--- a/src/features/simulateur/components/steps/StepAdresse/StepAdresse.tsx
+++ b/src/features/simulateur/components/steps/StepAdresse/StepAdresse.tsx
@@ -244,7 +244,8 @@ export function StepAdresse({ initialValue, numeroEtape, totalEtapes, canGoBack,
         coordonnees: formatCoordinatesString({ lat: buildingData.lat, lon: buildingData.lon }),
         clef_ban: addressData.clefBan,
         // Données du bâtiment (BDNB + potentiellement éditées)
-        zone_dexposition: buildingData.aleaArgiles || undefined,
+        // null = hors zone argileuse (réponse à part entière, distincte de "non répondu")
+        zone_dexposition: buildingData.aleaArgiles,
         annee_de_construction: formData.anneeConstruction?.toString(),
         niveaux: formData.nombreNiveaux ?? undefined,
         rnb: buildingData.rnbId,

--- a/src/features/simulateur/domain/rules/eligibility/zone-argile.rules.test.ts
+++ b/src/features/simulateur/domain/rules/eligibility/zone-argile.rules.test.ts
@@ -55,5 +55,11 @@ describe("zone-argile.rules", () => {
       expect(result.passed).toBe(false);
       expect(result.reason).toBe(EligibilityReason.ZONE_NON_FORTE);
     });
+
+    it("retourne failed pour null (hors zone argileuse)", () => {
+      const result = checkZoneForte(null);
+      expect(result.passed).toBe(false);
+      expect(result.reason).toBe(EligibilityReason.ZONE_NON_FORTE);
+    });
   });
 });

--- a/src/features/simulateur/domain/rules/eligibility/zone-argile.rules.ts
+++ b/src/features/simulateur/domain/rules/eligibility/zone-argile.rules.ts
@@ -20,7 +20,7 @@ export function checkDepartementEligible(codeDepartement: string | undefined): R
 /**
  * Vérifie si la zone d'exposition est forte
  */
-export function checkZoneForte(zoneExposition: string | undefined): RuleResult {
+export function checkZoneForte(zoneExposition: string | null | undefined): RuleResult {
   if (!zoneExposition) {
     return { passed: false, reason: EligibilityReason.ZONE_NON_FORTE };
   }

--- a/src/features/simulateur/domain/rules/navigation/step-flow.rules.test.ts
+++ b/src/features/simulateur/domain/rules/navigation/step-flow.rules.test.ts
@@ -144,6 +144,20 @@ describe("step-flow.rules", () => {
         expect(result.checks.zoneForte).toBe(false);
       });
 
+      it("déclenche early exit pour hors zone argileuse (null)", () => {
+        const answers: PartialRGASimulationData = {
+          logement: {
+            type: "maison",
+            code_departement: "24",
+            zone_dexposition: null,
+          },
+        };
+        const result = evaluateEligibility(answers);
+        expect(result.shouldExit).toBe(true);
+        expect(result.failedAtStep).toBe(SimulateurStep.ADRESSE);
+        expect(result.checks.zoneForte).toBe(false);
+      });
+
       it("déclenche early exit pour construction trop récente", () => {
         const anneeRecente = (new Date().getFullYear() - 5).toString();
         const answers: PartialRGASimulationData = {

--- a/src/shared/domain/types/rga-simulation.types.ts
+++ b/src/shared/domain/types/rga-simulation.types.ts
@@ -15,7 +15,7 @@ export interface RGASimulationData {
     annee_de_construction: string;
     rnb: string;
     niveaux: number;
-    zone_dexposition: "faible" | "moyen" | "fort";
+    zone_dexposition: "faible" | "moyen" | "fort" | null;
     type: "maison" | "appartement";
     mitoyen: boolean;
     proprietaire_occupant: boolean;


### PR DESCRIPTION
Une adresse hors zone (aleaArgiles null) passait en non évalué au lieu de non éligible.
