### PR TITLE
wip: add lien fpa sur eligibilité

### DIFF
--- a/src/features/parcours/core/services/eligibilite.service.test.ts
+++ b/src/features/parcours/core/services/eligibilite.service.test.ts
@@ -40,6 +40,10 @@ vi.mock("@/shared/database", () => ({
   userRepo: { findById: vi.fn() },
 }));
 
+vi.mock("@/shared/config/env.config", () => ({
+  getServerEnv: vi.fn(() => ({ BASE_URL: "https://app.test" })),
+}));
+
 const AMO = {
   nom: "AMO Test",
   siret: "12345678900011",
@@ -115,5 +119,13 @@ describe("createEligibiliteDossier — prefill AMO", () => {
     expect(payload).not.toHaveProperty(`champ_${DS_FIELD_IDS.ELIGIBILITE.EMAIL_AMO}`);
     expect(payload).not.toHaveProperty(`champ_${DS_FIELD_IDS.ELIGIBILITE.ADRESSE_AMO}`);
     expect(payload).not.toHaveProperty(`champ_${DS_FIELD_IDS.ELIGIBILITE.TELEPHONE_AMO}`);
+  });
+
+  it("préremplit l'annotation privée « lien vers le dossier FPA » (comme diagnostic/devis)", async () => {
+    const payload = await runWithAmo({});
+
+    expect(payload[`champ_${DS_FIELD_IDS.ELIGIBILITE.ANNOTATION_LIEN_FPA}`]).toBe(
+      "https://app.test/espace-agent/dossiers/parcours-1"
+    );
   });
 });

--- a/src/features/parcours/core/services/eligibilite.service.ts
+++ b/src/features/parcours/core/services/eligibilite.service.ts
@@ -11,6 +11,7 @@ import { DS_FIELDS_ELIGIBILITE } from "../../dossiers-ds/domain";
 import { DS_FIELD_IDS } from "../../dossiers-ds/domain/value-objects/ds-field-ids";
 import { createDebugLogger } from "@/shared/utils";
 import { PartialRGASimulationData } from "@/features/simulateur";
+import { getServerEnv } from "@/shared/config/env.config";
 
 const debug = createDebugLogger("ELIGIBILITE");
 
@@ -26,7 +27,9 @@ interface EligibiliteResult {
 }
 
 /**
- * Crée un dossier d'éligibilité avec les données RGA
+ * Crée un dossier d'éligibilité avec les données RGA.
+ * Préremplit aussi l'annotation privée « Lien vers le dossier sur le fonds de
+ * prévention argile » (comme diagnostic/devis).
  */
 export async function createEligibiliteDossier(
   userId: string,
@@ -149,6 +152,11 @@ export async function createEligibiliteDossier(
     if (user?.telephone) {
       prefillData[`champ_Q2hhbXAtNTQyMjQ0MA==`] = user.telephone;
     }
+
+    // Annotation privée : lien vers le dossier back-office FPA (comme diagnostic/devis)
+    const env = getServerEnv();
+    const fpaLink = `${env.BASE_URL}/espace-agent/dossiers/${parcoursData.parcours.id}`;
+    prefillData[`champ_${DS_FIELD_IDS.ELIGIBILITE.ANNOTATION_LIEN_FPA}`] = fpaLink;
 
     // Logger tous les champs mappés
     debug.log("Données mappées pour DS (prefill):");

--- a/src/features/parcours/dossiers-ds/domain/value-objects/ds-field-ids.ts
+++ b/src/features/parcours/dossiers-ds/domain/value-objects/ds-field-ids.ts
@@ -12,6 +12,10 @@ export const DS_FIELD_IDS = {
     ANNEE_CONSTRUCTION: "Q2hhbXAtNTU0MjU2OA==",
     ZONE_EXPOSITION: "Q2hhbXAtNTUxMDk4Mw==",
     NOMBRE_NIVEAUX: "Q2hhbXAtNTQxNzM0OA==",
+    // Annotation privée (instructeur) — même ID que DIAGNOSTIC/DEVIS (Champ-6352089),
+    // à confirmer sur la démarche éligibilité via `pnpm tsx scripts/ops/ds/fetch-demarche-schema.ts <numero>`
+    // si le préremplissage échoue silencieusement côté DS.
+    ANNOTATION_LIEN_FPA: "Q2hhbXAtNjM1MjA4OQ==",
   },
   // Autres démarches
   DIAGNOSTIC: {


### PR DESCRIPTION
Comme sur les autres démarches, je rajoute le lien vers le dossier FPA dans les annotations privées. 

- Je ne suis pas certain de l'id utilisé (mais pour diag et devis c'etait le même alors j'ai mis le même). 
- Je n'ai pas testé. 