### PR TITLE
fix(espace-agent): rend consultable le détail des dossiers sans AMO

### DIFF
--- a/docs/security/RBAC-ROLES.md
+++ b/docs/security/RBAC-ROLES.md
@@ -129,7 +129,61 @@ Distinctions clés :
 
 ---
 
-## 6. Fichiers clés
+## 6. Cohérence listing ↔ détail (résolution territoriale)
+
+> **Règle** : le contrôle d'accès au **détail** d'un dossier/prospect doit
+> s'aligner exactement sur la **visibilité du listing**. Un dossier visible dans
+> la liste d'un agent doit être ouvrable par cet agent — et inversement. Toute
+> divergence produit un « visible en liste mais 404 au détail » (ou l'inverse,
+> une fuite).
+
+Un parcours a **deux sources de localisation** : la simulation du demandeur
+(`rgaSimulationData`) et celle saisie par l'agent (`rgaSimulationDataAgent`, ex.
+flux _av-add-dossier_). Deux conventions de résolution coexistent :
+
+- **USER-first** (`getDemandeurFirstSimulation` = `rgaSimulationData ?? rgaSimulationDataAgent`) :
+  utilisée pour le **filtrage territorial** (listing) et le **contrôle d'accès**.
+- **AGENT-first** (`getEffectiveRGAData` = `rgaSimulationDataAgent ?? rgaSimulationData`) :
+  réservée à l'**affichage** du détail (l'adresse BAN-stricte de l'agent prime)
+  et aux **stats de référence**.
+
+Le prédicat unique de territorialité est
+`matchesTerritoire(getDemandeurFirstSimulation(parcours), departements, epcis)`
+(union département ∪ EPCI), partagé par le listing
+(`parcoursPreventionRepository.getParcoursByTerritoire`) et par le contrôle
+d'accès (`verifyProspectTerritoryAccess`).
+
+### Bug corrigé (juin 2026) — 404 sur les dossiers sans AMO
+
+**Symptôme** : des dossiers « en attente d'AV » / « en formulaire d'éligibilité »
+visibles dans le listing renvoyaient un **404** à l'ouverture, y compris pour un
+`SUPER_ADMINISTRATEUR` (accès national).
+
+**Cause principale (statut `SANS_AMO`)** : ces dossiers sont des parcours **sans
+accompagnement AMO** — la validation a le statut `SANS_AMO` (responsable =
+Aller-vers territorial) tout en progressant dans le parcours (éligibilité,
+diagnostic…). Le routing les envoie vers `/espace-agent/dossiers/[validationId]`,
+mais `STATUTS_CONSULTABLES` n'incluait que SUIVIS + REFUSES, **pas `SANS_AMO`** :
+`getDossierDetail` retournait « non consultable » → `notFound()` → 404 pour tout
+le monde (super-admin compris, car le filtre statut s'applique avant tout contrôle
+de rôle). **Correctif** : `SANS_AMO` ajouté à `STATUTS_CONSULTABLES`
+(`amo-dossiers.types.ts`). À noter : une validation `SANS_AMO` a `valideeAt = null`
+(`suiviDepuis` est donc nullable).
+
+**Cause secondaire (résolution territoriale, agents scoppés)** : indépendamment du
+statut, `verifyProspectTerritoryAccess` résolvait la localisation en **AGENT-first**
+(`getEffectiveRGAData`) alors que le listing filtre en **USER-first**. Quand les
+deux simulations divergeaient sur le département/EPCI, un agent scoppé (AMO / AV /
+hybride) voyait le dossier en liste mais était rejeté au détail. **Correctif** :
+`verifyProspectTerritoryAccess` utilise désormais le même prédicat
+`matchesTerritoire(getDemandeurFirstSimulation(...))` que le listing ; un agent sans
+périmètre territorial (non-national) est refusé, comme dans le listing. Un rôle
+national (`scope.isNational`) court-circuite ce contrôle et n'était donc pas
+concerné par cette cause secondaire.
+
+---
+
+## 7. Fichiers clés
 
 | Rôle                             | Fichier                                                                  |
 | -------------------------------- | ------------------------------------------------------------------------ |

--- a/src/app/(backoffice)/espace-agent/dossiers/[id]/page.tsx
+++ b/src/app/(backoffice)/espace-agent/dossiers/[id]/page.tsx
@@ -107,7 +107,12 @@ export default async function DossierDetailPage({ params }: PageProps) {
         {/* Section en-tête : Callout + InfoDemandeur */}
         <div className="fr-grid-row fr-grid-row--gutters">
           <div className="fr-col-12 fr-col-md-8">
-            <InfoDossierCallout currentStep={dossier.currentStep} currentStatus={dossier.currentStatus} dsStatus={dossier.dsStatus} validationStatut={dossier.validationStatut} />
+            <InfoDossierCallout
+              currentStep={dossier.currentStep}
+              currentStatus={dossier.currentStatus}
+              dsStatus={dossier.dsStatus}
+              validationStatut={dossier.validationStatut}
+            />
             <div className="fr-mt-4w">
               <ActionsRealisees parcoursId={dossier.parcoursId} />
             </div>
@@ -116,7 +121,7 @@ export default async function DossierDetailPage({ params }: PageProps) {
             <div style={{ alignSelf: "flex-start" }}>
               <InfoDemandeur
                 demandeur={dossier.demandeur}
-                suiviDepuis={dossier.suiviDepuis}
+                suiviDepuis={dossier.suiviDepuis ?? undefined}
                 editSimulationHref={ROUTES.backoffice.espaceAmo.editionDonneesSimulation(dossier.id)}
               />
             </div>

--- a/src/features/auth/permissions/services/agent-scope.service.test.ts
+++ b/src/features/auth/permissions/services/agent-scope.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UserRole } from "@/shared/domain/value-objects/user-role.enum";
 import type { AgentScope, AgentScopeInput } from "../domain/types/agent-scope.types";
+import type { ParcoursPrevention } from "@/shared/database/schema/parcours-prevention";
 
 // Mocks des repositories utilisés par calculateAgentScope
 vi.mock("@/shared/database", () => ({
@@ -17,13 +18,28 @@ vi.mock("@/shared/database", () => ({
   },
 }));
 
+// Mock du repository parcours (findById) tout en conservant le vrai
+// `matchesTerritoire` exporté par le même module.
+vi.mock("@/shared/database/repositories/parcours-prevention.repository", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/database/repositories/parcours-prevention.repository")>();
+  return {
+    ...actual,
+    parcoursPreventionRepository: {
+      ...actual.parcoursPreventionRepository,
+      findById: vi.fn(),
+    },
+  };
+});
+
 import { agentPermissionsRepository, allersVersRepository, entreprisesAmoRepo } from "@/shared/database";
+import { parcoursPreventionRepository } from "@/shared/database/repositories/parcours-prevention.repository";
 import {
   calculateAgentScope,
   canAccessDossier,
   canViewStatsForTerritory,
   getScopeFilterConditions,
   isAmoConfigured,
+  verifyProspectTerritoryAccess,
 } from "./agent-scope.service";
 
 describe("agent-scope.service", () => {
@@ -482,6 +498,101 @@ describe("agent-scope.service", () => {
 
       expect(isAmoConfigured(adminAgent)).toBe(true);
       expect(isAmoConfigured(analysteAgent)).toBe(true);
+    });
+  });
+
+  describe("verifyProspectTerritoryAccess", () => {
+    // Parcours minimal pour `findById` : seules les deux simulations comptent
+    // pour la résolution territoriale (le reste est ignoré par le contrôle).
+    function parcours(
+      sims: Partial<Pick<ParcoursPrevention, "rgaSimulationData" | "rgaSimulationDataAgent">>
+    ): ParcoursPrevention {
+      return {
+        rgaSimulationData: null,
+        rgaSimulationDataAgent: null,
+        ...sims,
+      } as ParcoursPrevention;
+    }
+
+    function simAuDepartement(code: string) {
+      return { logement: { code_departement: code } } as ParcoursPrevention["rgaSimulationData"];
+    }
+
+    it("autorise un super-admin (national) sans consulter le parcours", async () => {
+      const error = await verifyProspectTerritoryAccess("parcours-1", {
+        id: "admin-1",
+        role: UserRole.SUPER_ADMINISTRATEUR,
+        entrepriseAmoId: null,
+        allersVersId: null,
+      });
+
+      expect(error).toBeNull();
+      // Court-circuit national : pas de lecture du parcours.
+      expect(parcoursPreventionRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it("autorise l'accès quand la simulation DEMANDEUR matche, même si la simulation AGENT diverge (régression bug d'accès)", async () => {
+      // Scope AMO_ET_ALLERS_VERS sur le département 32.
+      vi.mocked(allersVersRepository.getDepartementsByAllersVersId).mockResolvedValue(["32"]);
+      vi.mocked(allersVersRepository.getEpcisByAllersVersId).mockResolvedValue([]);
+      vi.mocked(entreprisesAmoRepo.getDepartementsByEntrepriseAmoId).mockResolvedValue(["32"]);
+      vi.mocked(entreprisesAmoRepo.getEpcisByEntrepriseAmoId).mockResolvedValue([]);
+
+      // Demandeur dans le 32 (présent en liste), simulation agent dans le 31.
+      vi.mocked(parcoursPreventionRepository.findById).mockResolvedValue(
+        parcours({
+          rgaSimulationData: simAuDepartement("32"),
+          rgaSimulationDataAgent: simAuDepartement("31"),
+        })
+      );
+
+      const error = await verifyProspectTerritoryAccess("parcours-1", {
+        id: "agent-hybride",
+        role: UserRole.AMO_ET_ALLERS_VERS,
+        entrepriseAmoId: "entreprise-123",
+        allersVersId: "av-456",
+      });
+
+      // user-first → 32 → accès autorisé (avant le fix : agent-first → 31 → 404).
+      expect(error).toBeNull();
+    });
+
+    it("refuse l'accès quand le prospect est hors territoire", async () => {
+      vi.mocked(allersVersRepository.getDepartementsByAllersVersId).mockResolvedValue(["32"]);
+      vi.mocked(allersVersRepository.getEpcisByAllersVersId).mockResolvedValue([]);
+      vi.mocked(entreprisesAmoRepo.getDepartementsByEntrepriseAmoId).mockResolvedValue(["32"]);
+      vi.mocked(entreprisesAmoRepo.getEpcisByEntrepriseAmoId).mockResolvedValue([]);
+
+      vi.mocked(parcoursPreventionRepository.findById).mockResolvedValue(
+        parcours({ rgaSimulationData: simAuDepartement("33") })
+      );
+
+      const error = await verifyProspectTerritoryAccess("parcours-1", {
+        id: "agent-hybride",
+        role: UserRole.AMO_ET_ALLERS_VERS,
+        entrepriseAmoId: "entreprise-123",
+        allersVersId: "av-456",
+      });
+
+      expect(error).toBe("Ce prospect n'est pas dans votre territoire");
+    });
+
+    it("retourne une erreur si le parcours est introuvable", async () => {
+      vi.mocked(allersVersRepository.getDepartementsByAllersVersId).mockResolvedValue(["32"]);
+      vi.mocked(allersVersRepository.getEpcisByAllersVersId).mockResolvedValue([]);
+      vi.mocked(entreprisesAmoRepo.getDepartementsByEntrepriseAmoId).mockResolvedValue(["32"]);
+      vi.mocked(entreprisesAmoRepo.getEpcisByEntrepriseAmoId).mockResolvedValue([]);
+
+      vi.mocked(parcoursPreventionRepository.findById).mockResolvedValue(null);
+
+      const error = await verifyProspectTerritoryAccess("parcours-inexistant", {
+        id: "agent-hybride",
+        role: UserRole.AMO_ET_ALLERS_VERS,
+        entrepriseAmoId: "entreprise-123",
+        allersVersId: "av-456",
+      });
+
+      expect(error).toBe("Parcours non trouvé");
     });
   });
 });

--- a/src/features/auth/permissions/services/agent-scope.service.ts
+++ b/src/features/auth/permissions/services/agent-scope.service.ts
@@ -1,8 +1,11 @@
 import { getCurrentUser } from "@/features/auth/services/user.service";
 import { UserRole } from "@/shared/domain/value-objects";
 import { agentPermissionsRepository, allersVersRepository, entreprisesAmoRepo } from "@/shared/database";
-import { parcoursPreventionRepository } from "@/shared/database/repositories/parcours-prevention.repository";
-import { getEffectiveRGAData } from "@/features/parcours/core/services/rga-data.service";
+import {
+  matchesTerritoire,
+  parcoursPreventionRepository,
+} from "@/shared/database/repositories/parcours-prevention.repository";
+import { getDemandeurFirstSimulation } from "@/shared/domain/utils/rga-simulation.utils";
 import type { AgentScope, AgentScopeInput, DossierAccessCheck, ScopeFilters } from "../domain/types/agent-scope.types";
 
 /**
@@ -287,19 +290,21 @@ export async function verifyProspectTerritoryAccess(
     return "Parcours non trouvé";
   }
 
-  const rgaData = getEffectiveRGAData(parcours);
-  const codeDepartement = rgaData?.logement?.code_departement;
-  const codeEpci = rgaData?.logement?.epci;
-
-  const matchesDepartement =
-    scope.departements.length > 0 && codeDepartement && scope.departements.includes(String(codeDepartement));
-  const matchesEpci = scope.epcis.length > 0 && codeEpci && scope.epcis.includes(String(codeEpci));
-
-  if (!matchesDepartement && !matchesEpci) {
+  // Un agent sans périmètre territorial (ni département ni EPCI) ne voit aucun
+  // prospect — cohérent avec le listing qui renvoie une liste vide dans ce cas.
+  const hasFiltreTerritorial = scope.departements.length > 0 || scope.epcis.length > 0;
+  if (!hasFiltreTerritorial) {
     return "Ce prospect n'est pas dans votre territoire";
   }
 
-  return null;
+  // Aligné sur le listing (`getParcoursByTerritoire` → `matchesTerritoire`) :
+  // même résolution USER-first (`getDemandeurFirstSimulation`) et même prédicat
+  // union département ∪ EPCI. Avant, ce contrôle lisait `getEffectiveRGAData`
+  // (AGENT-first), d'où l'incohérence « dossier visible en liste mais 404 au
+  // détail » quand la simulation du demandeur et celle de l'agent divergeaient.
+  const inTerritoire = matchesTerritoire(getDemandeurFirstSimulation(parcours), scope.departements, scope.epcis);
+
+  return inTerritoire ? null : "Ce prospect n'est pas dans votre territoire";
 }
 
 /**

--- a/src/features/backoffice/espace-agent/dossiers/domain/types/amo-dossiers.types.ts
+++ b/src/features/backoffice/espace-agent/dossiers/domain/types/amo-dossiers.types.ts
@@ -14,10 +14,15 @@ export const STATUTS_REFUSES = [StatutValidationAmo.LOGEMENT_NON_ELIGIBLE, Statu
 
 /**
  * Statuts pour lesquels la page detail `/dossiers/[id]` est consultable.
- * SUIVIS + REFUSES : un dossier archivé non éligible reste lisible côté agent
- * pour consulter le motif d'inéligibilité.
+ * SUIVIS + REFUSES + SANS_AMO :
+ * - un dossier archivé non éligible reste lisible côté agent pour consulter le
+ *   motif d'inéligibilité ;
+ * - un dossier `SANS_AMO` (demandeur sans accompagnement AMO) progresse quand
+ *   même dans le parcours (éligibilité, diagnostic…) : son responsable est
+ *   l'Aller-vers territorial, il doit donc rester consultable. Sans cette ligne,
+ *   ces dossiers renvoyaient un 404 au détail (y compris pour un super-admin).
  */
-export const STATUTS_CONSULTABLES = [...STATUTS_SUIVIS, ...STATUTS_REFUSES];
+export const STATUTS_CONSULTABLES = [...STATUTS_SUIVIS, ...STATUTS_REFUSES, StatutValidationAmo.SANS_AMO];
 
 /**
  * Variantes visuelles pour la cellule « Précisions ».

--- a/src/features/backoffice/espace-agent/dossiers/domain/types/dossier-detail.types.ts
+++ b/src/features/backoffice/espace-agent/dossiers/domain/types/dossier-detail.types.ts
@@ -47,8 +47,8 @@ export interface DossierDetail {
   parcoursCreatedAt: Date;
   /** Date de dernière mise à jour du parcours */
   lastUpdatedAt: Date;
-  /** Date de validation de la demande par l'AMO */
-  suiviDepuis: Date;
+  /** Date de validation de la demande par l'AMO (null pour un dossier SANS_AMO) */
+  suiviDepuis: Date | null;
   /** Informations sur l'indemnisation passée (optionnel) */
   dateIndemnisation?: DateIndemnisation;
   /** Dates de progression du parcours par étape */

--- a/src/features/backoffice/espace-agent/dossiers/services/dossier-detail.service.ts
+++ b/src/features/backoffice/espace-agent/dossiers/services/dossier-detail.service.ts
@@ -52,8 +52,9 @@ export async function getDossierDetail(dossierId: string): Promise<ActionResult<
       return { success: false, error: "Dossier non trouvé" };
     }
 
-    // Page consultable pour les statuts SUIVIS + REFUSES (un dossier archivé
-    // non éligible reste lisible pour voir le motif).
+    // Page consultable pour les statuts SUIVIS + REFUSES + SANS_AMO (un dossier
+    // archivé non éligible reste lisible pour voir le motif ; un dossier sans AMO
+    // reste lisible car il progresse quand même dans le parcours).
     if (!STATUTS_CONSULTABLES.includes(dossier.validation.statut)) {
       return { success: false, error: "Ce dossier n'est pas consultable" };
     }
@@ -158,7 +159,7 @@ export async function getDossierDetail(dossierId: string): Promise<ActionResult<
       validationStatut: dossier.validation.statut,
       parcoursCreatedAt: dossier.parcours.createdAt,
       lastUpdatedAt: dossier.parcours.updatedAt,
-      suiviDepuis: dossier.validation.valideeAt!,
+      suiviDepuis: dossier.validation.valideeAt,
       dates,
       agentEditInfo,
       creator,


### PR DESCRIPTION
Le statut SANS_AMO était exclu de STATUTS_CONSULTABLES, donc /dossiers/[id] renvoyait un 404 (y compris super-admin) ; aligne aussi le contrôle territorial du détail sur le listing.