### PR TITLE
feat(espace-agent): distingue 'corriger' d'un dossier renvoyé en construction

### DIFF
--- a/src/app/(backoffice)/espace-agent/dossiers/components/DossiersSuivisTable.tsx
+++ b/src/app/(backoffice)/espace-agent/dossiers/components/DossiersSuivisTable.tsx
@@ -164,7 +164,8 @@ export function DossiersSuivisTable({
                         dossier.currentStep,
                         dossier.currentStatus,
                         dossier.dsStatus,
-                        dossier.validation
+                        dossier.validation,
+                        dossier.instructedAt
                       );
                       const responsableLabel = getResponsableDisplayName(dossier.responsable);
 

--- a/src/features/backoffice/espace-agent/dossiers/domain/responsable-presentation.test.ts
+++ b/src/features/backoffice/espace-agent/dossiers/domain/responsable-presentation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import { Status } from "@/shared/domain/value-objects/status.enum";
 import { StatutValidationAmo } from "@/shared/domain/value-objects/statut-validation-amo.enum";
+import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
 import {
   getDossierStepLabel,
   getEtatBadge,
@@ -11,9 +12,9 @@ import {
 
 describe("getDossierStepLabel", () => {
   it("retourne 'Non-éligible' pour une validation LOGEMENT_NON_ELIGIBLE", () => {
-    expect(
-      getDossierStepLabel(Step.CHOIX_AMO, { statut: StatutValidationAmo.LOGEMENT_NON_ELIGIBLE })
-    ).toBe("Non-éligible");
+    expect(getDossierStepLabel(Step.CHOIX_AMO, { statut: StatutValidationAmo.LOGEMENT_NON_ELIGIBLE })).toBe(
+      "Non-éligible"
+    );
   });
 
   it("retourne le libellé maquette pour CHOIX_AMO", () => {
@@ -65,7 +66,8 @@ describe("getDossierPrecisionLabel", () => {
       Step.ELIGIBILITE,
       Status.TODO,
       null,
-      { statut: StatutValidationAmo.LOGEMENT_NON_ELIGIBLE }
+      { statut: StatutValidationAmo.LOGEMENT_NON_ELIGIBLE },
+      null
     );
     expect(text).toBe("Logement non éligible.");
   });
@@ -76,7 +78,8 @@ describe("getDossierPrecisionLabel", () => {
       Step.ELIGIBILITE,
       Status.TODO,
       null,
-      { statut: StatutValidationAmo.ACCOMPAGNEMENT_REFUSE }
+      { statut: StatutValidationAmo.ACCOMPAGNEMENT_REFUSE },
+      null
     );
     expect(text).toBe("Accompagnement refusé.");
   });
@@ -87,7 +90,8 @@ describe("getDossierPrecisionLabel", () => {
       Step.ELIGIBILITE,
       Status.EN_INSTRUCTION,
       null,
-      { statut: StatutValidationAmo.LOGEMENT_ELIGIBLE }
+      { statut: StatutValidationAmo.LOGEMENT_ELIGIBLE },
+      null
     );
     expect(text).toMatch(/En instruction/);
   });
@@ -98,18 +102,55 @@ describe("getDossierPrecisionLabel", () => {
       Step.DIAGNOSTIC,
       Status.TODO,
       null,
-      { statut: StatutValidationAmo.LOGEMENT_ELIGIBLE }
+      { statut: StatutValidationAmo.LOGEMENT_ELIGIBLE },
+      null
     );
     expect(text).toMatch(/diagnostic/i);
   });
 
+  it("renvoie 'remplir' (premier dépôt) quand EN_CONSTRUCTION sans instructedAt", () => {
+    const text = getDossierPrecisionLabel(
+      "MENAGE",
+      Step.ELIGIBILITE,
+      Status.TODO,
+      DSStatus.EN_CONSTRUCTION,
+      { statut: StatutValidationAmo.LOGEMENT_ELIGIBLE },
+      null
+    );
+    expect(text).toBe("Le demandeur doit remplir le formulaire d'éligibilité.");
+  });
+
+  it("renvoie 'corriger' pour un dossier d'éligibilité renvoyé en construction par la DDT", () => {
+    const text = getDossierPrecisionLabel(
+      "MENAGE",
+      Step.ELIGIBILITE,
+      Status.TODO,
+      DSStatus.EN_CONSTRUCTION,
+      { statut: StatutValidationAmo.LOGEMENT_ELIGIBLE },
+      new Date("2026-01-10T10:00:00Z")
+    );
+    expect(text).toBe("Le demandeur doit corriger son formulaire d'éligibilité.");
+  });
+
+  it("renvoie 'corriger' pour un dossier de diagnostic renvoyé en construction par la DDT", () => {
+    const text = getDossierPrecisionLabel(
+      "MENAGE",
+      Step.DIAGNOSTIC,
+      Status.TODO,
+      DSStatus.EN_CONSTRUCTION,
+      { statut: StatutValidationAmo.LOGEMENT_ELIGIBLE },
+      new Date("2026-01-10T10:00:00Z")
+    );
+    expect(text).toBe("Le demandeur doit corriger son diagnostic.");
+  });
+
   it("renvoie 'En attente de qualification' pour AV_QUALIFICATION", () => {
-    const text = getDossierPrecisionLabel("AV_QUALIFICATION", Step.INVITATION, Status.TODO, null, null);
+    const text = getDossierPrecisionLabel("AV_QUALIFICATION", Step.INVITATION, Status.TODO, null, null, null);
     expect(text).toMatch(/qualification/i);
   });
 
   it("renvoie 'Dossier archivé' pour ARCHIVE", () => {
-    const text = getDossierPrecisionLabel("ARCHIVE", Step.ELIGIBILITE, Status.TODO, null, null);
+    const text = getDossierPrecisionLabel("ARCHIVE", Step.ELIGIBILITE, Status.TODO, null, null, null);
     expect(text).toBe("Dossier archivé.");
   });
 });

--- a/src/features/backoffice/espace-agent/dossiers/domain/responsable-presentation.ts
+++ b/src/features/backoffice/espace-agent/dossiers/domain/responsable-presentation.ts
@@ -61,10 +61,7 @@ export const DOSSIER_STEP_LABELS: Record<Step, string> = {
  * - sinon le libellé de l'étape
  * - « Non-éligible » si validation refusée (logement non éligible)
  */
-export function getDossierStepLabel(
-  step: Step,
-  validation: { statut: StatutValidationAmo } | null
-): string {
+export function getDossierStepLabel(step: Step, validation: { statut: StatutValidationAmo } | null): string {
   if (validation?.statut === StatutValidationAmo.LOGEMENT_NON_ELIGIBLE) {
     return "Non-éligible";
   }
@@ -114,7 +111,8 @@ export function getDossierPrecisionLabel(
   currentStep: Step,
   currentStatus: Status,
   dsStatus: DSStatus | null,
-  validation: { statut: StatutValidationAmo } | null
+  validation: { statut: StatutValidationAmo } | null,
+  instructedAt: Date | null
 ): string {
   if (validation?.statut === StatutValidationAmo.LOGEMENT_NON_ELIGIBLE) {
     return "Logement non éligible.";
@@ -133,6 +131,8 @@ export function getDossierPrecisionLabel(
     case "MENAGE":
       if (dsStatus === DSStatus.REFUSE) return "Refusé par la DDT — consulter la messagerie démarches.";
       if (currentStatus === Status.VALIDE) return etapeValideeLabel(currentStep);
+      // Déposé puis renvoyé en construction par la DDT (déjà instruit une fois) → correction attendue (cf. ADR-0009).
+      if (dsStatus === DSStatus.EN_CONSTRUCTION && instructedAt != null) return etapeCorrectionLabel(currentStep);
       return etapeTodoLabel(currentStep);
     case "REFUSE":
       // Couvert par les early returns ci-dessus pour les libellés détaillés ;
@@ -153,6 +153,21 @@ function etapeTodoLabel(step: Step): string {
       return "Diagnostic accepté. Le demandeur doit transmettre les devis.";
     case Step.FACTURES:
       return "Devis acceptés. Le demandeur doit transmettre les factures.";
+    default:
+      return "";
+  }
+}
+
+function etapeCorrectionLabel(step: Step): string {
+  switch (step) {
+    case Step.ELIGIBILITE:
+      return "Le demandeur doit corriger son formulaire d'éligibilité.";
+    case Step.DIAGNOSTIC:
+      return "Le demandeur doit corriger son diagnostic.";
+    case Step.DEVIS:
+      return "Le demandeur doit corriger ses devis.";
+    case Step.FACTURES:
+      return "Le demandeur doit corriger ses factures.";
     default:
       return "";
   }


### PR DESCRIPTION
Le tableau affichait toujours 'doit remplir le formulaire' même pour un dossier renvoyé en construction par la DDT ; on déduit le libellé de correction de instructedAt pour les 4 formulaires DN.
