### PR TITLE
fix(security): corrige les CVE openssl de l'image dev et répare la build Docker

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,7 +1,7 @@
 # Configuration Talisman pour fonds-prevention-argile
 fileignoreconfig:
   - filename: pnpm-lock.yaml
-    checksum: e7eb680db210d7f1051cf4a370f8890e8feca2b7996fe1abda93d260b765251c
+    checksum: dcb76e795adf560d567ebf2c16c6e4ce3be7cc939ee1659b72c0a27db65d152f
   - filename: package-lock.json
     checksum: ignore
   - filename: .env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM node:22-alpine
+FROM node:24-alpine
 
-# Installer pnpm globalement avec npm
-RUN npm install -g pnpm@10.18.2
+# Mettre a jour les paquets systeme Alpine (corrige les CVE openssl/libssl3)
+RUN apk upgrade --no-cache
+
+# Installer pnpm globalement avec npm (aligne sur packageManager du repo)
+RUN npm install -g pnpm@11.5.2
 
 WORKDIR /app
 
-# Copier les fichiers de dépendances
-COPY package.json pnpm-lock.yaml ./
+# Copier les fichiers de dépendances (pnpm-workspace.yaml porte les overrides)
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Installer les dépendances
 RUN pnpm install --frozen-lockfile

--- a/docs/security/snyk-accepted-vulnerabilities.md
+++ b/docs/security/snyk-accepted-vulnerabilities.md
@@ -76,8 +76,53 @@ Toutes transitives, sans path d'exploitation directe (0 High après l'override `
 | `uuid` <11.1.1            | Moderate | runtime | `exceljs > uuid`                            | exceljs appelle `uuidv4()` sans buffer → faille non atteignable ; override v11 = major risqué |
 | `diff` (jsdiff DoS)       | Low      | devDep  | `ts-node > diff`                            | Non déployé en prod                                                                           |
 
+## Refresh CVE — juin 2026 (branche `fix/cve`)
+
+Branche dédiée aux CVE remontées par le scan conteneur + nouvelle dérive `pnpm audit`.
+Vérification : `pnpm validate` (typecheck + lint + 1291 tests verts).
+
+### CVE Alpine openssl/libssl3 — image **dev uniquement**, corrigées
+
+`CVE-2026-45445`, `CVE-2026-42766`, `CVE-2026-42767` (openssl/libssl3 `3.5.6-r0`) sont des
+paquets **apk Alpine**, pas npm. Elles proviennent de `FROM node:22-alpine` dans le
+`Dockerfile`, qui ne sert qu'au **dev local** (`docker-compose.yml`, `CMD pnpm start:dev`).
+La **prod** déploie via le **buildpack Node Scalingo** (base Ubuntu, `.buildpacks` + `Procfile`),
+sans cette image Alpine : ces CVE ne touchent pas le runtime de production.
+
+**Correctif** (`Dockerfile`) :
+
+- bump `node:22-alpine` → `node:24-alpine` (aligne `engines.node=24.x`) ;
+- `RUN apk upgrade --no-cache` pour garantir les paquets système (openssl) patchés
+  (`libssl3`/`libcrypto3` `3.5.6-r0` → `3.5.7-r0`, vérifié sur l'image construite) ;
+- copie de `pnpm-workspace.yaml` avant `pnpm install --frozen-lockfile` et alignement
+  de pnpm `10.18.2` → `11.5.2` (les overrides vivent désormais dans `pnpm-workspace.yaml`,
+  non copié auparavant → la build dev échouait en `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`).
+
+### Dependabot embarqués
+
+- `@gouvfr/dsfr-chart` 2.0.4 → 2.1.1 (PR #226). Le breaking change 2.1.0 (databox `title`→`name`)
+  ne nous concerne pas : on n'utilise que `<line-chart>` avec `name=`.
+- `@types/react` 19.2.14 → 19.2.17 (PR #226, types only).
+
+### Reportés (inchangés, PR dédiée Next 16)
+
+- **Next 16** (#213), **ESLint 10** (#211), **@vitejs/plugin-react 6** (#209) : voir refresh juin
+  ci-dessus, toujours couplés à la migration Next 16.
+
+### Nouvelle vuln High acceptée — `esbuild` (devtooling)
+
+| Dépendance vulnérable | Sévérité | Type  | Chemin                                                        | Justification                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --------------------- | -------- | ----- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `esbuild` <0.28.1     | High     | build | `tsx > esbuild`, `drizzle-kit > esbuild` (override `^0.25.0`) | « Missing binary integrity verification in **Deno** » : non atteignable en Node ; esbuild ne tourne qu'au build/migration (`tsx migrate.ts`), pas en service de requêtes. Le pin vient de l'override explicite `esbuild: ^0.25.0` (`pnpm-workspace.yaml`). Bump vers `^0.28.1` **tenté** mais bloqué par `minimumReleaseAge` (1 semaine) : `esbuild@0.28.1` publié le 2026-06-11 → éligible à partir du **2026-06-18**. À ce moment, repasser l'override à `^0.28.1` et `pnpm install` (pas besoin d'exclusion). |
+
+Les Moderate restantes (`protocol-buffers-schema`, `postcss`, `uuid`) sont inchangées (voir tableau
+refresh juin ci-dessus).
+
 ## Prochaine revue
 
 - **Lors de l'upgrade Next 16** (PR dédiée) : réévaluer next, eslint-config-next,
   ESLint 10 et le `postcss` bundlé par Next ; migrer le script `lint` vers le CLI ESLint.
+- **`esbuild`** : à partir du **2026-06-18** (fin du `minimumReleaseAge`), passer l'override
+  `esbuild: ^0.25.0` → `^0.28.1` dans `pnpm-workspace.yaml` puis `pnpm install` — élimine la
+  seule High runtime restante.
 - **Vérifier trimestriellement** les fix upstream pour `exceljs` (tmp, uuid) et `maplibre-gl`.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@getbrevo/brevo": "5.0.4",
     "@gouvfr/dsfr": "1.14.4",
-    "@gouvfr/dsfr-chart": "2.0.4",
+    "@gouvfr/dsfr-chart": "2.1.1",
     "@react-email/components": "1.0.12",
     "@react-email/render": "2.0.8",
     "@socialgouv/matomo-next": "1.13.1",
@@ -76,7 +76,7 @@
     "@testing-library/user-event": "14.6.1",
     "@types/node": "22.13.5",
     "@types/nodemailer": "8.0.0",
-    "@types/react": "19.2.14",
+    "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "5.1.4",
     "@vitest/ui": "4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.14.4
         version: 1.14.4
       '@gouvfr/dsfr-chart':
-        specifier: 2.0.4
-        version: 2.0.4
+        specifier: 2.1.1
+        version: 2.1.1
       '@react-email/components':
         specifier: 1.0.12
         version: 1.0.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -88,7 +88,7 @@ importers:
         version: 4.4.3
       zustand:
         specifier: 5.0.14
-        version: 5.0.14(@types/react@19.2.14)(react@19.2.7)
+        version: 5.0.14(@types/react@19.2.17)(react@19.2.7)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: 4.3.0
@@ -101,7 +101,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -112,11 +112,11 @@ importers:
         specifier: 8.0.0
         version: 8.0.0
       '@types/react':
-        specifier: 19.2.14
-        version: 19.2.14
+        specifier: 19.2.17
+        version: 19.2.17
       '@types/react-dom':
         specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.14)
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 5.1.4
         version: 5.1.4(vite@7.3.2(@types/node@22.13.5)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4))
@@ -553,8 +553,9 @@ packages:
     resolution: {integrity: sha512-wN4mHE6O0Pb/d/Dh3E4MAm2zCHbLLUcFF8/wgwTeMPy9KzHBYLu7S/nsJbzd0AWL09MHn8vwue8ULL9YOzluOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@gouvfr/dsfr-chart@2.0.4':
-    resolution: {integrity: sha512-/JoW6R7ystExxvuLvHacR0ZWcL1PpDkUyG/niF8jgqRaksWgb31EpJGQjmgaHR29nrANdyvoRb1DEQAL00XZ1A==}
+  '@gouvfr/dsfr-chart@2.1.1':
+    resolution: {integrity: sha512-+d31EVpxqfA/O5xrPZzOTF8C4usHCVmt+fk00twyMyDp8Tpcz8J7hP4s4a6M+OgkOwnOriRoV5ET55gJmWoIZA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   '@gouvfr/dsfr@1.14.4':
     resolution: {integrity: sha512-Ca17apmTyAF2tMFwMcLwQN7fTlbfMFeyYSLUIUmjoSg1XVF4vDDkbvvKBpWJWaoTLDSFZBbvvHzcDyxw9wSkLA==}
@@ -1403,8 +1404,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/supercluster@7.1.3':
     resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
@@ -4078,7 +4079,7 @@ snapshots:
 
   '@getbrevo/brevo@5.0.4': {}
 
-  '@gouvfr/dsfr-chart@2.0.4': {}
+  '@gouvfr/dsfr-chart@2.1.1': {}
 
   '@gouvfr/dsfr@1.14.4': {}
 
@@ -4631,15 +4632,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.4.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -4711,11 +4712,11 @@ snapshots:
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
-  '@types/react@19.2.14':
+  '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
 
@@ -7229,7 +7230,7 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@5.0.14(@types/react@19.2.14)(react@19.2.7):
+  zustand@5.0.14(@types/react@19.2.17)(react@19.2.7):
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
       react: 19.2.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,8 @@ overrides:
   # ReDoS $data (transitif via eslint)
   ajv: "^6.14.0"
   # Arbitrary requests via dev server (transitif via drizzle-kit)
+  # NB: CVE Deno binary-integrity (<0.28.1) non-exploitable en Node ; bump vers ^0.28.1
+  # bloqué par minimumReleaseAge (0.28.1 publié le 2026-06-11) jusqu'au 2026-06-18.
   esbuild: "^0.25.0"
   # Path traversal via prefix/postfix non assainis (transitif via exceljs)
   tmp: "^0.2.6"


### PR DESCRIPTION
Bump node 24-alpine + apk upgrade (libssl3 3.5.6→3.5.7-r0), copie pnpm-workspace.yaml avant l'install frozen, embarque dsfr-chart 2.1.1 + @types/react.
