### PR TITLE
fix(dossiers-ds): aligne les libellés du champ mandataire avec DN

### DIFF
--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -168,15 +168,22 @@ sur le détail de la demande/du dossier.
 
 **Report vers Démarches Numériques.** La démarche d'éligibilité porte un champ
 « Avez-vous un mandataire, et si oui, est-il financier ? » (`MANDATAIRE_FINANCIER`,
-liste à 3 options). Il est prérempli à la création du dossier **uniquement quand
-`est_mandataire_financier = true`**, avec la valeur `« Mandataire administratif et financier »`
-(libellé contractuel côté DN — cf. `DS_OPTIONS_MANDATAIRE`, toute divergence fait rejeter la
-valeur au préremplissage puisque c'est une liste déroulante, pas un enum/ID stable).
+liste à 3 options — libellés contractuels côté DN, cf. `DS_OPTIONS_MANDATAIRE` : toute
+divergence fait rejeter la valeur au préremplissage puisque c'est une liste déroulante,
+pas un enum/ID stable). **Toujours prérempli** à la création du dossier, avec exactement
+une des 3 valeurs :
 
-> Ce champ DN appartient à la section « représentant légal / mandataire **du demandeur** »,
-> pas à la section AMO : un `false` côté AMO ne dit ni s'il existe un autre mandataire
-> (proche, représentant légal), ni si l'AMO est mandataire _non_ financier. On laisse donc
-> le champ vide sur `false` comme sur `null` — le demandeur répond lui-même. Préremplir
+| Situation                                                | Valeur envoyée                          |
+| --------------------------------------------------------- | ---------------------------------------- |
+| Pas d'AMO (`SANS_AMO` / « je gère seul »)                  | `Pas de mandataire`                      |
+| AMO accompagnant, `est_mandataire_financier = true`        | `Mandataire administratif et financier`  |
+| AMO accompagnant, `est_mandataire_financier = false`/`null` | `Mandataire administratif`               |
+
+> Un AMO qui accompagne le demandeur est considéré **de facto mandataire administratif**
+> (décision assumée : pas de déclaration explicite séparée pour ce volet, contrairement au
+> volet financier qui reste une déclaration explicite de l'AMO). Ce champ DN appartient à
+> la section « représentant légal / mandataire **du demandeur** », pas à la section AMO —
+> mais en pratique l'AMO qui suit administrativement le dossier EST ce mandataire. Préremplir
 > « Mandataire administratif et financier » a par ailleurs une conséquence : la PJ « Relevé
 > d'identité bancaire du mandataire financier » est obligatoire côté DN.
 

--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -169,14 +169,16 @@ sur le détail de la demande/du dossier.
 **Report vers Démarches Numériques.** La démarche d'éligibilité porte un champ
 « Avez-vous un mandataire, et si oui, est-il financier ? » (`MANDATAIRE_FINANCIER`,
 liste à 3 options). Il est prérempli à la création du dossier **uniquement quand
-`est_mandataire_financier = true`**, avec la valeur `« Mandataire financier »`.
+`est_mandataire_financier = true`**, avec la valeur `« Mandataire administratif et financier »`
+(libellé contractuel côté DN — cf. `DS_OPTIONS_MANDATAIRE`, toute divergence fait rejeter la
+valeur au préremplissage puisque c'est une liste déroulante, pas un enum/ID stable).
 
 > Ce champ DN appartient à la section « représentant légal / mandataire **du demandeur** »,
 > pas à la section AMO : un `false` côté AMO ne dit ni s'il existe un autre mandataire
 > (proche, représentant légal), ni si l'AMO est mandataire _non_ financier. On laisse donc
 > le champ vide sur `false` comme sur `null` — le demandeur répond lui-même. Préremplir
-> « Mandataire financier » a par ailleurs une conséquence : la PJ « Relevé d'identité
-> bancaire du mandataire financier » est obligatoire côté DN.
+> « Mandataire administratif et financier » a par ailleurs une conséquence : la PJ « Relevé
+> d'identité bancaire du mandataire financier » est obligatoire côté DN.
 
 **Préremplissage = création seulement, jamais mise à jour (QA juillet 2026).** Si le
 demandeur annule son accompagnement AMO après coup, on ne « corrige » pas le dossier DN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.42.1",
+  "version": "1.43.0",
   "private": true,
   "packageManager": "pnpm@11.10.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "private": true,
   "packageManager": "pnpm@11.10.0",
   "engines": {

--- a/src/features/parcours/core/services/eligibilite.service.test.ts
+++ b/src/features/parcours/core/services/eligibilite.service.test.ts
@@ -122,28 +122,31 @@ describe("createEligibiliteDossier — prefill AMO", () => {
     expect(payload).not.toHaveProperty(`champ_${DS_FIELD_IDS.ELIGIBILITE.TELEPHONE_AMO}`);
   });
 
-  it("préremplit « Mandataire administratif et financier » quand l'AMO s'est déclarée mandataire", async () => {
+  it("préremplit « Mandataire administratif et financier » quand l'AMO s'est déclarée mandataire financier", async () => {
     const payload = await runWithAmo({}, true);
 
     expect(payload[`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`]).toBe(DS_OPTIONS_MANDATAIRE.FINANCIER);
   });
 
-  it("laisse le champ mandataire vide quand l'AMO a répondu « non »", async () => {
-    // Un « non » ne dit pas s'il existe un autre mandataire : on ne répond pas à sa place.
+  it("préremplit « Mandataire administratif » (AMO présent) quand l'AMO a répondu « non » sur le volet financier", async () => {
     const payload = await runWithAmo({}, false);
 
-    expect(payload).not.toHaveProperty(`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`);
+    expect(payload[`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`]).toBe(
+      DS_OPTIONS_MANDATAIRE.NON_FINANCIER
+    );
   });
 
-  it("laisse le champ mandataire vide quand la question n'a pas été posée (null)", async () => {
+  it("préremplit « Mandataire administratif » (AMO présent) quand la question financière n'a pas été posée (null)", async () => {
     const payload = await runWithAmo({}, null);
 
-    expect(payload).not.toHaveProperty(`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`);
+    expect(payload[`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`]).toBe(
+      DS_OPTIONS_MANDATAIRE.NON_FINANCIER
+    );
   });
 
-  it("n'écrit pas le champ mandataire sans AMO, même si la validation le dit mandataire", async () => {
+  it("préremplit « Pas de mandataire » sans AMO, même si une validation orpheline le dit mandataire financier", async () => {
     const payload = await runWithAmo(null, true);
 
-    expect(payload).not.toHaveProperty(`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`);
+    expect(payload[`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`]).toBe(DS_OPTIONS_MANDATAIRE.AUCUN);
   });
 });

--- a/src/features/parcours/core/services/eligibilite.service.test.ts
+++ b/src/features/parcours/core/services/eligibilite.service.test.ts
@@ -122,7 +122,7 @@ describe("createEligibiliteDossier — prefill AMO", () => {
     expect(payload).not.toHaveProperty(`champ_${DS_FIELD_IDS.ELIGIBILITE.TELEPHONE_AMO}`);
   });
 
-  it("préremplit « Mandataire financier » quand l'AMO s'est déclarée mandataire", async () => {
+  it("préremplit « Mandataire administratif et financier » quand l'AMO s'est déclarée mandataire", async () => {
     const payload = await runWithAmo({}, true);
 
     expect(payload[`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`]).toBe(DS_OPTIONS_MANDATAIRE.FINANCIER);

--- a/src/features/parcours/core/services/eligibilite.service.ts
+++ b/src/features/parcours/core/services/eligibilite.service.ts
@@ -142,14 +142,20 @@ export async function createEligibiliteDossier(
       if (amo.telephone) {
         prefillData[`champ_${DS_FIELD_IDS.ELIGIBILITE.TELEPHONE_AMO}`] = amo.telephone;
       }
+    }
 
-      // Uniquement quand l'AMO s'est déclarée mandataire financier : c'est le seul cas
-      // déductible. Un « non » ne dit pas s'il existe un autre mandataire (proche,
-      // représentant légal) ni si l'AMO est mandataire non financier → on laisse vide.
+    // Question mandataire toujours préremplie (3 choix) : un AMO qui accompagne le
+    // demandeur est de facto son mandataire administratif ; le volet financier reste
+    // la déclaration explicite de l'AMO (est_mandataire_financier). Sans AMO (SANS_AMO
+    // / « je gère seul »), aucun mandataire.
+    if (!amo) {
+      prefillData[`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`] = DS_OPTIONS_MANDATAIRE.AUCUN;
+    } else {
       const validationResult = await getValidationAmo();
-      if (validationResult.success && validationResult.data?.estMandataireFinancier === true) {
-        prefillData[`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`] = DS_OPTIONS_MANDATAIRE.FINANCIER;
-      }
+      const estMandataireFinancier = validationResult.success && validationResult.data?.estMandataireFinancier === true;
+      prefillData[`champ_${DS_FIELD_IDS.ELIGIBILITE.MANDATAIRE_FINANCIER}`] = estMandataireFinancier
+        ? DS_OPTIONS_MANDATAIRE.FINANCIER
+        : DS_OPTIONS_MANDATAIRE.NON_FINANCIER;
     }
 
     // Ajouter le téléphone du demandeur

--- a/src/features/parcours/dossiers-ds/domain/value-objects/ds-field-ids.ts
+++ b/src/features/parcours/dossiers-ds/domain/value-objects/ds-field-ids.ts
@@ -4,8 +4,9 @@
 export const DS_FIELD_IDS = {
   ELIGIBILITE: {
     // Section « 2. Identification du représentant légal ou du mandataire » : porte sur le
-    // mandataire du DEMANDEUR, pas sur l'AMO. On ne le préremplit que si l'AMO s'est
-    // déclarée mandataire financier — seul cas où la réponse est déductible sans ambiguïté.
+    // mandataire du DEMANDEUR, pas sur l'AMO. Toujours prérempli (3 choix, cf.
+    // DS_OPTIONS_MANDATAIRE) : un AMO accompagnant est de facto mandataire administratif,
+    // le volet financier suit la déclaration explicite de l'AMO (est_mandataire_financier).
     MANDATAIRE_FINANCIER: "Q2hhbXAtNjQ3MDQ5Nw==",
     SIRET_AMO: "Q2hhbXAtNTQxOTQyOQ==",
     ADRESSE_AMO: "Q2hhbXAtNTQxOTQzMg==",

--- a/src/features/parcours/dossiers-ds/domain/value-objects/ds-field-ids.ts
+++ b/src/features/parcours/dossiers-ds/domain/value-objects/ds-field-ids.ts
@@ -44,8 +44,8 @@ export const DS_FIELD_IDS = {
  */
 export const DS_OPTIONS_MANDATAIRE = {
   AUCUN: "Pas de mandataire",
-  NON_FINANCIER: "Mandataire non financier",
-  FINANCIER: "Mandataire financier",
+  NON_FINANCIER: "Mandataire administratif",
+  FINANCIER: "Mandataire administratif et financier",
 } as const;
 
 /**


### PR DESCRIPTION
DS_OPTIONS_MANDATAIRE envoie une valeur en clair (liste déroulante, pas un enum/ID stable) : le libellé des options a été mis à jour côté Démarches Numériques, le préremplissage rejetait silencieusement la valeur sans ce correctif.