### PR TITLE
chore(ops): script de détachement AMO (passage en sans AMO)

### DIFF
--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -94,6 +94,26 @@ le script ops `pnpm fix:reouvrir-demande` et la server action UI `reouvrirDemand
 Permissions et audit : voir [ADR-0016](../adr/0016-reouverture-demande-refusee.md) et
 [RBAC-ROLES.md](../security/RBAC-ROLES.md).
 
+### 2.5 Détachement de l'AMO (passage en « sans AMO »)
+
+Un demandeur avait choisi un AMO quand celui-ci était **obligatoire** ; depuis la
+modification de l'arrêté, l'AMO est facultatif et il veut poursuivre **seul**. Aucun
+écran ne permet d'annuler un accompagnement une fois l'AMO choisi (l'UI ne couvre que
+le « renoncer » avant choix, `skipAmoStepForUser`, qui exige `choix_amo / todo` + un
+département `FACULTATIF`). On **détache** donc l'AMO manuellement.
+
+Script ops `pnpm fix:detacher-amo` (`scripts/ops/fix/detacher-amo.ts`, dry-run par
+défaut, `--apply`, ciblage `--parcours-id` ou `--nom`). Effet, en transaction :
+`parcours_amo_validations -> statut = sans_amo`, `attribution_mode = aucun`,
+`entreprise_amo_id = NULL` (purge commentaire / `validee_at` / tracking email) ; les
+tokens AMO encore actifs sont invalidés (`used_at = now`, sinon l'AMO pourrait valider
+via le vieux lien email). Étape : encore à `choix_amo` -> avance à `eligibilite / todo`
+(comme le « skip » UI) ; déjà au-delà -> étape **inchangée** (on ne fait que détacher).
+Le responsable bascule sur l'aller-vers du territoire (résolution par
+`rgaSimulationData`, cf. [RBAC-ROLES §6](../security/RBAC-ROLES.md)). Pas d'entrée
+d'audit `parcours_actions` (action ops). À distinguer de la ré-ouverture (§2.4), qui
+remet une demande **refusée** en attente de validation AMO — ici on **retire** l'AMO.
+
 ---
 
 ## 3. Architecture de la synchronisation
@@ -489,6 +509,7 @@ n'a rien finalisé côté DN, fréquent et souvent normal).
 | Sonde lecture-seule dossiers DN             | `scripts/ops/sync-erreurs/probe-dossiers.ts` (`pnpm ds:probe-dossiers`)                        |
 | Action UI sync                              | `src/features/parcours/dossiers-ds/actions/dossier-sync.actions.ts`                            |
 | Validation AMO (auto-progression CHOIX_AMO) | `src/features/parcours/amo/services/amo-validation.service.ts`                                 |
+| Détachement AMO (passage en sans AMO)       | `scripts/ops/fix/detacher-amo.ts` (`pnpm fix:detacher-amo`)                                    |
 | Endpoint CRON                               | `src/app/api/cron/sync-parcours/route.ts`                                                      |
 | Workflow CRON GitHub Actions                | `.github/workflows/cron-sync-parcours.yml`                                                     |
 | Server actions admin                        | `src/features/backoffice/administration/synchronisations/actions/sync-runs.actions.ts`         |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "private": true,
   "packageManager": "pnpm@11.8.0",
   "engines": {
@@ -44,6 +44,7 @@
     "ds:probe-dossiers": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/probe-dossiers.ts",
     "fix:double-progression": "tsx scripts/ops/fix/fix-double-progression-amo.ts",
     "fix:reouvrir-demande": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/reouvrir-demande.ts",
+    "fix:detacher-amo": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/detacher-amo.ts",
     "fix:eligibilite-sync-error": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts",
     "fix:clean-faux-depots": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/clean-faux-depots-submitted-at.ts",
     "fix:relink-eligibilite": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/relink-eligibilite-dossier.ts",

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -45,6 +45,7 @@ Les scripts **autonomes** (sans import `@/`, comme `check-ds-permissions` et
 | [`verify-dashboard-stats.ts`](#verify-dashboard-stats)           | read-only | Vérifie que les stats du tableau de bord correspondent aux requêtes SQL équivalentes                                            | `tsx scripts/ops/audit/verify-dashboard-stats.ts`      |
 | [`fix-missing-epci.ts`](#fix-missing-epci)                       | **écrit** | Backfill du code EPCI sur les parcours qui en sont dépourvus (via `geo.api.gouv.fr`)                                            | `pnpm fix:epci`                                        |
 | [`reouvrir-demande.ts`](#reouvrir-demande)                       | **écrit** | Ré-ouvre une demande refusée par l'AMO (changement d'avis) : statut refusé -> en_attente + token frais (+ email)                | `pnpm fix:reouvrir-demande`                            |
+| [`detacher-amo.ts`](#detacher-amo)                               | **écrit** | Détache l'AMO d'un parcours (passage en « sans AMO ») : AMO choisi avant l'arrêté, le demandeur veut continuer seul             | `pnpm fix:detacher-amo`                                |
 | [`debug-matomo-events.ts`](#debug-matomo-events)                 | read-only | Diagnostic des doublons d'événements Matomo (funnel simulateur)                                                                 | `tsx scripts/ops/debug/debug-matomo-events.ts`         |
 | [`fetch-demarche-schema.ts`](#fetch-demarche-schema)             | read-only | Récupère le schéma GraphQL d'une démarche DS (utile pour itérer sur les mappings)                                               | `tsx scripts/ops/ds/fetch-demarche-schema.ts`          |
 | [`check-ds-permissions.ts`](#check-ds-permissions)               | read-only | Vérifie que le token GraphQL a accès à chaque démarche configurée (sinon synchro KO)                                            | `pnpm ds:check-permissions`                            |
@@ -167,6 +168,35 @@ pnpm fix:reouvrir-demande --parcours-id=<uuid>                  # dry-run
 pnpm fix:reouvrir-demande --parcours-id=<uuid> --apply          # applique (sans email)
 pnpm fix:reouvrir-demande --parcours-id=<uuid> --apply --send-email
 ```
+
+### detacher-amo
+
+Détache l'AMO d'un parcours et le bascule en « sans AMO » quand le demandeur veut
+poursuivre seul. Cas d'usage : un AMO avait été choisi alors qu'il était obligatoire,
+puis l'arrêté a rendu l'AMO facultatif ; aucun écran ne permet d'annuler
+l'accompagnement une fois l'AMO choisi → opération manuelle. Reproduit l'état cible du
+flux UI « renoncer à l'AMO » (`skipAmoStepForUser`) mais en partant d'un AMO **déjà
+choisi ou validé**, ce que l'UI ne couvre pas.
+
+Effet (en transaction) : `parcours_amo_validations` -> `statut = sans_amo`,
+`attribution_mode = aucun`, `entreprise_amo_id = NULL`, purge commentaire / `validee_at`
+/ tracking email ; les tokens AMO encore actifs sont invalidés (`used_at = now`, sinon
+l'AMO pourrait valider via le vieux lien email). Progression d'étape : si le parcours
+est encore à `choix_amo`, il avance à `eligibilite/todo` (comme le « skip » UI) ; s'il a
+déjà dépassé `choix_amo`, l'étape est **inchangée** (on détache seulement l'AMO). Le
+responsable bascule sur l'aller-vers du territoire (résolution par `rgaSimulationData`).
+Dry-run par défaut.
+
+> Le script n'écrit pas d'entrée d'audit `parcours_actions` (action ops, pas un agent
+> connecté).
+
+```bash
+pnpm fix:detacher-amo --nom=Dupont                     # dry-run, trouve par nom (ILIKE)
+pnpm fix:detacher-amo --parcours-id=<uuid>             # dry-run
+pnpm fix:detacher-amo --parcours-id=<uuid> --apply     # applique
+```
+
+**Prérequis** : `.env.local` avec `DATABASE_URL` (l'API DS n'est pas sollicitée).
 
 ### debug-matomo-events
 

--- a/scripts/ops/fix/detacher-amo.ts
+++ b/scripts/ops/fix/detacher-amo.ts
@@ -1,0 +1,252 @@
+/**
+ * Détache l'AMO d'un parcours et le bascule en « sans AMO » (le demandeur fait son
+ * parcours seul).
+ *
+ * Contexte
+ * --------
+ * Une demandeuse avait choisi un AMO quand celui-ci était obligatoire. Depuis la
+ * modification de l'arrêté, l'AMO est facultatif : elle souhaite poursuivre seule.
+ * Aucun écran ne permet d'annuler l'accompagnement une fois l'AMO choisi → opération
+ * manuelle.
+ *
+ * Ce script reproduit l'état cible du flux « renoncer à l'AMO » (`skipAmoStepForUser`,
+ * `amo-selection.service.ts`) mais en partant d'un AMO DÉJÀ choisi (ou déjà validé),
+ * ce que le flux UI ne couvre pas : `parcours_amo_validations` passe en `SANS_AMO`,
+ * `entreprise_amo_id` est détaché, le tracking email est purgé, et les tokens de
+ * validation encore actifs sont invalidés (le lien email AMO ne doit plus rien valider).
+ *
+ * Le responsable du parcours « sans AMO » devient l'aller-vers du territoire (résolution
+ * habituelle par `rgaSimulationData`) — rien à écrire de plus côté parcours.
+ *
+ * Progression d'étape
+ *   - Si le parcours est encore à `choix_amo` (todo OU en_instruction, l'AMO n'a pas
+ *     encore validé) → on avance à `eligibilite / todo`, exactement comme le « skip » UI.
+ *   - Si le parcours a déjà dépassé `choix_amo` (AMO validé, éligibilité en cours…) →
+ *     on NE touche PAS à l'étape : on se contente de détacher l'AMO. Le dossier en cours
+ *     devient « sans AMO » et suit son cours.
+ *
+ * Niveaux d'engagement
+ *   (rien)     dry-run : affiche l'état + le plan, aucune écriture
+ *   --apply    applique le détachement
+ *
+ * Ciblage (un seul requis)
+ *   --parcours-id=<uuid>   cible un parcours précis (recommandé en prod)
+ *   --nom=<nom>            recherche par users.nom (ILIKE) ; abandon si != 1 résultat
+ *
+ * Usage
+ *   pnpm fix:detacher-amo --nom=Dupont                       # dry-run
+ *   pnpm fix:detacher-amo --parcours-id=<uuid>               # dry-run
+ *   pnpm fix:detacher-amo --parcours-id=<uuid> --apply
+ *
+ * NB : action ops (pas un agent connecté) — pas d'entrée d'audit `parcours_actions`.
+ *
+ * Pré-requis : .env.local (ou vars Scalingo) avec la config DB.
+ */
+
+import "../lib/env";
+import { and, desc, eq, ilike, isNull } from "drizzle-orm";
+import { createOpsDb } from "../lib/db";
+import {
+  parcoursPrevention,
+  parcoursAmoValidations,
+  amoValidationTokens,
+  entreprisesAmo,
+  users,
+} from "@/shared/database/schema";
+import { StatutValidationAmo } from "@/shared/domain/value-objects/statut-validation-amo.enum";
+import { AttributionAmoMode } from "@/shared/domain/value-objects/attribution-amo-mode.enum";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+import { Status } from "@/shared/domain/value-objects/status.enum";
+import { getArg, hasFlag } from "../lib/args";
+
+const APPLY = hasFlag("apply");
+const PARCOURS_ID = getArg("parcours-id");
+const NOM = getArg("nom");
+
+if (!PARCOURS_ID && !NOM) {
+  console.error("Ciblage requis : --parcours-id=<uuid> ou --nom=<nom>");
+  process.exit(1);
+}
+
+const { db, client } = createOpsDb();
+
+function line() {
+  console.log("=".repeat(72));
+}
+
+async function main() {
+  line();
+  console.log(`DÉTACHEMENT AMO (parcours « sans AMO ») — ${APPLY ? "APPLY" : "DRY-RUN"}`);
+  line();
+
+  // --- 1. Résolution du parcours ---
+  let parcoursRow: typeof parcoursPrevention.$inferSelect | undefined;
+
+  if (PARCOURS_ID) {
+    [parcoursRow] = await db.select().from(parcoursPrevention).where(eq(parcoursPrevention.id, PARCOURS_ID)).limit(1);
+  } else if (NOM) {
+    const matches = await db
+      .select({ parcours: parcoursPrevention, nom: users.nom, prenom: users.prenom, email: users.email })
+      .from(parcoursPrevention)
+      .innerJoin(users, eq(parcoursPrevention.userId, users.id))
+      .where(ilike(users.nom, `%${NOM}%`))
+      .orderBy(desc(parcoursPrevention.createdAt));
+
+    if (matches.length === 0) {
+      console.error(`Aucun parcours pour un nom contenant "${NOM}".`);
+      await client.end();
+      process.exit(1);
+    }
+    if (matches.length > 1) {
+      console.error(`${matches.length} parcours trouvés pour "${NOM}". Précisez avec --parcours-id :`);
+      for (const m of matches) {
+        console.error(
+          `  ${m.parcours.id}  ${m.prenom ?? ""} ${m.nom ?? ""} <${m.email ?? "?"}>  ${m.parcours.currentStep}/${m.parcours.currentStatus}`
+        );
+      }
+      await client.end();
+      process.exit(1);
+    }
+    parcoursRow = matches[0].parcours;
+  }
+
+  if (!parcoursRow) {
+    console.error("Parcours introuvable.");
+    await client.end();
+    process.exit(1);
+  }
+  const parcoursId = parcoursRow.id;
+
+  // --- 2. Diagnostic ---
+  const [user] = await db.select().from(users).where(eq(users.id, parcoursRow.userId)).limit(1);
+  const [validation] = await db
+    .select()
+    .from(parcoursAmoValidations)
+    .where(eq(parcoursAmoValidations.parcoursId, parcoursId))
+    .limit(1);
+  const entreprise = validation?.entrepriseAmoId
+    ? (await db.select().from(entreprisesAmo).where(eq(entreprisesAmo.id, validation.entrepriseAmoId)).limit(1))[0]
+    : undefined;
+
+  console.log(`Parcours    : ${parcoursId}`);
+  console.log(`Demandeur   : ${user?.prenom ?? ""} ${user?.nom ?? ""} <${user?.email ?? "?"}>`);
+  console.log(`Étape       : ${parcoursRow.currentStep} / ${parcoursRow.currentStatus}`);
+  console.log(
+    `Validation  : ${validation ? `${validation.statut} (${validation.attributionMode})` : "<aucune ligne>"}`
+  );
+  console.log(`AMO         : ${entreprise ? `${entreprise.nom} (${entreprise.id})` : "<aucune>"}`);
+  console.log();
+
+  // --- 3. Garde-fous ---
+  if (!validation) {
+    console.error("ABANDON : aucune validation AMO sur ce parcours. Rien à détacher.");
+    await client.end();
+    process.exit(1);
+  }
+  if (validation.statut === StatutValidationAmo.SANS_AMO && !validation.entrepriseAmoId) {
+    console.error("ABANDON : ce parcours est déjà « sans AMO ». Rien à faire.");
+    await client.end();
+    process.exit(1);
+  }
+  if (parcoursRow.archivedAt) {
+    console.error(
+      `ABANDON : parcours archivé (archived_at=${parcoursRow.archivedAt.toISOString()}). Le désarchiver d'abord.`
+    );
+    await client.end();
+    process.exit(1);
+  }
+
+  // --- 4. Plan ---
+  const avanceEligibilite = parcoursRow.currentStep === Step.CHOIX_AMO;
+  const [pendingTokens] = await db
+    .select({ n: amoValidationTokens.id })
+    .from(amoValidationTokens)
+    .where(and(eq(amoValidationTokens.parcoursAmoValidationId, validation.id), isNull(amoValidationTokens.usedAt)));
+
+  console.log("PLAN :");
+  console.log(`  validation '${validation.statut}' -> 'sans_amo' (attributionMode -> 'aucun', entreprise détachée)`);
+  console.log(`  purge : commentaire, valideeAt, tracking email, brevoMessageId`);
+  console.log(`  tokens AMO actifs -> invalidés (usedAt = now)${pendingTokens ? "" : " — aucun token actif"}`);
+  if (avanceEligibilite) {
+    console.log(`  étape '${parcoursRow.currentStep}/${parcoursRow.currentStatus}' -> 'eligibilite/todo'`);
+  } else {
+    console.log(
+      `  étape inchangée (déjà au-delà de choix_amo) : '${parcoursRow.currentStep}/${parcoursRow.currentStatus}'`
+    );
+  }
+  console.log();
+
+  if (!APPLY) {
+    console.log("Mode dry-run — aucune écriture. Commande pour appliquer :");
+    console.log(`  pnpm fix:detacher-amo --parcours-id=${parcoursId} --apply`);
+    await client.end();
+    return;
+  }
+
+  // --- 5. Application (transaction) ---
+  await db.transaction(async (tx) => {
+    await tx
+      .update(parcoursAmoValidations)
+      .set({
+        entrepriseAmoId: null,
+        statut: StatutValidationAmo.SANS_AMO,
+        attributionMode: AttributionAmoMode.AUCUN,
+        commentaire: null,
+        valideeAt: null,
+        brevoMessageId: null,
+        emailSentAt: null,
+        emailDeliveredAt: null,
+        emailOpenedAt: null,
+        emailClickedAt: null,
+        emailBounceType: null,
+        emailBounceReason: null,
+      })
+      .where(eq(parcoursAmoValidations.id, validation.id));
+
+    // Tue les liens email AMO encore actifs (sinon l'AMO pourrait valider après coup).
+    await tx
+      .update(amoValidationTokens)
+      .set({ usedAt: new Date() })
+      .where(and(eq(amoValidationTokens.parcoursAmoValidationId, validation.id), isNull(amoValidationTokens.usedAt)));
+
+    if (avanceEligibilite) {
+      await tx
+        .update(parcoursPrevention)
+        .set({ currentStep: Step.ELIGIBILITE, currentStatus: Status.TODO })
+        .where(eq(parcoursPrevention.id, parcoursId));
+    }
+  });
+
+  console.log("OK — AMO détaché, parcours basculé en « sans AMO ».");
+
+  // --- 6. Vérification finale ---
+  const [after] = await db
+    .select({
+      step: parcoursPrevention.currentStep,
+      status: parcoursPrevention.currentStatus,
+      validationStatut: parcoursAmoValidations.statut,
+      entrepriseAmoId: parcoursAmoValidations.entrepriseAmoId,
+    })
+    .from(parcoursPrevention)
+    .leftJoin(parcoursAmoValidations, eq(parcoursAmoValidations.parcoursId, parcoursPrevention.id))
+    .where(eq(parcoursPrevention.id, parcoursId))
+    .limit(1);
+
+  console.log();
+  line();
+  console.log("ÉTAT FINAL :");
+  console.log(
+    `  step/status : ${after?.step}/${after?.status}${avanceEligibilite ? "   (attendu eligibilite/todo)" : "   (inchangé)"}`
+  );
+  console.log(`  validation  : ${after?.validationStatut}   (attendu sans_amo)`);
+  console.log(`  entreprise  : ${after?.entrepriseAmoId ?? "NULL"}   (attendu NULL)`);
+  line();
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error("Erreur fatale :", err);
+  client.end();
+  process.exit(1);
+});


### PR DESCRIPTION
Détache manuellement un AMO choisi avant l'arrêté pour qu'un demandeur poursuive seul (aucun écran ne le permet).
