### PR TITLE
fix(ops): gèle le reset destructif des dossiers d'éligibilité (ADR-0026)

### DIFF
--- a/docs/adr/0026-gel-reset-eligibilite-not-found.md
+++ b/docs/adr/0026-gel-reset-eligibilite-not-found.md
@@ -1,0 +1,114 @@
+# ADR-0026 : Gel du reset destructif — « Dossier not found » ne prouve pas la disparition
+
+**Date** : 2026-08-24
+**Statut** : Accepté (amende [ADR-0013](0013-remediation-dossiers-dn-sync-erreur.md))
+
+## Contexte
+
+[ADR-0013](0013-remediation-dossiers-dn-sync-erreur.md) pose l'équation « `getDossier` renvoie
+`Dossier not found` → le pointeur est mort → reset (suppression de la ligne
+`dossiers_demarches_simplifiees`) ». Cette équation est **fausse**.
+
+Un dossier créé par l'API REST de préremplissage est un **brouillon orphelin, invisible de
+l'API GraphQL instructeur tant que l'usager ne l'a pas déposé** (comportement documenté par
+DN). Tant qu'il n'est pas transmis, `getDossier` répond `Dossier not found` — exactement
+comme pour un dossier réellement purgé. Les deux situations sont **indistinguables** par
+l'API : ni GraphQL (l'énumération `DossierState` ne contient pas `brouillon` ;
+`deletedDossiers` ne couvre que les dossiers ayant été visibles), ni REST (aucun endpoint de
+statut du token de préremplissage).
+
+Conséquence : le script `fix:eligibilite-sync-error --apply` supprime des pointeurs
+**vivants**. L'usager conserve son lien prefill, dépose plus tard, et son dossier devient
+orphelin — invisible de l'app, qui lui propose alors de recommencer et crée un second
+prérempli fantôme.
+
+Cas de référence, parcours `c3ffd5bb-7b8b-4d0d-a5b6-1ff91cabc975` (constaté en prod) :
+
+| Date               | Fait                                                                           |
+| ------------------ | ------------------------------------------------------------------------------ |
+| 2026-06-18 → 06-21 | 11 `sync_run_entries.error` sur `Sync dossier 32052358 ... Dossier not found`  |
+| ~2026-06-21/22     | La ligne disparaît (seul chemin de suppression identifié : ce script)          |
+| 2026-06-25         | L'usager dépose **#32052358** — même numéro, donc jamais supprimé côté DN      |
+| 2026-07-09         | **#32052358 accepté** — invisible de l'app                                     |
+| 2026-07-28         | L'app réaffiche « Remplir le formulaire » et crée **#32872663**, jamais ouvert |
+
+Le parcours est resté bloqué en `eligibilite/todo` alors que son éligibilité était acquise.
+
+## Décision
+
+> Nous **gelons l'option `--apply`** de `fix:eligibilite-sync-error` : le script refuse de
+> s'exécuter et sort en erreur. Le mode dry-run reste ouvert (diagnostic).
+>
+> Corollaire : **aucune remédiation ne supprime plus de pointeur**. La réparation passe par
+> le **relink** (`fix:relink-eligibilite`), qui repointe sans rien détruire.
+
+Le verdict `GONE` du script et l'état `DOSSIER_DN_NON_CREE` du diagnostic restent affichés
+mais deviennent **non concluants** : ils signifient « jamais observé déposé », pas « disparu ».
+
+Ce gel est une mesure d'arrêt d'urgence, pas la correction de fond. Il ouvre la voie à :
+reclassifier le prérempli non observé comme état normal (et non comme erreur de sync),
+persister l'historique des numéros DN générés, et réconcilier les dossiers perdus via
+l'annotation FPA porteuse du `parcoursId` ([ADR-0025](0025-lien-fpa-annotation-eligibilite.md)).
+
+## Options envisagées
+
+### Option A — Gel total de `--apply`, dry-run conservé (retenue)
+
+- Avantages : arrête immédiatement la destruction ; garde l'outil de diagnostic ; le garde-fou
+  vit dans le code, pas dans une consigne orale ; explicite la cause dans le message d'erreur.
+- Inconvénients : les rares cas de brouillon réellement purgé ne sont plus traités par script
+  (l'usager reste avec un lien mort jusqu'à la correction de fond).
+
+### Option B — Garder `--apply` derrière un seuil d'ancienneté
+
+- Avantages : traiterait encore les cas anciens.
+- Inconvénients : **aucun seuil n'est sûr**. DN conserve les brouillons trois mois après leur
+  **dernière modification**, information que l'app ne voit pas : un prérempli créé il y a
+  quatre mois peut avoir été modifié hier. Le seuil donnerait une fausse assurance.
+
+### Option C — Garder `--apply` sous condition de cross-check email négatif
+
+- Avantages : écarte les mismatches déjà identifiables.
+- Inconvénients : un cross-check `ABSENT` ne prouve rien non plus — l'usager peut déposer
+  demain. C'est précisément le scénario du cas de référence. De plus l'email n'est pas une clé
+  fiable (partagé, modifié, contact ≠ usager) et un prérempli non déposé n'expose pas encore
+  d'email usager.
+
+### Option D — Corriger d'abord la classification de la sync
+
+- Avantages : traite la cause (le faux positif) plutôt que le symptôme.
+- Inconvénients : demande une PR de code applicatif et un déploiement ; pendant ce temps le
+  script reste armé. Retenue comme **suite immédiate**, pas comme alternative au gel.
+
+## Conséquences
+
+### Positives
+
+- Plus aucun pointeur vivant ne peut être supprimé, y compris par un lancement distrait.
+- Le message d'erreur documente la cause : il n'y a rien à savoir en dehors du code.
+- Le diagnostic et le probe restent pleinement disponibles en lecture seule.
+
+### Négatives / Risques
+
+- Les parcours dont le brouillon a réellement été purgé conservent un pointeur mort et restent
+  affichés en sync-erreur — bruit assumé tant que la reclassification n'est pas faite.
+- `sync_run_entries` continue d'accumuler des erreurs sur ces dossiers (jusqu'à la suite).
+
+### Migration
+
+Aucune migration de données. Le stock de parcours déjà orphelinés se répare au cas par cas :
+recensement des numéros cités dans `sync_run_entries.error` et absents de
+`dossiers_demarches_simplifiees`, sondage DN (`ds:probe-dossiers`), puis relink des numéros
+déposés. Ces numéros sont des **indices** de récupération, jamais une base de relink
+automatique : ils ne restituent ni l'URL prefill ni le `ds_id`.
+
+## Liens
+
+- Script gelé : `scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts`
+- Réparation : `scripts/ops/sync-erreurs/relink-eligibilite-dossier.ts` (`pnpm fix:relink-eligibilite`)
+- Diagnostic : `scripts/ops/sync-erreurs/probe-dossiers.ts` (`pnpm ds:probe-dossiers`)
+- Guide : [SYNC-ERREURS-ET-REMEDIATION.md](../parcours/SYNC-ERREURS-ET-REMEDIATION.md)
+- [ADR-0013](0013-remediation-dossiers-dn-sync-erreur.md) — amendé sur le point « GONE → reset »
+- [ADR-0009](0009-semantique-statut-ds-depose-vs-brouillon.md) — sémantique `ds_status` / dépôt
+- [ADR-0012](0012-url-reprise-dossier-basee-sur-depot.md) — URL « commencer » vs « reprendre »
+- [ADR-0025](0025-lien-fpa-annotation-eligibilite.md) — annotation FPA (clé de réconciliation)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,5 +53,6 @@ purement cosmétique.
 | 0023 | [Remplacement de Crisp par le widget « Messages » de La Suite numérique](0023-remplacement-crisp-par-lasuite-messages.md)               | Accepté |
 | 0024 | [Commentaires/actions ouverts au super-admin dans l'espace agent](0024-commentaires-super-admin-espace-agent.md)                        | Accepté |
 | 0025 | [Lien FPA dans les annotations DN — ids par démarche et permalien parcours](0025-lien-fpa-annotation-eligibilite.md)                    | Accepté |
+| 0026 | [Gel du reset destructif — « Dossier not found » ne prouve pas la disparition](0026-gel-reset-eligibilite-not-found.md)                 | Accepté |
 
 <!-- Ajouter chaque nouvel ADR ici -->

--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -675,6 +675,12 @@ Détection préventive : `pnpm ds:check-permissions` (statut `UNAUTHORIZED`).
 > Guide simplifié dédié (cas, sous-cas, scripts, playbook) :
 > [SYNC-ERREURS-ET-REMEDIATION.md](SYNC-ERREURS-ET-REMEDIATION.md).
 
+> **GELÉ depuis le 2026-08-24 ([ADR-0026](../adr/0026-gel-reset-eligibilite-not-found.md))** :
+> un prérempli non déposé est **invisible de l'API instructeur** et répond `Dossier not found`
+> comme un dossier purgé — le verdict « disparu » n'est donc pas concluant et le reset a
+> supprimé des pointeurs vivants. `--apply` refuse de s'exécuter ; réparer par **relink**
+> (`pnpm fix:relink-eligibilite`). Section conservée pour comprendre l'outil, pas pour l'appliquer.
+
 Quand le lien DS n'a jamais été fait correctement (token non instructeur, démarche non
 publiée, dossier introuvable), le dossier d'éligibilité est « fantôme » : jamais
 déposable, jamais synchronisable. Le parcours reste bloqué en `eligibilite/todo` et
@@ -794,7 +800,7 @@ impots.gouv, assureur, CERFA mandat — `pieces-aide.map.ts`).
 | Composant PJ partagé (agent + demandeur)       | `dossiers-ds/components/PiecesJustificatives.tsx`                                              |
 | Proxy modèle PJ (URL temporaire DN régénérée)  | `src/app/api/ds/piece-modele/route.ts` (`buildModeleProxyUrl` / `getFreshModeleUrl`)           |
 | Probe pièces + modèles DN                      | `scripts/ops/ds/fetch-pieces-justificatives.ts` (`pnpm ds:fetch-pieces`)                       |
-| Reset dossier éligibilité sync-erreur          | `scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts` (`pnpm fix:eligibilite-sync-error`) |
+| Reset dossier éligibilité (GELÉ, ADR-0026)     | `scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts` (`pnpm fix:eligibilite-sync-error`) |
 | Sonde lecture-seule dossiers DN                | `scripts/ops/sync-erreurs/probe-dossiers.ts` (`pnpm ds:probe-dossiers`)                        |
 | Backfill processed_at depuis dateTraitement    | `scripts/ops/ds/backfill-processed-at.ts` (`pnpm ds:backfill-processed-at`)                    |
 | Action UI sync                                 | `src/features/parcours/dossiers-ds/actions/dossier-sync.actions.ts`                            |

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -7,6 +7,15 @@ d'un dossier Démarches Numériques (DN) introuvable.
 > Complète [FLOW-AND-SYNC.md](FLOW-AND-SYNC.md) (§3 sync, §7 pièges DN). À lire avant
 > d'utiliser les scripts `ds:probe-dossiers` et `fix:eligibilite-sync-error`.
 
+> **AVERTISSEMENT (2026-08-24) — le reset est GELÉ, cf. [ADR-0026](../adr/0026-gel-reset-eligibilite-not-found.md).**
+> Un prérempli **non encore déposé** est invisible de l'API instructeur DN et répond
+> `Dossier not found` **exactement comme un dossier purgé**. Le verdict **GONE de ce guide
+> n'est donc pas concluant**, et le reset a supprimé des pointeurs vivants (parcours
+> `c3ffd5bb` : dossier #32052358 « not found » en juin, supprimé, puis déposé le 25/06 et
+> accepté le 09/07 — devenu invisible de l'app). `fix:eligibilite-sync-error --apply` refuse
+> désormais de s'exécuter. Tout ce qui suit sur le reset est conservé pour l'historique mais
+> **ne doit pas être appliqué** ; la réparation passe par le **relink**.
+
 ---
 
 ## 1. C'est quoi une « sync erreur » ?
@@ -45,6 +54,10 @@ Le sur-ensemble « sync erreur » se décompose, selon le **verdict DN réel** (
 | **B3** — déposé puis purgé/expiré        | not_found + ABSENT                        | `last_sync_at` renseigné                 | **reset**              | —                            |
 | **Erreur de sondage**                    | unauthorized / api_error                  | —                                        | `ds:check-permissions` | —                            |
 | **(transverse)** faux dépôt legacy       | n'importe                                 | `submitted_at` set + `last_sync_at` NULL | —                      | **`fix:clean-faux-depots`**  |
+
+> Les lignes **reset** de ce tableau sont **gelées** ([ADR-0026](../adr/0026-gel-reset-eligibilite-not-found.md)) :
+> B1 et B3 ne sont pas distinguables d'un prérempli simplement pas encore déposé. Ne rien
+> supprimer ; seul le **relink** (B2) répare aujourd'hui.
 
 `clean` ne répare pas le parcours (c'est `reset`) : il efface le `submitted_at` trompeur posé
 à la création par le code pré-#216 (cf. §6), qui fausse diagnostic et stats. `pnpm
@@ -146,7 +159,7 @@ pnpm ds:probe-dossiers --numbers=28621590,32006324
   dossiers par email usager, et marque chaque GONE `ABSENT` ou `EXISTE_SOUS_AUTRE_NUMERO`.
 - Récap final avec ventilation des catégories et des GONE.
 
-### `pnpm fix:eligibilite-sync-error` — reset AUTO-VÉRIFIANT
+### `pnpm fix:eligibilite-sync-error` — reset AUTO-VÉRIFIANT (GELÉ, ADR-0026)
 
 Remet un demandeur bloqué « comme si l'AMO venait de valider » : supprime la ligne
 `dossiers_demarches_simplifiees` de l'étape éligibilité, en laissant le parcours en
@@ -166,9 +179,11 @@ chaque candidat et ne supprime **que** les dossiers que DN confirme disparus :
 ```bash
 pnpm fix:eligibilite-sync-error                      # dry-run (sonde DN, montre le plan)
 pnpm fix:eligibilite-sync-error --anonymize          # dry-run anonymisé
-pnpm fix:eligibilite-sync-error --parcours-id=<uuid> --apply   # un seul cas
-pnpm fix:eligibilite-sync-error --apply              # supprime tous les GONE
+pnpm fix:eligibilite-sync-error --parcours-id=<uuid> # dry-run ciblé
 ```
+
+> `--apply` **refuse de s'exécuter** (sortie en erreur) : le verdict GONE ne distingue pas un
+> prérempli en attente d'un dossier purgé. Seul le dry-run reste utile, comme diagnostic.
 
 Ne touche **ni** à la validation AMO (déjà `LOGEMENT_ELIGIBLE`), **ni** à
 `sync_run_entries` (historique conservé).
@@ -251,8 +266,9 @@ Au déploiement, `dn_probe_state` est vide → colonne « Verdict DN » = **Non 
 1. **Relink** (mismatches B2) **en premier** : `pnpm fix:relink-eligibilite --from-sync-errors`
    → `--apply` → **re-sync**. _Pourquoi en premier : un mismatch est « not found », le reset le
    supprimerait à tort ; le relink le rend « existe » et le reset l'épargne ensuite._
-2. **Reset** (drop-offs B1 + purgés B3) : `pnpm fix:eligibilite-sync-error` → `--apply`.
-   _Sûr : re-vérifie DN, ne supprime que les GONE confirmés._
+2. ~~**Reset** (drop-offs B1 + purgés B3)~~ — **GELÉ** ([ADR-0026](../adr/0026-gel-reset-eligibilite-not-found.md)).
+   `--apply` refuse de s'exécuter : « GONE » ne distingue pas un prérempli en attente d'un
+   dossier purgé, et la suppression orpheline le dossier déposé plus tard. Dry-run seul.
 3. **Clean** (faux dépôts legacy, transverse) : `pnpm fix:clean-faux-depots` → `--apply`.
    \_Indépendant : ne répare pas le parcours, nettoie les `submitted_at` trompeurs (diagnostic
    - stats). Lançable quand on veut.\_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "private": true,
   "packageManager": "pnpm@11.10.0",
   "engines": {

--- a/scripts/ops/sync-erreurs/README.md
+++ b/scripts/ops/sync-erreurs/README.md
@@ -9,12 +9,17 @@ Tous les scripts : **dry-run par défaut**, `--apply` pour écrire, `--anonymize
 les PII. Ils chargent l'env via `../lib/db` (dotenv) ; ceux qui appellent DN importent
 `graphqlClient` **après** pour garantir l'ordre de chargement.
 
-| Script                              | Alias                             | Rôle                                                         |
-| ----------------------------------- | --------------------------------- | ------------------------------------------------------------ |
-| `probe-dossiers.ts`                 | `pnpm ds:probe-dossiers`          | Sonde DN **lecture seule** (verdicts + cross-check email)    |
-| `reset-eligibilite-sync-error.ts`   | `pnpm fix:eligibilite-sync-error` | **Reset** des dossiers confirmés disparus côté DN (drop-off) |
-| `relink-eligibilite-dossier.ts`     | `pnpm fix:relink-eligibilite`     | **Relink** d'un mismatch (dossier réel sous un autre numéro) |
-| `clean-faux-depots-submitted-at.ts` | `pnpm fix:clean-faux-depots`      | Nettoyage des faux `submitted_at` legacy (pré-#216)          |
+| Script                              | Alias                             | Rôle                                                            |
+| ----------------------------------- | --------------------------------- | --------------------------------------------------------------- |
+| `probe-dossiers.ts`                 | `pnpm ds:probe-dossiers`          | Sonde DN **lecture seule** (verdicts + cross-check email)       |
+| `reset-eligibilite-sync-error.ts`   | `pnpm fix:eligibilite-sync-error` | **GELÉ** (`--apply` refusé, ADR-0026) — dry-run diagnostic seul |
+| `relink-eligibilite-dossier.ts`     | `pnpm fix:relink-eligibilite`     | **Relink** d'un mismatch (dossier réel sous un autre numéro)    |
+| `clean-faux-depots-submitted-at.ts` | `pnpm fix:clean-faux-depots`      | Nettoyage des faux `submitted_at` legacy (pré-#216)             |
 
-Ordre recommandé : **probe** → resync (UI) → **relink** → **reset** → **clean**. Détails et
-cas résolus : voir le playbook (§4 de la doc).
+Ordre recommandé : **probe** → resync (UI) → **relink** → **clean**. Détails et cas résolus :
+voir le playbook (§4 de la doc).
+
+> Le **reset est gelé** ([ADR-0026](../../../docs/adr/0026-gel-reset-eligibilite-not-found.md)) :
+> un prérempli non déposé est invisible de l'API instructeur et répond `Dossier not found`
+> comme un dossier purgé, donc le verdict GONE ne prouve rien. Supprimer la ligne orpheline
+> le dossier que l'usager déposera plus tard. Réparer par **relink**, jamais par suppression.

--- a/scripts/ops/sync-erreurs/README.md
+++ b/scripts/ops/sync-erreurs/README.md
@@ -5,9 +5,12 @@ Toolkit de diagnostic et remédiation des parcours bloqués en `eligibilite/todo
 
 Guide complet (cas, sous-cas, playbook) : [docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md](../../../docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md).
 
-Tous les scripts : **dry-run par défaut**, `--apply` pour écrire, `--anonymize` pour masquer
-les PII. Ils chargent l'env via `../lib/db` (dotenv) ; ceux qui appellent DN importent
-`graphqlClient` **après** pour garantir l'ordre de chargement.
+Tous les scripts : **dry-run par défaut**, `--anonymize` pour masquer les PII. `--apply`
+écrit — **sauf `fix:eligibilite-sync-error`, dont le `--apply` est gelé** (refus + sortie en
+erreur, cf. [ADR-0026](../../../docs/adr/0026-gel-reset-eligibilite-not-found.md) et l'encadré
+en bas de page) : il ne reste utilisable qu'en dry-run, comme diagnostic. Ils chargent l'env
+via `../lib/db` (dotenv) ; ceux qui appellent DN importent `graphqlClient` **après** pour
+garantir l'ordre de chargement.
 
 | Script                              | Alias                             | Rôle                                                            |
 | ----------------------------------- | --------------------------------- | --------------------------------------------------------------- |

--- a/scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts
+++ b/scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts
@@ -14,8 +14,13 @@
  * formulaire d'éligibilité" réapparaît et `createEligibiliteDossier` génère un NOUVEAU
  * lien prefill ("commencer"), et non "reprendre" le dossier cassé.
  *
+ * GELÉ (ADR-0026) — `--apply` est DÉSACTIVÉ : un prérempli non déposé est invisible de l'API
+ * instructeur et répond « Dossier not found » comme un dossier purgé, donc le verdict GONE
+ * ci-dessous ne prouve rien. Le dry-run reste ouvert (diagnostic) ; réparer via
+ * `pnpm fix:relink-eligibilite`.
+ *
  * SÉCURITÉ — vérification DN par dossier (lecture seule) AVANT toute suppression :
- *   GONE    DN « Dossier not found » ou dossier inexistant → pointeur mort → RESET autorisé
+ *   GONE    DN « Dossier not found » ou dossier inexistant → verdict NON concluant (cf. gel)
  *   EXISTS  le dossier existe encore côté DN (en construction / en instruction / traité)
  *           → VRAIE donnée, jamais supprimé : la prochaine sync réussie le rattrapera
  *   PROBE_ERREUR  erreur DN autre que « not found » (unauthorized, réseau…) → jamais
@@ -26,7 +31,7 @@
  *
  * Niveaux d'engagement :
  *   (rien)   dry-run : sonde DN, affiche le plan, aucune écriture
- *   --apply  supprime les lignes des dossiers confirmés GONE par DN
+ *   --apply  DÉSACTIVÉ (gel) : le script refuse et sort en erreur
  *
  * Filtres / options :
  *   --parcours-id=<uuid>  limite à un seul parcours (cas isolé / debug)
@@ -36,7 +41,6 @@
  * Usage :
  *   pnpm fix:eligibilite-sync-error                      # dry-run (sonde DN)
  *   pnpm fix:eligibilite-sync-error --anonymize          # dry-run anonymisé
- *   pnpm fix:eligibilite-sync-error --apply              # supprime les GONE
  *   pnpm fix:eligibilite-sync-error --parcours-id=<uuid> # cible
  *
  * Prérequis : .env.local avec DATABASE_URL + DEMARCHES_SIMPLIFIEES_GRAPHQL_API_* .
@@ -168,7 +172,32 @@ function line(c: Candidate): string {
   return `[${redactUuid(c.parcoursId)}] ${redactEmail(c.email)} — ${num} local(ds_status=${c.localDsStatus ?? "null"})`;
 }
 
+/** Gel du `--apply` (ADR-0026) : « Dossier not found » ne prouve pas la disparition. */
+async function refuseApply(): Promise<never> {
+  console.error("=".repeat(72));
+  console.error("RESET GELÉ — l'option --apply est désactivée");
+  console.error("=".repeat(72));
+  console.error(
+    "Un dossier prérempli non encore déposé est INVISIBLE de l'API instructeur DN :\n" +
+      "`getDossier` répond « Dossier not found » exactement comme pour un dossier purgé.\n" +
+      "Le verdict GONE de ce script ne prouve donc pas la disparition, et supprimer la ligne\n" +
+      "orpheline le dossier que l'usager déposera plus tard via son lien encore valide.\n" +
+      "\n" +
+      "Cas de référence : parcours c3ffd5bb (dossier #32052358 « not found » du 18 au 21 juin,\n" +
+      "supprimé par ce script, puis déposé le 25 juin et accepté le 9 juillet — invisible depuis).\n" +
+      "\n" +
+      "Le mode DRY-RUN reste ouvert (diagnostic). Pour réparer un cas : pnpm fix:relink-eligibilite.\n" +
+      "Voir docs/adr/0026-gel-reset-eligibilite-not-found.md et\n" +
+      "docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md."
+  );
+  console.error("=".repeat(72));
+  await client.end();
+  process.exit(1);
+}
+
 async function main() {
+  if (APPLY) await refuseApply();
+
   console.log("=".repeat(72));
   console.log(`RESET ÉLIGIBILITÉ SYNC-ERREUR — ${APPLY ? "APPLY" : "DRY-RUN"}${ANONYMIZE ? " (anonymisé)" : ""}`);
   console.log("=".repeat(72));
@@ -214,7 +243,12 @@ async function main() {
   }
 
   if (!APPLY) {
-    console.log(`Mode dry-run — aucune écriture. Relancer avec --apply pour supprimer ${gone.length} dossier(s) GONE.`);
+    console.log(
+      `Mode dry-run — aucune écriture. ${gone.length} dossier(s) GONE : verdict NON concluant ` +
+        "(un prérempli non déposé répond aussi « not found »). Le reset est gelé (ADR-0026) ; " +
+        "sonder avec `pnpm ds:probe-dossiers --from-sync-errors --email-crosscheck` et réparer " +
+        "les mismatches avec `pnpm fix:relink-eligibilite`."
+    );
     await client.end();
     return;
   }


### PR DESCRIPTION
Un dossier prérempli non encore déposé est invisible de l'API instructeur DN : getDossier répond Dossier not found exactement comme pour un dossier purgé. Le verdict GONE de fix:eligibilite-sync-error ne prouve donc pas la disparition, et le --apply a supprimé des pointeurs vivants — le parcours c3ffd5bb en est la démonstration (dossier #32052358 « not found » du 18 au 21 juin, supprimé, puis déposé le 25 juin et accepté le 9 juillet, devenu invisible de l'app).

Cette PR gèle --apply (refus + exit 1), conserve le dry-run comme diagnostic, et corrige la documentation qui instruisait la suppression. Mesure d'arrêt d'urgence : la correction de fond (ne plus classer un prérempli non observé comme erreur de sync) suit en Phase 1.