### PR TITLE
feat(ops): script de backfill des attributs Brevo (sans rejeu d'évène…

### DIFF
--- a/docs/emails/BREVO-LIFECYCLE.md
+++ b/docs/emails/BREVO-LIFECYCLE.md
@@ -169,7 +169,31 @@ opt-out et lien de désinscription requis avant toute Automation d'envoi en prod
 
 ---
 
-## 8. Fichiers clés
+## 8. Backfill des contacts existants (script ops)
+
+Les attributs ne sont poussés qu'au moment d'un **évènement** (§2). Un contact dont le dernier
+évènement est antérieur à l'ajout d'un attribut au contrat (§3) reste donc figé sur les anciennes
+données — ex. `CONSEILLER_*` ou `ADMIN_URL` absents chez un demandeur inscrit avant leur mise en
+place, ce qui fait planter les Automations qui comptent dessus.
+
+`pnpm fix:backfill-brevo` recalcule et **upsert** l'état courant complet de chaque contact, sans
+jamais rejouer `trackEvent` (aucun évènement historique n'est re-tiré, donc aucune Automation
+n'est déclenchée). Il réutilise `buildContactAttributes` / `buildConseillerAttributes` — les mêmes
+fonctions que les hooks live — et redérive depuis la base les attributs d'état normalement posés
+par les hooks événementiels : `A_AMO` / `AMO_STATUT` / `EST_MANDATAIRE` (depuis
+`parcours_amo_validations.statut`), `DS_STATUT` (dossier DS de l'étape courante) et
+`CREE_PAR_CONSEILLER` (`parcours.created_by_agent_id`).
+
+Dry-run par défaut ; voir [`scripts/ops/README.md`](../../scripts/ops/README.md#backfill-brevo-attributes)
+pour les options (`--apply`, `--parcours-id`, `--sleep`, `--no-anonymize`) et les prérequis.
+
+> `DS_STATUT` suit la même convention que le hook `dn_update` : il reflète le dossier de l'**étape
+> courante** et vaut `""` si ce dossier n'est pas encore déposé — un contact revenu à une étape non
+> déposée voit donc son `DS_STATUT` remis à vide, exactement comme en flux live (§2).
+
+---
+
+## 9. Fichiers clés
 
 | Rôle                                                                | Fichier                                                                                      |
 | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
@@ -180,3 +204,4 @@ opt-out et lien de désinscription requis avant toute Automation d'envoi en prod
 | Point d'entrée `emitBrevoEvent`                                     | `src/shared/email/brevo/brevo-contacts.service.ts`                                           |
 | Dossier créé par un conseiller (hook `dossier_cree_par_conseiller`) | `src/features/backoffice/espace-agent/creation-dossier/services/creation-dossier.service.ts` |
 | Compte créé / rattachement stub (`isNewAccount`)                    | `src/shared/database/repositories/user.repository.ts` (`upsertFromFranceConnect`)            |
+| Backfill des attributs (sans rejeu d'évènements)                    | `scripts/ops/fix/backfill-brevo-attributes.ts` (`pnpm fix:backfill-brevo`)                   |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.47.2",
+  "version": "1.48.0",
   "private": true,
   "packageManager": "pnpm@11.10.0",
   "engines": {
@@ -54,6 +54,7 @@
     "fix:relink-eligibilite": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/relink-eligibilite-dossier.ts",
     "fix:reclasser-source-autre": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/reclasser-source-autre.ts",
     "fix:purge-comptes-test-fc": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/purge-comptes-test-fc.ts",
+    "fix:backfill-brevo": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/backfill-brevo-attributes.ts",
     "rga:import": "tsx scripts/import/rga-zones/import-rga-zones.ts"
   },
   "dependencies": {

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -47,6 +47,7 @@ Les scripts **autonomes** (sans import `@/`, comme `check-ds-permissions` et
 | [`reouvrir-demande.ts`](#reouvrir-demande)                       | **écrit** | Ré-ouvre une demande refusée par l'AMO (changement d'avis) : statut refusé -> en_attente + token frais (+ email)                | `pnpm fix:reouvrir-demande`                            |
 | [`detacher-amo.ts`](#detacher-amo)                               | **écrit** | Détache l'AMO d'un parcours (passage en « sans AMO ») : AMO choisi avant l'arrêté, le demandeur veut continuer seul             | `pnpm fix:detacher-amo`                                |
 | [`purge-comptes-test-fc.ts`](#purge-comptes-test-fc)             | **écrit** | Supprime (cascade) les comptes demandeurs de test FranceConnect du CSV mocké FC low — staging/local uniquement, refus en prod   | `pnpm fix:purge-comptes-test-fc`                       |
+| [`backfill-brevo-attributes.ts`](#backfill-brevo-attributes)     | **écrit** | Recalcule et pousse (upsert, sans rejouer les évènements) l'état complet des attributs Brevo pour tous les contacts             | `pnpm fix:backfill-brevo`                              |
 | [`debug-matomo-events.ts`](#debug-matomo-events)                 | read-only | Diagnostic des doublons d'événements Matomo (funnel simulateur)                                                                 | `tsx scripts/ops/debug/debug-matomo-events.ts`         |
 | [`fetch-demarche-schema.ts`](#fetch-demarche-schema)             | read-only | Dump les champs + annotations d'une démarche DS avec leurs IDs (alimente `ds-field-ids.ts`)                                     | `pnpm ds:fetch-schema <numero>`                        |
 | [`check-ds-permissions.ts`](#check-ds-permissions)               | read-only | Vérifie que le token GraphQL a accès à chaque démarche configurée (sinon synchro KO)                                            | `pnpm ds:check-permissions`                            |
@@ -228,6 +229,34 @@ pnpm fix:purge-comptes-test-fc --no-anonymize           # emails/noms en clair
 
 **Prérequis** : `.env.local` avec `DATABASE_URL` + `NEXT_PUBLIC_APP_ENV` ; accès réseau à
 raw.githubusercontent.com pour le CSV.
+
+### backfill-brevo-attributes
+
+Recalcule et pousse (upsert de contact, **jamais** de `trackEvent` — les évènements
+historiques ne sont pas rejoués) l'état courant complet des attributs Brevo pour tous les
+parcours. Contexte : les attributs ne sont poussés qu'au moment d'un évènement métier, donc
+un contact créé avant l'ajout d'un attribut au contrat (ex. `CONSEILLER_*`, `ADMIN_URL`)
+reste figé sur les anciennes données, ce qui fait planter les Automations qui comptent
+dessus (cf. [docs/emails/BREVO-LIFECYCLE.md](../../docs/emails/BREVO-LIFECYCLE.md)).
+
+Réutilise les mêmes fonctions que les hooks live (`buildContactAttributes`,
+`buildConseillerAttributes`) pour les attributs génériques, et redérive depuis la vérité DB
+actuelle les attributs d'état normalement posés par les hooks événementiels (`A_AMO` /
+`AMO_STATUT` / `EST_MANDATAIRE` depuis `parcours_amo_validations.statut`, `DS_STATUT` depuis
+le dossier DS de l'étape courante, `CREE_PAR_CONSEILLER` depuis `created_by_agent_id`). No-op
+propre si la synchro Brevo est désactivée. Dry-run par défaut.
+
+```bash
+pnpm fix:backfill-brevo                          # dry-run, tous les parcours
+pnpm fix:backfill-brevo --apply
+pnpm fix:backfill-brevo --parcours-id=<uuid> --apply
+pnpm fix:backfill-brevo --sleep=300              # ralentit (défaut 150ms entre upserts)
+pnpm fix:backfill-brevo --no-anonymize           # emails en clair
+```
+
+**Prérequis** : `.env.local` complet (`DATABASE_URL` + `BREVO_API_KEY` +
+`BREVO_CONTACT_LIST_ID` + reste de la config serveur, lue via `getServerEnv()` par
+`resolveAdminUrl`).
 
 ### debug-matomo-events
 

--- a/scripts/ops/audit/audit-dossiers-bloques.ts
+++ b/scripts/ops/audit/audit-dossiers-bloques.ts
@@ -32,13 +32,13 @@ import { createRedactor } from "../lib/anonymize";
 import { STEP_LABELS } from "@/shared/domain/value-objects/step.enum";
 import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
 import { classifyDossierAnomaly } from "@/features/parcours/dossiers-ds/domain/value-objects/ds-anomaly";
-import { getArg, hasFlag } from "../lib/args";
+import { getArg, getNumberArg, hasFlag } from "../lib/args";
 
 // --- Args ---
 const CHECK_DS = hasFlag("check-ds");
 const CSV_PATH = getArg("csv");
 const ANONYMIZE = hasFlag("anonymize");
-const OLDER_THAN_DAYS = getArg("older-than") ? Number(getArg("older-than")) : 0;
+const OLDER_THAN_DAYS = getNumberArg("older-than", 0);
 
 // Statuts audités : les deux par défaut, restreignables via --only=
 const ONLY = getArg("only");

--- a/scripts/ops/ds/backfill-processed-at.ts
+++ b/scripts/ops/ds/backfill-processed-at.ts
@@ -41,13 +41,13 @@ import { createOpsDb } from "../lib/db";
 import { graphqlClient } from "@/features/parcours/dossiers-ds/adapters/graphql/client";
 import { dossiersDemarchesSimplifiees } from "@/shared/database/schema";
 import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
-import { getArg, hasFlag } from "../lib/args";
+import { getArg, getNumberArg, hasFlag } from "../lib/args";
 import { sleep } from "../sync-erreurs/_shared";
 import { createRedactor } from "../lib/anonymize";
 
 const APPLY = hasFlag("apply");
 const PARCOURS_ID = getArg("parcours-id");
-const SLEEP_MS = Number(getArg("sleep") ?? "200");
+const SLEEP_MS = getNumberArg("sleep", 200);
 const ANONYMIZE = !hasFlag("no-anonymize"); // anonymisé par défaut
 
 const { redactDsNumber } = createRedactor(ANONYMIZE);

--- a/scripts/ops/fix/backfill-brevo-attributes.ts
+++ b/scripts/ops/fix/backfill-brevo-attributes.ts
@@ -59,12 +59,12 @@ import {
 import { buildContactAttributes } from "@/shared/email/brevo/contact-mapping";
 import { buildConseillerAttributes } from "@/shared/email/brevo/conseiller-mapping";
 import { upsertContact, type BrevoAttributes } from "@/shared/email/brevo/brevo-contacts.adapter";
-import { getArg, hasFlag } from "../lib/args";
+import { getArg, getNumberArg, hasFlag } from "../lib/args";
 import { createRedactor } from "../lib/anonymize";
 
 const APPLY = hasFlag("apply");
 const PARCOURS_ID = getArg("parcours-id");
-const SLEEP_MS = Number(getArg("sleep") ?? "150");
+const SLEEP_MS = getNumberArg("sleep", 150);
 const ANONYMIZE = !hasFlag("no-anonymize");
 
 const { redactEmail, redactUuid } = createRedactor(ANONYMIZE);

--- a/scripts/ops/fix/backfill-brevo-attributes.ts
+++ b/scripts/ops/fix/backfill-brevo-attributes.ts
@@ -1,0 +1,206 @@
+/**
+ * Backfill des attributs de contact Brevo — SANS rejouer les évènements.
+ *
+ * Contexte
+ * --------
+ * Les attributs Brevo ne sont poussés qu'au moment d'un évènement métier
+ * (`emitBrevoEvent`). Un contact créé avant l'ajout d'un attribut au contrat (ex.
+ * `CONSEILLER_*`, `ADMIN_URL`) reste figé sur les anciennes données tant qu'aucun
+ * nouvel évènement ne repasse dessus — ce qui fait planter les Automations Brevo qui
+ * comptent dessus (cf. docs/emails/BREVO-LIFECYCLE.md).
+ *
+ * Ce script recalcule et pousse (upsert de contact, JAMAIS de `trackEvent` — les
+ * évènements historiques ne sont pas rejoués) l'état COURANT complet de chaque
+ * contact, en réutilisant les mêmes fonctions que les hooks live :
+ *   - buildContactAttributes(user, parcours, email) : PRENOM/NOM/DATE_INSCRIPTION/
+ *     SITUATION/ETAPE/STATUT/SOURCE_ACQUISITION/PARCOURS_ID/ADMIN_URL/INSEE/DEPARTEMENT
+ *   - buildConseillerAttributes(parcours.id)        : CONSEILLER_TYPE/NOM/EMAIL/
+ *     TELEPHONE/HORAIRES
+ * Complété par les attributs d'état posés historiquement par les hooks événementiels
+ * (non rejouables depuis les fonctions ci-dessus), redérivés ici depuis la vérité DB
+ * actuelle :
+ *   - A_AMO / AMO_STATUT / EST_MANDATAIRE : depuis `parcours_amo_validations.statut`
+ *     (A_AMO = true dès qu'une décision AMO existe : éligible, non éligible, ou
+ *     accompagnement refusé — pas seulement "éligible")
+ *   - DS_STATUT                           : depuis le dossier DS de l'étape courante
+ *   - CREE_PAR_CONSEILLER                 : depuis `parcours.created_by_agent_id`
+ *
+ * Dry-run par défaut. `--apply` pour écrire. `--parcours-id=<uuid>` pour cibler un
+ * parcours. `--sleep=<ms>` (défaut 150) entre deux upserts (rate limit Brevo).
+ * Identifiants anonymisés par défaut, `--no-anonymize` pour les emails en clair.
+ *
+ * Usage :
+ *   pnpm fix:backfill-brevo                          # dry-run, tous les parcours
+ *   pnpm fix:backfill-brevo --apply
+ *   pnpm fix:backfill-brevo --parcours-id=<uuid> --apply
+ *   pnpm fix:backfill-brevo --no-anonymize
+ *
+ * Prérequis : .env.local complet (DATABASE_URL + BREVO_API_KEY + BREVO_CONTACT_LIST_ID
+ * + le reste de la config serveur, lue par `getServerEnv()` via `resolveAdminUrl`).
+ * No-op propre (rien à faire) si la synchro Brevo est désactivée (local, ou liste non
+ * configurée).
+ */
+
+import "../lib/env";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/shared/database/client";
+import {
+  parcoursPrevention,
+  users,
+  parcoursAmoValidations,
+  dossiersDemarchesSimplifiees,
+} from "@/shared/database/schema";
+import { StatutValidationAmo } from "@/shared/domain/value-objects/statut-validation-amo.enum";
+import {
+  BREVO_ATTRS,
+  resolveBrevoContactEmail,
+  isBrevoContactSyncEnabled,
+} from "@/shared/email/brevo/brevo-contacts.config";
+import { buildContactAttributes } from "@/shared/email/brevo/contact-mapping";
+import { buildConseillerAttributes } from "@/shared/email/brevo/conseiller-mapping";
+import { upsertContact, type BrevoAttributes } from "@/shared/email/brevo/brevo-contacts.adapter";
+import { getArg, hasFlag } from "../lib/args";
+import { createRedactor } from "../lib/anonymize";
+
+const APPLY = hasFlag("apply");
+const PARCOURS_ID = getArg("parcours-id");
+const SLEEP_MS = Number(getArg("sleep") ?? "150");
+const ANONYMIZE = !hasFlag("no-anonymize");
+
+const { redactEmail, redactUuid } = createRedactor(ANONYMIZE);
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// A_AMO = true dès qu'une décision AMO a été rendue, éligible ou non (cf.
+// approveValidation / rejectEligibility / declineAccompagnementEligible dans
+// amo-validation.service.ts, qui poussent tous les trois A_AMO=true).
+const STATUTS_DECIDES = [
+  StatutValidationAmo.LOGEMENT_ELIGIBLE,
+  StatutValidationAmo.LOGEMENT_NON_ELIGIBLE,
+  StatutValidationAmo.ACCOMPAGNEMENT_REFUSE,
+];
+
+function line() {
+  console.log("=".repeat(72));
+}
+
+async function buildBackfillAttributes(
+  parcours: typeof parcoursPrevention.$inferSelect,
+  user: typeof users.$inferSelect,
+  email: string
+): Promise<BrevoAttributes> {
+  const attrs: BrevoAttributes = {
+    ...(await buildContactAttributes(user, parcours, email)),
+    ...(await buildConseillerAttributes(parcours.id)),
+  };
+
+  const [validation] = await db
+    .select()
+    .from(parcoursAmoValidations)
+    .where(eq(parcoursAmoValidations.parcoursId, parcours.id))
+    .limit(1);
+
+  if (validation && STATUTS_DECIDES.includes(validation.statut)) {
+    attrs[BREVO_ATTRS.A_AMO] = true;
+    attrs[BREVO_ATTRS.AMO_STATUT] = validation.statut;
+    if (validation.estMandataireFinancier !== null) {
+      attrs[BREVO_ATTRS.EST_MANDATAIRE] = validation.estMandataireFinancier;
+    }
+  } else {
+    attrs[BREVO_ATTRS.A_AMO] = false;
+  }
+
+  const [dossierEtapeCourante] = await db
+    .select({ dsStatus: dossiersDemarchesSimplifiees.dsStatus })
+    .from(dossiersDemarchesSimplifiees)
+    .where(
+      and(
+        eq(dossiersDemarchesSimplifiees.parcoursId, parcours.id),
+        eq(dossiersDemarchesSimplifiees.step, parcours.currentStep)
+      )
+    )
+    .limit(1);
+  if (dossierEtapeCourante) {
+    attrs[BREVO_ATTRS.DS_STATUT] = dossierEtapeCourante.dsStatus ?? "";
+  }
+
+  attrs[BREVO_ATTRS.CREE_PAR_CONSEILLER] = parcours.createdByAgentId !== null;
+
+  return attrs;
+}
+
+async function main() {
+  line();
+  console.log(
+    `BACKFILL attributs Brevo (sans rejeu d'évènements) — ${APPLY ? "APPLY" : "DRY-RUN"}${ANONYMIZE ? " (anonymisé)" : ""}`
+  );
+  if (PARCOURS_ID) console.log(`Parcours ciblé : ${PARCOURS_ID}`);
+  line();
+
+  if (!isBrevoContactSyncEnabled()) {
+    console.log("Synchro Brevo désactivée (local, ou BREVO_API_KEY/BREVO_CONTACT_LIST_ID absents) — rien à faire.");
+    return;
+  }
+
+  const rows = await db
+    .select({ parcours: parcoursPrevention, user: users })
+    .from(parcoursPrevention)
+    .innerJoin(users, eq(users.id, parcoursPrevention.userId))
+    .where(PARCOURS_ID ? eq(parcoursPrevention.id, PARCOURS_ID) : undefined);
+
+  console.log(`Parcours à traiter : ${rows.length}\n`);
+
+  let updated = 0;
+  let wouldUpdate = 0;
+  let skippedNoEmail = 0;
+  let errors = 0;
+
+  for (const { parcours, user } of rows) {
+    const email = resolveBrevoContactEmail(user);
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+
+    try {
+      const attrs = await buildBackfillAttributes(parcours, user, email);
+      console.log(`  ${redactUuid(parcours.id)}  ${redactEmail(email)}  ${Object.keys(attrs).length} attributs`);
+
+      if (APPLY) {
+        const ok = await upsertContact(email, attrs);
+        if (ok) {
+          updated++;
+        } else {
+          console.error(`    échec upsertContact pour ${redactEmail(email)}`);
+          errors++;
+        }
+      } else {
+        wouldUpdate++;
+      }
+    } catch (error) {
+      console.error(`  ERREUR ${redactUuid(parcours.id)}:`, error instanceof Error ? error.message : error);
+      errors++;
+    }
+
+    if (SLEEP_MS > 0) await sleep(SLEEP_MS);
+  }
+
+  console.log();
+  line();
+  console.log("RÉCAP");
+  console.log(`  Contacts mis à jour     : ${updated}`);
+  console.log(`  Contacts à mettre à jour (dry-run) : ${wouldUpdate}`);
+  console.log(`  Ignorés (email non résoluble)      : ${skippedNoEmail}`);
+  console.log(`  Erreurs                            : ${errors}`);
+  if (!APPLY && wouldUpdate > 0) {
+    console.log(`\nRelancer avec --apply pour écrire.`);
+  }
+  line();
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error("Erreur fatale:", error);
+    process.exit(1);
+  });

--- a/scripts/ops/lib/args.test.ts
+++ b/scripts/ops/lib/args.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { parseNumberArg } from "./args";
+
+describe("parseNumberArg", () => {
+  it("replie sur la valeur par défaut quand l'argument est absent", () => {
+    expect(parseNumberArg(undefined, 200)).toBe(200);
+  });
+
+  it("accepte un entier, un décimal et zéro", () => {
+    expect(parseNumberArg("300", 200)).toBe(300);
+    expect(parseNumberArg("0.5", 200)).toBe(0.5);
+    expect(parseNumberArg("0", 200)).toBe(0);
+  });
+
+  it("rejette une valeur non numérique au lieu de rendre NaN", () => {
+    expect(parseNumberArg("abc", 200)).toBeNull();
+    expect(parseNumberArg("300ms", 200)).toBeNull();
+  });
+
+  it("rejette une valeur vide (`--sleep=`)", () => {
+    expect(parseNumberArg("", 200)).toBeNull();
+    expect(parseNumberArg("   ", 200)).toBeNull();
+  });
+
+  it("rejette l'infini et les valeurs sous le minimum", () => {
+    expect(parseNumberArg("Infinity", 200)).toBeNull();
+    expect(parseNumberArg("-5", 200)).toBeNull();
+    expect(parseNumberArg("2", 200, 10)).toBeNull();
+  });
+});

--- a/scripts/ops/lib/args.ts
+++ b/scripts/ops/lib/args.ts
@@ -14,3 +14,25 @@ export function getArg(name: string): string | undefined {
 export function hasFlag(name: string): boolean {
   return args.includes(`--${name}`);
 }
+
+/**
+ * Valide une valeur numérique d'argument. Retourne `null` si elle est inexploitable
+ * (vide, non numérique, sous `min`) — le `Number()` nu rendrait un `NaN` silencieux.
+ */
+export function parseNumberArg(raw: string | undefined, fallback: number, min = 0): number | null {
+  if (raw === undefined) return fallback;
+  if (raw.trim() === "") return null;
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= min ? value : null;
+}
+
+/** Valeur numérique d'un `--name=<nombre>`, avec repli. Sort en erreur si invalide. */
+export function getNumberArg(name: string, fallback: number, min = 0): number {
+  const raw = getArg(name);
+  const value = parseNumberArg(raw, fallback, min);
+  if (value === null) {
+    console.error(`--${name} invalide : "${raw}" (attendu : un nombre >= ${min})`);
+    process.exit(1);
+  }
+  return value;
+}

--- a/scripts/ops/sync-erreurs/probe-dossiers.ts
+++ b/scripts/ops/sync-erreurs/probe-dossiers.ts
@@ -50,7 +50,7 @@ import { createRedactor } from "../lib/anonymize";
 import { parcoursPrevention, users, dossiersDemarchesSimplifiees } from "@/shared/database/schema";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import { Status } from "@/shared/domain/value-objects/status.enum";
-import { getArg, hasFlag } from "../lib/args";
+import { getArg, getNumberArg, hasFlag } from "../lib/args";
 import { sleep, norm, getErrorByParcours, buildEmailIndex } from "./_shared";
 
 // --- Args ---
@@ -58,17 +58,12 @@ const FROM_SYNC_ERRORS = hasFlag("from-sync-errors");
 const NUMBERS_ARG = getArg("numbers");
 const EMAIL_CROSSCHECK = hasFlag("email-crosscheck");
 const ANONYMIZE = !hasFlag("no-anonymize"); // anonymisé par défaut
-const SLEEP_MS = Number(getArg("sleep") ?? "200");
+const SLEEP_MS = getNumberArg("sleep", 200);
 
 const { redactEmail, redactUuid, redactName } = createRedactor(ANONYMIZE);
 
 type Categorie =
-  | "SUPPRIME_OU_INTROUVABLE"
-  | "INEXISTANT"
-  | "DEPOSE_NON_INSTRUIT"
-  | "EN_INSTRUCTION"
-  | "TRAITE"
-  | "ERREUR_API";
+  "SUPPRIME_OU_INTROUVABLE" | "INEXISTANT" | "DEPOSE_NON_INSTRUIT" | "EN_INSTRUCTION" | "TRAITE" | "ERREUR_API";
 
 interface Cible {
   dsNumber: string;

--- a/scripts/ops/sync-erreurs/relink-eligibilite-dossier.ts
+++ b/scripts/ops/sync-erreurs/relink-eligibilite-dossier.ts
@@ -36,7 +36,7 @@ import { createRedactor } from "../lib/anonymize";
 import { parcoursPrevention, users, dossiersDemarchesSimplifiees } from "@/shared/database/schema";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import { Status } from "@/shared/domain/value-objects/status.enum";
-import { getArg, hasFlag } from "../lib/args";
+import { getArg, getNumberArg, hasFlag } from "../lib/args";
 import { sleep, norm, getErrorByParcours, isNotFound, buildEmailIndex } from "./_shared";
 
 const APPLY = hasFlag("apply");
@@ -44,7 +44,7 @@ const ANONYMIZE = hasFlag("anonymize");
 const FROM_SYNC_ERRORS = hasFlag("from-sync-errors");
 const PARCOURS_ID = getArg("parcours-id");
 const TO_DS_NUMBER = getArg("to-ds-number");
-const SLEEP_MS = Number(getArg("sleep") ?? "200");
+const SLEEP_MS = getNumberArg("sleep", 200);
 
 const { redactUuid, redactEmail } = createRedactor(ANONYMIZE);
 const { db, client } = createOpsDb();

--- a/scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts
+++ b/scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts
@@ -56,14 +56,14 @@ import { createRedactor } from "../lib/anonymize";
 import { parcoursPrevention, users, dossiersDemarchesSimplifiees } from "@/shared/database/schema";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import { Status } from "@/shared/domain/value-objects/status.enum";
-import { getArg, hasFlag } from "../lib/args";
+import { getArg, getNumberArg, hasFlag } from "../lib/args";
 import { sleep, getErrorByParcours, classifyDnError } from "./_shared";
 
 // --- Args ---
 const APPLY = hasFlag("apply");
 const ANONYMIZE = hasFlag("anonymize");
 const PARCOURS_ID_FILTER = getArg("parcours-id");
-const SLEEP_MS = Number(getArg("sleep") ?? "200");
+const SLEEP_MS = getNumberArg("sleep", 200);
 
 const { redactUuid, redactEmail } = createRedactor(ANONYMIZE);
 const { db, client } = createOpsDb();


### PR DESCRIPTION
…ments)

Les anciens demandeurs n'ont pas les attributs ajoutés au contrat après leur dernier évènement Brevo (CONSEILLER_*, ADMIN_URL...), ce qui fait planter les Automations qui comptent dessus. Recalcule et upsert l'état courant complet par contact, sans jamais rejouer trackEvent — réutilise les mêmes fonctions que les hooks live.