### PR TITLE
fix(sync): un prérempli non déposé n'est plus une erreur de synchronisation

### DIFF
--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -346,6 +346,16 @@ Source : `src/features/parcours/dossiers-ds/domain/value-objects/ds-status.ts`.
 
 Note : `REFUSE` repasse en `EN_INSTRUCTION` interne (et non `VALIDE`) — c'est volontaire, un dossier refusé n'avance pas l'étape.
 
+Note : **un prérempli non déposé n'est pas une erreur de sync** ([ADR-0026](../adr/0026-gel-reset-eligibilite-not-found.md)).
+DN masque à l'API instructeur un dossier que l'usager n'a pas transmis : `getDossier` répond
+`Dossier not found`. Quand le dossier local n'a **ni `last_sync_at` ni `submitted_at`**,
+`syncDossierStatus` enregistre le verdict `not_found` dans `dn_probe_state` et retourne un
+succès (`notObserved: true`) — aucune entrée `sync_run_entries.error`, aucun rouge dans le
+diagnostic (état « Prérempli non déposé », severity `info`). L'erreur n'est conservée que pour
+un dossier **déjà observé** qui disparaît, ou pour une vraie erreur technique. La classification
+s'appuie sur `extensions.code` de la réponse GraphQL (`DsGraphQLError`), pas sur le libellé du
+message.
+
 Note : un `ds_status = null` (dossier créé non déposé) n'a pas d'entrée de mapping — `recomputeParcoursStatus` l'ignore et laisse `current_status` inchangé. `EN_CONSTRUCTION` (déposé) reste mappé en `TODO` interne : un dépôt en attente d'instruction n'avance pas encore l'étape côté parcours. Les dates `submitted_at` (passage en construction = dépôt), `instructed_at` (passage en instruction) et `processed_at` (décision DDT) sont écrites par la sync via le mapper de colonne Drizzle (`Date` typée — ne jamais interpoler un `Date` dans un `sql` brut, cela fait planter l'UPDATE). Voir [ADR-0009](../adr/0009-semantique-statut-ds-depose-vs-brouillon.md).
 
 Note : `processed_at` est la **date de décision DDT**, sourcée du champ DS `dateTraitement` (et non d'un `new Date()` au moment où la sync détecte l'état). Elle est renseignée pour **tout état final** : `ACCEPTE`, `REFUSE` et `CLASSE_SANS_SUITE` (auparavant elle n'était écrite que sur `ACCEPTE`). Comme les autres dates, elle est immuable (écrite via spread conditionnel, jamais écrasée par `null`). Côté UI, `processed_at` alimente la timeline des dossiers (`DossierTimeline`) avec le libellé « Validé le … » (accepté) ou « Refusé le … » (refusé / classé sans suite).

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -66,23 +66,26 @@ ds:probe-dossiers --from-sync-errors --email-crosscheck` produit ce décompte di
 
 ### Détail des états et verdicts
 
-Quand la synchro échoue (erreur **active**), le diagnostic distingue **trois états** (en
-base, sans appel DN), en s'appuyant sur le verdict DN persisté `dn_probe_state` :
+Le diagnostic distingue **trois états** (en base, sans appel DN), en s'appuyant sur le verdict
+DN persisté `dn_probe_state`. Depuis [ADR-0026](../adr/0026-gel-reset-eligibilite-not-found.md),
+seuls les deux premiers naissent d'une **erreur de sync** : un prérempli non déposé n'en produit
+plus (la sync retourne un succès `notObserved`), il est classé sur ses seules colonnes locales.
 
-| État diagnostic                                       | Condition en base                                               | Sévérité | Sens                                                                                    |
-| ----------------------------------------------------- | --------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
-| **Anomalie de synchro** (`SYNC_ANOMALIE`)             | `dn_probe_state` = `unauthorized` / `api_error`                 | error    | vrai pépin technique (token, réseau) — **à investiguer**                                |
-| **Dossier déposé disparu** (`DOSSIER_DEPOSE_DISPARU`) | `last_sync_at` ET `submitted_at`, pas d'`instructed_at`         | warning  | dépôt réel confirmé puis disparu côté DN — **rare**                                     |
-| **Dossier DN non créé** (`DOSSIER_DN_NON_CREE`)       | autres cas (jamais confirmé : `not_found`, `last_sync_at` null) | info     | le demandeur a cliqué « Remplir » mais rien créé côté DN — **fréquent, souvent normal** |
+| État diagnostic                                       | Condition en base                                       | Sévérité | Sens                                                                                        |
+| ----------------------------------------------------- | ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| **Anomalie de synchro** (`SYNC_ANOMALIE`)             | `dn_probe_state` = `unauthorized` / `api_error`         | error    | vrai pépin technique (token, réseau) — **à investiguer**                                    |
+| **Dossier déposé disparu** (`DOSSIER_DEPOSE_DISPARU`) | `last_sync_at` ET `submitted_at`, pas d'`instructed_at` | warning  | dépôt réel confirmé puis disparu côté DN — **rare**                                         |
+| **Prérempli non déposé** (`DOSSIER_DN_NON_CREE`)      | ni `last_sync_at` ni `submitted_at`                     | info     | pas encore transmis, donc masqué par DN à l'API instructeur — **normal, le gros du volume** |
 
 > **Pourquoi `last_sync_at` et pas seulement `submitted_at` ?** `submitted_at` seul **n'est
 > pas fiable** : avant la PR #216, il était posé **à la création** du dossier (faux dépôt
 > legacy), pas au dépôt réel. Le **seul** signal d'un vrai dépôt est `last_sync_at`
 > renseigné (= une sync a confirmé le dossier côté DN). Voir §6.
 
-> **Pourquoi « non créé » est en `info` (pas en rouge) ?** C'est le **gros du volume** et
-> c'est **souvent normal** (drop-off du funnel : clic « Remplir » sans aller au bout sur DN).
-> On ne garde le rouge que pour la vraie **anomalie technique**.
+> **Pourquoi « prérempli non déposé » est en `info` (pas en rouge) ?** Parce que ce n'est pas
+> une anomalie : DN masque à l'API instructeur tout dossier non transmis, donc l'absence de
+> nouvelles est l'état **attendu** tant que l'usager n'a pas déposé. C'est aussi le gros du
+> volume (105 cas sur 116 en août 2026). Le rouge est réservé à la vraie **anomalie technique**.
 
 > **Pourquoi `last_sync_at` et pas seulement `submitted_at` ?** `submitted_at` seul **n'est
 > pas fiable** : avant la PR #216, il était posé **à la création** du dossier (faux dépôt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.47.1",
+  "version": "1.47.2",
   "private": true,
   "packageManager": "pnpm@11.10.0",
   "engines": {

--- a/src/features/backoffice/administration/diagnostics/domain/diagnostics.types.ts
+++ b/src/features/backoffice/administration/diagnostics/domain/diagnostics.types.ts
@@ -19,7 +19,7 @@ export enum DiagnosticState {
   JAMAIS_SYNCHRONISE = "jamais_synchronise",
   /** Déposé depuis plus du seuil sans avoir été pris en instruction : ne bouge plus. */
   BLOQUE = "bloque",
-  /** Le demandeur a cliqué « Remplir » mais n'a pas (encore) créé/finalisé son dossier côté DN. Fréquent. */
+  /** Prérempli créé, jamais transmis : invisible de l'API instructeur. Normal et fréquent (ADR-0026). */
   DOSSIER_DN_NON_CREE = "dossier_dn_non_cree",
   // --- États normaux du dossier de l'étape courante ---
   /** Dossier créé mais jamais déposé par l'usager (brouillon). */
@@ -76,9 +76,9 @@ export const DIAGNOSTIC_STATE_META: Record<
     severity: "warning",
   },
   [DiagnosticState.DOSSIER_DN_NON_CREE]: {
-    label: "Dossier DN non créé",
+    label: "Prérempli non déposé",
     description:
-      "Le demandeur a cliqué « Remplir le formulaire » mais n'a pas (encore) créé/finalisé son dossier sur Démarches Numériques (rien côté DN). Fréquent et souvent normal : récent = peut encore aboutir ; ancien = abandon à nettoyer.",
+      "Le demandeur a cliqué « Remplir le formulaire » mais n'a pas encore transmis son dossier : DN masque un prérempli non déposé à l'API instructeur, d'où l'absence de nouvelles. État NORMAL, et non la preuve d'un dossier disparu — ne jamais supprimer sur ce seul signal (ADR-0026). Récent = peut encore aboutir ; ancien = abandon probable.",
     severity: "info",
   },
   [DiagnosticState.BROUILLON]: {
@@ -125,6 +125,7 @@ export const DIAGNOSTIC_STATE_ORDER: DiagnosticState[] = [
   DiagnosticState.ORPHELIN,
   DiagnosticState.JAMAIS_SYNCHRONISE,
   DiagnosticState.BLOQUE,
+  // États normaux à partir d'ici : « Prérempli non déposé » n'est plus une anomalie (ADR-0026).
   DiagnosticState.DOSSIER_DN_NON_CREE,
   DiagnosticState.BROUILLON,
   DiagnosticState.DEPOSE_EN_ATTENTE,

--- a/src/features/backoffice/administration/diagnostics/services/diagnostics.service.test.ts
+++ b/src/features/backoffice/administration/diagnostics/services/diagnostics.service.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { classify } from "./diagnostics.service";
+import { DiagnosticState, DIAGNOSTIC_STATE_META } from "../domain/diagnostics.types";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+import { Status } from "@/shared/domain/value-objects/status.enum";
+import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
+
+vi.mock("@/shared/database/client", () => ({ db: {} }));
+
+/** Ligne minimale : un dossier d'éligibilité rattaché à un parcours actif. */
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    parcoursId: "p1",
+    userId: "u1",
+    currentStep: Step.ELIGIBILITE,
+    currentStatus: Status.TODO,
+    parcoursCreatedAt: new Date("2026-06-01T00:00:00Z"),
+    dossierId: "d1",
+    dsNumber: "123",
+    dsStatus: null,
+    submittedAt: null,
+    instructedAt: null,
+    lastSyncAt: null,
+    dossierCreatedAt: new Date("2026-06-02T00:00:00Z"),
+    dnProbeState: null,
+    dnProbeAt: null,
+    eligAccepteId: null,
+    userNom: null,
+    userPrenom: null,
+    userEmail: null,
+    ...overrides,
+  } as never;
+}
+
+// Cf. ADR-0026 : DN masque un prérempli non transmis à l'API instructeur.
+describe("classify — prérempli non déposé (ADR-0026)", () => {
+  it("classe en « prérempli non déposé » un dossier jamais observé, même sans erreur de sync", () => {
+    expect(classify(row({ dnProbeState: "not_found" }), undefined)).toBe(DiagnosticState.DOSSIER_DN_NON_CREE);
+  });
+
+  it("ne le classe pas en « jamais synchronisé » (qui reste réservé au faux dépôt legacy)", () => {
+    expect(classify(row(), undefined)).not.toBe(DiagnosticState.JAMAIS_SYNCHRONISE);
+    // submitted_at posé à la création sans sync (pré-#216) : là, l'anomalie tient toujours.
+    expect(classify(row({ submittedAt: new Date("2026-06-02T00:00:00Z") }), undefined)).toBe(
+      DiagnosticState.JAMAIS_SYNCHRONISE
+    );
+  });
+
+  it("reste un état informatif, jamais une anomalie", () => {
+    expect(DIAGNOSTIC_STATE_META[DiagnosticState.DOSSIER_DN_NON_CREE].severity).toBe("info");
+  });
+
+  it("conserve l'anomalie technique quand le verdict DN est unauthorized/api_error", () => {
+    expect(classify(row({ dnProbeState: "unauthorized" }), "boom")).toBe(DiagnosticState.SYNC_ANOMALIE);
+    expect(classify(row({ dnProbeState: "api_error" }), "boom")).toBe(DiagnosticState.SYNC_ANOMALIE);
+  });
+
+  it("conserve « dossier déposé disparu » pour un dépôt confirmé par une sync", () => {
+    const r = row({
+      dnProbeState: "not_found",
+      lastSyncAt: new Date("2026-07-01T00:00:00Z"),
+      submittedAt: new Date("2026-07-01T00:00:00Z"),
+    });
+    expect(classify(r, "boom")).toBe(DiagnosticState.DOSSIER_DEPOSE_DISPARU);
+  });
+
+  it("laisse intacts les états normaux d'un dossier réellement synchronisé", () => {
+    const r = row({
+      dsStatus: DSStatus.EN_INSTRUCTION,
+      lastSyncAt: new Date("2026-07-01T00:00:00Z"),
+      submittedAt: new Date("2026-06-20T00:00:00Z"),
+      instructedAt: new Date("2026-06-25T00:00:00Z"),
+    });
+    expect(classify(r, undefined)).toBe(DiagnosticState.EN_INSTRUCTION);
+  });
+});

--- a/src/features/backoffice/administration/diagnostics/services/diagnostics.service.ts
+++ b/src/features/backoffice/administration/diagnostics/services/diagnostics.service.ts
@@ -47,7 +47,12 @@ interface RawRow {
   userEmail: string | null;
 }
 
-function classify(r: RawRow, syncError: string | undefined): DiagnosticState {
+/** Exportée pour les tests : la règle de classement est le cœur métier du diagnostic. */
+export function classify(r: RawRow, syncError: string | undefined): DiagnosticState {
+  // Prérempli jamais observé côté DN (aucune sync réussie, aucun dépôt) : DN le masque à
+  // l'API instructeur tant qu'il n'est pas transmis. État normal, pas une anomalie (ADR-0026).
+  const prefillNonObserve = !!r.dossierId && !r.lastSyncAt && !r.submittedAt;
+
   if (syncError) {
     // Vraie anomalie technique (token non instructeur, réseau) : le verdict DN persisté le dit.
     if (r.dnProbeState === "unauthorized" || r.dnProbeState === "api_error") return DiagnosticState.SYNC_ANOMALIE;
@@ -64,6 +69,8 @@ function classify(r: RawRow, syncError: string | undefined): DiagnosticState {
     return DiagnosticState.SANS_DOSSIER;
   }
 
+  if (prefillNonObserve) return DiagnosticState.DOSSIER_DN_NON_CREE;
+  // Reste ici le faux dépôt legacy : `submitted_at` posé à la création sans sync (pré-#216).
   if (r.dsNumber && !r.lastSyncAt) return DiagnosticState.JAMAIS_SYNCHRONISE;
 
   switch (r.dsStatus) {

--- a/src/features/parcours/core/services/devis.service.ts
+++ b/src/features/parcours/core/services/devis.service.ts
@@ -127,6 +127,7 @@ export async function createDevisDossier(userId: string): Promise<ActionResult<D
       dsNumber: createResponse.dossier_number.toString(),
       dsDemarcheId: demarcheId,
       dsUrl: createResponse.dossier_url,
+      dsId: createResponse.dossier_id,
     });
 
     if (!dossierResult.success) {

--- a/src/features/parcours/core/services/diagnostic.service.ts
+++ b/src/features/parcours/core/services/diagnostic.service.ts
@@ -119,6 +119,7 @@ export async function createDiagnosticDossier(userId: string): Promise<ActionRes
       dsNumber: createResponse.dossier_number.toString(),
       dsDemarcheId: demarcheId,
       dsUrl: createResponse.dossier_url,
+      dsId: createResponse.dossier_id,
     });
 
     if (!dossierResult.success) {

--- a/src/features/parcours/core/services/eligibilite.service.ts
+++ b/src/features/parcours/core/services/eligibilite.service.ts
@@ -216,6 +216,7 @@ export async function createEligibiliteDossier(
       dsNumber: createResponse.dossier_number.toString(),
       dsDemarcheId: demarcheId,
       dsUrl: createResponse.dossier_url,
+      dsId: createResponse.dossier_id,
     });
 
     if (!dossierResult.success) {

--- a/src/features/parcours/dossiers-ds/adapters/graphql/client.ts
+++ b/src/features/parcours/dossiers-ds/adapters/graphql/client.ts
@@ -8,6 +8,20 @@ import type {
   DossiersFilters,
 } from "./types";
 
+/**
+ * Erreur GraphQL DN portant son `extensions.code` (ex. `not_found`), pour classer sans
+ * dépendre du libellé du message — cf. ADR-0026.
+ */
+export class DsGraphQLError extends Error {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "DsGraphQLError";
+    this.code = code;
+  }
+}
+
 export class DemarchesSimplifieesClient {
   private apiUrl: string;
   private apiKey: string;
@@ -49,8 +63,9 @@ export class DemarchesSimplifieesClient {
 
       if (result.errors?.length) {
         const errorMessages = result.errors.map((e) => e.message).join(", ");
+        const code = result.errors[0]?.extensions?.code;
         console.error("GraphQL errors:", result.errors);
-        throw new Error(`GraphQL errors: ${errorMessages}`);
+        throw new DsGraphQLError(`GraphQL errors: ${errorMessages}`, typeof code === "string" ? code : undefined);
       }
 
       if (!result.data) {
@@ -295,8 +310,9 @@ export class DemarchesSimplifieesClient {
     `;
 
     // On ne capture PAS l'erreur ici : une erreur API (unauthorized, réseau...) doit
-    // remonter pour être tracée. `data.dossier` vaut null uniquement quand le dossier
-    // est réellement introuvable (réponse DS sans erreur).
+    // remonter pour être tracée. `null` (comme `not_found`) signifie « invisible de l'API
+    // instructeur » — un prérempli non déposé en fait partie, ce n'est pas une preuve de
+    // suppression (ADR-0026).
     const data = await this.executeQuery<{ dossier: Dossier }>(query, {
       number: dossierNumber,
     });

--- a/src/features/parcours/dossiers-ds/services/dossier-ds.service.ts
+++ b/src/features/parcours/dossiers-ds/services/dossier-ds.service.ts
@@ -1,6 +1,6 @@
 import { db } from "@/shared/database/client";
 import { dossiersDemarchesSimplifiees } from "@/shared/database/schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, desc } from "drizzle-orm";
 import type { Step } from "../../core/domain/value-objects/step";
 import { DSStatus } from "../domain/value-objects/ds-status";
 import type { ActionResult } from "@/shared/types";
@@ -14,6 +14,8 @@ interface CreateDossierDSParams {
   dsNumber: string;
   dsDemarcheId: string;
   dsUrl?: string;
+  /** Identifiant GraphQL du dossier renvoyé par l'API de préremplissage (ADR-0026). */
+  dsId?: string;
 }
 
 /**
@@ -34,6 +36,7 @@ export async function createDossierForCurrentStep(
         dsNumber: params.dsNumber,
         dsDemarcheId: params.dsDemarcheId,
         dsUrl: params.dsUrl,
+        dsId: params.dsId,
       })
       .returning();
 
@@ -74,10 +77,13 @@ export async function recordDnProbeState(dossierId: string, state: string): Prom
  * Récupère un dossier DS par étape
  */
 export async function getDossierByStep(parcoursId: string, step: Step) {
+  // `ORDER BY` explicite : la contrainte unique (parcours_id, step) rend le doublon impossible,
+  // mais un LIMIT 1 sans ordre resterait indéterministe si elle venait à sauter.
   const [dossier] = await db
     .select()
     .from(dossiersDemarchesSimplifiees)
     .where(and(eq(dossiersDemarchesSimplifiees.parcoursId, parcoursId), eq(dossiersDemarchesSimplifiees.step, step)))
+    .orderBy(desc(dossiersDemarchesSimplifiees.createdAt))
     .limit(1);
 
   return dossier || null;

--- a/src/features/parcours/dossiers-ds/services/ds-sync.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/ds-sync.service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { syncDossierStatus } from "./ds-sync.service";
 import { getDossierByStep, updateDossierStatus, recordDnProbeState } from "./dossier-ds.service";
-import { graphqlClient } from "../adapters/graphql/client";
+import { graphqlClient, DsGraphQLError } from "../adapters/graphql/client";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import { DSStatus } from "@/shared/domain/value-objects/ds-status.enum";
 import { emitBrevoEvent, BREVO_EVENTS, BREVO_ATTRS } from "@/shared/email/brevo";
@@ -12,11 +12,17 @@ vi.mock("./dossier-ds.service", () => ({
   recordDnProbeState: vi.fn(),
 }));
 
-vi.mock("../adapters/graphql/client", () => ({
-  graphqlClient: {
-    getDossierStatus: vi.fn(),
-  },
-}));
+vi.mock("../adapters/graphql/client", () => {
+  class DsGraphQLError extends Error {
+    readonly code?: string;
+    constructor(message: string, code?: string) {
+      super(message);
+      this.name = "DsGraphQLError";
+      this.code = code;
+    }
+  }
+  return { graphqlClient: { getDossierStatus: vi.fn() }, DsGraphQLError };
+});
 
 // La barrière @/shared/email/brevo réimportée via importOriginal ci-dessous tire tout son
 // graphe de dépendances réel (contact-mapping -> admin-url-resolver, conseiller-mapping ->
@@ -137,5 +143,63 @@ describe("syncDossierStatus — évènement Brevo dn_update", () => {
     await syncDossierStatus("p1", Step.ELIGIBILITE, "456");
 
     expect(mockedEmit).not.toHaveBeenCalled();
+  });
+});
+
+// Cf. ADR-0026 : DN masque un prérempli non transmis à l'API instructeur, qui répond
+// « not found » comme pour un dossier purgé. Un tel dossier ne doit plus être compté en erreur.
+describe("syncDossierStatus — prérempli non déposé (ADR-0026)", () => {
+  const prefillNonObserve = { id: "d1", dsStatus: null, lastSyncAt: null, submittedAt: null };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUpdateDossierStatus.mockResolvedValue({ success: true, data: { updated: true } });
+    mockedRecordDnProbeState.mockResolvedValue(undefined);
+  });
+
+  it("ne signale pas d'erreur quand DN répond not_found sur un dossier jamais observé", async () => {
+    mockedGetDossierByStep.mockResolvedValue(prefillNonObserve as never);
+    mockedGetDossierStatus.mockRejectedValue(new DsGraphQLError("GraphQL errors: Dossier not found", "not_found"));
+
+    const result = await syncDossierStatus("p1", Step.ELIGIBILITE, "123");
+
+    if (!result.success) throw new Error(`attendu en succès, reçu : ${result.error}`);
+    expect(result.data.notObserved).toBe(true);
+    expect(mockedRecordDnProbeState).toHaveBeenCalledWith("d1", "not_found");
+  });
+
+  it("traite le null de DN comme un prérempli non déposé, pas comme une disparition", async () => {
+    mockedGetDossierByStep.mockResolvedValue(prefillNonObserve as never);
+    mockedGetDossierStatus.mockResolvedValue(null);
+
+    const result = await syncDossierStatus("p1", Step.ELIGIBILITE, "123");
+
+    if (!result.success) throw new Error(`attendu en succès, reçu : ${result.error}`);
+    expect(result.data.notObserved).toBe(true);
+  });
+
+  it("signale bien une erreur quand un dossier DÉJÀ observé disparaît", async () => {
+    mockedGetDossierByStep.mockResolvedValue({
+      id: "d2",
+      dsStatus: DSStatus.EN_CONSTRUCTION,
+      lastSyncAt: new Date("2026-07-01T00:00:00Z"),
+      submittedAt: new Date("2026-07-01T00:00:00Z"),
+    } as never);
+    mockedGetDossierStatus.mockRejectedValue(new DsGraphQLError("GraphQL errors: Dossier not found", "not_found"));
+
+    const result = await syncDossierStatus("p1", Step.ELIGIBILITE, "456");
+
+    if (result.success) throw new Error("attendu en échec : un dossier déjà observé qui disparaît");
+    expect(result.error).toContain("456");
+  });
+
+  it("classe sur extensions.code, sans dépendre du libellé du message", async () => {
+    mockedGetDossierByStep.mockResolvedValue(prefillNonObserve as never);
+    mockedGetDossierStatus.mockRejectedValue(new DsGraphQLError("GraphQL errors: accès refusé", "unauthorized"));
+
+    const result = await syncDossierStatus("p1", Step.ELIGIBILITE, "789");
+
+    expect(mockedRecordDnProbeState).toHaveBeenCalledWith("d1", "unauthorized");
+    expect(result.success).toBe(false);
   });
 });

--- a/src/features/parcours/dossiers-ds/services/ds-sync.service.ts
+++ b/src/features/parcours/dossiers-ds/services/ds-sync.service.ts
@@ -1,4 +1,4 @@
-import { graphqlClient } from "../adapters/graphql/client";
+import { graphqlClient, DsGraphQLError } from "../adapters/graphql/client";
 import { getDossierByStep, updateDossierStatus, recordDnProbeState } from "./dossier-ds.service";
 import type { Step } from "../../core/domain/value-objects/step";
 import { DS_TO_INTERNAL_STATUS, DSStatus } from "../domain/value-objects/ds-status";
@@ -20,6 +20,16 @@ interface SyncResult {
   updated: boolean;
   oldStatus?: DSStatus;
   newStatus?: DSStatus;
+  /** Prérempli encore invisible de l'API instructeur : état normal, pas une erreur (ADR-0026). */
+  notObserved?: boolean;
+}
+
+/**
+ * Un dossier jamais confirmé côté DN (aucune sync réussie, aucun dépôt) est un prérempli que
+ * l'usager n'a pas encore transmis : DN le masque à l'API instructeur, d'où le « not found ».
+ */
+function isPrefillNonObserve(dossier: { lastSyncAt: Date | null; submittedAt: Date | null }): boolean {
+  return !dossier.lastSyncAt && !dossier.submittedAt;
 }
 
 /**
@@ -45,8 +55,15 @@ export async function syncDossierStatus(
     dsResult = await graphqlClient.getDossierStatus(Number(dsNumber));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const code = error instanceof DsGraphQLError ? error.code : undefined;
+    const probeState = probeStateFromError(message, code);
     // Trace le verdict DN même en erreur (pour le diagnostic en lecture DB).
-    await recordDnProbeState(localDossier.id, probeStateFromError(message));
+    await recordDnProbeState(localDossier.id, probeState);
+
+    if (probeState === "not_found" && isPrefillNonObserve(localDossier)) {
+      return { success: true, data: { updated: false, notObserved: true } };
+    }
+
     console.error(`Erreur syncDossierStatus (step=${step}, dsNumber=${dsNumber}):`, error);
     return {
       success: false,
@@ -56,9 +73,14 @@ export async function syncDossierStatus(
 
   if (!dsResult) {
     await recordDnProbeState(localDossier.id, "not_found");
+
+    if (isPrefillNonObserve(localDossier)) {
+      return { success: true, data: { updated: false, notObserved: true } };
+    }
+
     return {
       success: false,
-      error: `Dossier ${dsNumber} introuvable côté DS (numéro inexistant ou brouillon non déposé)`,
+      error: `Dossier ${dsNumber} introuvable côté DS (déposé puis disparu côté DN)`,
     };
   }
 
@@ -114,8 +136,11 @@ export async function syncDossierStatus(
   };
 }
 
-/** Normalise un message d'erreur DN en verdict de sondage. */
-function probeStateFromError(message: string): string {
+/** Normalise une erreur DN en verdict de sondage : `extensions.code` d'abord, message en repli. */
+function probeStateFromError(message: string, code?: string): string {
+  if (code === "not_found") return "not_found";
+  if (code === "unauthorized") return "unauthorized";
+
   const m = message.toLowerCase();
   if (m.includes("not found") || m.includes("not_found")) return "not_found";
   if (m.includes("unauthorized")) return "unauthorized";

--- a/src/shared/database/migrations/0042_white_adam_destine.sql
+++ b/src/shared/database/migrations/0042_white_adam_destine.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "dossiers_demarches_simplifiees" ADD CONSTRAINT "dossiers_ds_parcours_step_unique" UNIQUE("parcours_id","step");

--- a/src/shared/database/migrations/meta/0042_snapshot.json
+++ b/src/shared/database/migrations/meta/0042_snapshot.json
@@ -1,0 +1,1923 @@
+{
+  "id": "136bb2f6-43da-4d6f-9e55-4056d7e970cc",
+  "prevId": "a8ed8f88-04c1-4ef2-a5f4-7e9b227aaea7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departement_code": {
+          "name": "departement_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sub": {
+          "name": "sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usual_name": {
+          "name": "usual_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siret": {
+          "name": "siret",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizational_unit": {
+          "name": "organizational_unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "agent_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'administrateur'"
+        },
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "agents_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": ["entreprise_amo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agents_allers_vers_id_allers_vers_id_fk": {
+          "name": "agents_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "allers_vers",
+          "columnsFrom": ["allers_vers_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_sub_unique": {
+          "name": "agents_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": ["sub"]
+        },
+        "agents_email_unique": {
+          "name": "agents_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers_departements": {
+      "name": "allers_vers_departements",
+      "schema": "",
+      "columns": {
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_departement": {
+          "name": "code_departement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allers_vers_departements_allers_vers_id_allers_vers_id_fk": {
+          "name": "allers_vers_departements_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "allers_vers_departements",
+          "tableTo": "allers_vers",
+          "columnsFrom": ["allers_vers_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "allers_vers_departements_allers_vers_id_code_departement_pk": {
+          "name": "allers_vers_departements_allers_vers_id_code_departement_pk",
+          "columns": ["allers_vers_id", "code_departement"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers_epci": {
+      "name": "allers_vers_epci",
+      "schema": "",
+      "columns": {
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_epci": {
+          "name": "code_epci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allers_vers_epci_allers_vers_id_allers_vers_id_fk": {
+          "name": "allers_vers_epci_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "allers_vers_epci",
+          "tableTo": "allers_vers",
+          "columnsFrom": ["allers_vers_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "allers_vers_epci_allers_vers_id_code_epci_pk": {
+          "name": "allers_vers_epci_allers_vers_id_code_epci_pk",
+          "columns": ["allers_vers_id", "code_epci"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers": {
+      "name": "allers_vers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails": {
+          "name": "emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "horaires": {
+          "name": "horaires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.amo_validation_tokens": {
+      "name": "amo_validation_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_amo_validation_id": {
+          "name": "parcours_amo_validation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "amo_validation_token_idx": {
+          "name": "amo_validation_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "amo_validation_validation_id_idx": {
+          "name": "amo_validation_validation_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_amo_validation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "amo_validation_tokens_parcours_amo_validation_id_parcours_amo_validations_id_fk": {
+          "name": "amo_validation_tokens_parcours_amo_validation_id_parcours_amo_validations_id_fk",
+          "tableFrom": "amo_validation_tokens",
+          "tableTo": "parcours_amo_validations",
+          "columnsFrom": ["parcours_amo_validation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "amo_validation_tokens_token_unique": {
+          "name": "amo_validation_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catastrophes_naturelles": {
+      "name": "catastrophes_naturelles",
+      "schema": "",
+      "columns": {
+        "code_national_catnat": {
+          "name": "code_national_catnat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_debut_evt": {
+          "name": "date_debut_evt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_fin_evt": {
+          "name": "date_fin_evt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_publication_arrete": {
+          "name": "date_publication_arrete",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_publication_jo": {
+          "name": "date_publication_jo",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle_risque_jo": {
+          "name": "libelle_risque_jo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle_commune": {
+          "name": "libelle_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catastrophes_naturelles_code_insee_idx": {
+          "name": "catastrophes_naturelles_code_insee_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_date_debut_evt_idx": {
+          "name": "catastrophes_naturelles_date_debut_evt_idx",
+          "columns": [
+            {
+              "expression": "date_debut_evt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_code_insee_date_idx": {
+          "name": "catastrophes_naturelles_code_insee_date_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_debut_evt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_libelle_risque_idx": {
+          "name": "catastrophes_naturelles_libelle_risque_idx",
+          "columns": [
+            {
+              "expression": "libelle_risque_jo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_code_national_idx": {
+          "name": "catastrophes_naturelles_code_national_idx",
+          "columns": [
+            {
+              "expression": "code_national_catnat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "catastrophes_naturelles_code_national_catnat_code_insee_pk": {
+          "name": "catastrophes_naturelles_code_national_catnat_code_insee_pk",
+          "columns": ["code_national_catnat", "code_insee"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dossiers_demarches_simplifiees": {
+      "name": "dossiers_demarches_simplifiees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_id": {
+          "name": "ds_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_demarche_id": {
+          "name": "ds_demarche_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_status": {
+          "name": "ds_status",
+          "type": "ds_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructed_at": {
+          "name": "instructed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_url": {
+          "name": "ds_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dn_probe_state": {
+          "name": "dn_probe_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dn_probe_at": {
+          "name": "dn_probe_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dossiers_demarches_simplifiees_parcours_id_parcours_prevention_id_fk": {
+          "name": "dossiers_demarches_simplifiees_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "dossiers_demarches_simplifiees",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dossiers_demarches_simplifiees_ds_number_unique": {
+          "name": "dossiers_demarches_simplifiees_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["ds_number"]
+        },
+        "dossiers_ds_parcours_step_unique": {
+          "name": "dossiers_ds_parcours_step_unique",
+          "nullsNotDistinct": false,
+          "columns": ["parcours_id", "step"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo_communes": {
+      "name": "entreprises_amo_communes",
+      "schema": "",
+      "columns": {
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entreprises_amo_communes_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "entreprises_amo_communes_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "entreprises_amo_communes",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": ["entreprise_amo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entreprises_amo_communes_entreprise_amo_id_code_insee_pk": {
+          "name": "entreprises_amo_communes_entreprise_amo_id_code_insee_pk",
+          "columns": ["entreprise_amo_id", "code_insee"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo_epci": {
+      "name": "entreprises_amo_epci",
+      "schema": "",
+      "columns": {
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_epci": {
+          "name": "code_epci",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entreprises_amo_epci_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "entreprises_amo_epci_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "entreprises_amo_epci",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": ["entreprise_amo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entreprises_amo_epci_entreprise_amo_id_code_epci_pk": {
+          "name": "entreprises_amo_epci_entreprise_amo_id_code_epci_pk",
+          "columns": ["entreprise_amo_id", "code_epci"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo": {
+      "name": "entreprises_amo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siret": {
+          "name": "siret",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departements": {
+          "name": "departements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails": {
+          "name": "emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horaires": {
+          "name": "horaires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entreprises_amo_siret_unique": {
+          "name": "entreprises_amo_siret_unique",
+          "nullsNotDistinct": false,
+          "columns": ["siret"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fc_id": {
+          "name": "fc_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nom_famille": {
+          "name": "nom_famille",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prenom": {
+          "name": "prenom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_contact": {
+          "name": "email_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_acquisition": {
+          "name": "source_acquisition",
+          "type": "source_acquisition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_acquisition_precision": {
+          "name": "source_acquisition_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partner_source": {
+          "name": "partner_source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token_expires_at": {
+          "name": "claim_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_fc_id_unique": {
+          "name": "users_fc_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["fc_id"]
+        },
+        "users_claim_token_unique": {
+          "name": "users_claim_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["claim_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_prevention": {
+      "name": "parcours_prevention",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'choix_amo'"
+        },
+        "current_status": {
+          "name": "current_status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "situation_particulier": {
+          "name": "situation_particulier",
+          "type": "situation_particulier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prospect'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data": {
+          "name": "rga_simulation_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_completed_at": {
+          "name": "rga_simulation_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_data_deleted_at": {
+          "name": "rga_data_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_data_deletion_reason": {
+          "name": "rga_data_deletion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data_agent": {
+          "name": "rga_simulation_data_agent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data_agent_baseline": {
+          "name": "rga_simulation_data_agent_baseline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_agent_edited_at": {
+          "name": "rga_simulation_agent_edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_agent_edited_by": {
+          "name": "rga_simulation_agent_edited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by": {
+          "name": "archived_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parcours_prevention_user_id_users_id_fk": {
+          "name": "parcours_prevention_user_id_users_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_rga_simulation_agent_edited_by_agents_id_fk": {
+          "name": "parcours_prevention_rga_simulation_agent_edited_by_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": ["rga_simulation_agent_edited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_archived_by_agents_id_fk": {
+          "name": "parcours_prevention_archived_by_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": ["archived_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_created_by_agent_id_agents_id_fk": {
+          "name": "parcours_prevention_created_by_agent_id_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": ["created_by_agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parcours_prevention_user_id_unique": {
+          "name": "parcours_prevention_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_actions": {
+      "name": "parcours_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_precision": {
+          "name": "action_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_structure": {
+          "name": "author_structure",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_structure_type": {
+          "name": "author_structure_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parcours_actions_parcours_id_parcours_prevention_id_fk": {
+          "name": "parcours_actions_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "parcours_actions",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_actions_agent_id_agents_id_fk": {
+          "name": "parcours_actions_agent_id_agents_id_fk",
+          "tableFrom": "parcours_actions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_amo_validations": {
+      "name": "parcours_amo_validations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statut": {
+          "name": "statut",
+          "type": "statut_validation_amo",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en_attente'"
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "attribution_amo_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manuel'"
+        },
+        "commentaire": {
+          "name": "commentaire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "est_mandataire_financier": {
+          "name": "est_mandataire_financier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demande_arret_at": {
+          "name": "demande_arret_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prenom": {
+          "name": "user_prenom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_nom": {
+          "name": "user_nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_telephone": {
+          "name": "user_telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse_logement": {
+          "name": "adresse_logement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brevo_message_id": {
+          "name": "brevo_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_sent_at": {
+          "name": "email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_delivered_at": {
+          "name": "email_delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_opened_at": {
+          "name": "email_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_clicked_at": {
+          "name": "email_clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bounce_type": {
+          "name": "email_bounce_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bounce_reason": {
+          "name": "email_bounce_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "choisie_at": {
+          "name": "choisie_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validee_at": {
+          "name": "validee_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parcours_amo_validations_brevo_message_id_idx": {
+          "name": "parcours_amo_validations_brevo_message_id_idx",
+          "columns": [
+            {
+              "expression": "brevo_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parcours_amo_validations_parcours_id_parcours_prevention_id_fk": {
+          "name": "parcours_amo_validations_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "parcours_amo_validations",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_amo_validations_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "parcours_amo_validations_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "parcours_amo_validations",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": ["entreprise_amo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parcours_amo_validations_parcours_id_unique": {
+          "name": "parcours_amo_validations_parcours_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["parcours_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prospect_qualifications": {
+      "name": "prospect_qualifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions_realisees": {
+          "name": "actions_realisees",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raisons_ineligibilite": {
+          "name": "raisons_ineligibilite",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "est_mandataire_financier": {
+          "name": "est_mandataire_financier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "prospect_qualifications_parcours_id_idx": {
+          "name": "prospect_qualifications_parcours_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prospect_qualifications_parcours_id_parcours_prevention_id_fk": {
+          "name": "prospect_qualifications_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "prospect_qualifications",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prospect_qualifications_agent_id_agents_id_fk": {
+          "name": "prospect_qualifications_agent_id_agents_id_fk",
+          "tableFrom": "prospect_qualifications",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rga_zones": {
+      "name": "rga_zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alea": {
+          "name": "alea",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_runs": {
+      "name": "sync_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "sync_run_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "total_parcours_scanned": {
+          "name": "total_parcours_scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_parcours_updated": {
+          "name": "total_parcours_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_errors": {
+          "name": "total_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_summary": {
+          "name": "error_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_runs_started_at_idx": {
+          "name": "sync_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_run_entries": {
+      "name": "sync_run_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sync_run_id": {
+          "name": "sync_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_before": {
+          "name": "step_before",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_after": {
+          "name": "step_after",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_status_changes": {
+          "name": "ds_status_changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_advanced": {
+          "name": "step_advanced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_run_entries_sync_run_id_idx": {
+          "name": "sync_run_entries_sync_run_id_idx",
+          "columns": [
+            {
+              "expression": "sync_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_run_entries_parcours_id_idx": {
+          "name": "sync_run_entries_parcours_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_run_entries_sync_run_id_sync_runs_id_fk": {
+          "name": "sync_run_entries_sync_run_id_sync_runs_id_fk",
+          "tableFrom": "sync_run_entries",
+          "tableTo": "sync_runs",
+          "columnsFrom": ["sync_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_run_entries_parcours_id_parcours_prevention_id_fk": {
+          "name": "sync_run_entries_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "sync_run_entries",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "public",
+      "values": ["administrateur", "super_administrateur", "amo", "analyste", "allers_vers", "amo_et_allers_vers"]
+    },
+    "public.ds_status": {
+      "name": "ds_status",
+      "schema": "public",
+      "values": ["en_construction", "en_instruction", "accepte", "refuse", "classe_sans_suite", "non_accessible"]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": ["todo", "en_instruction", "valide"]
+    },
+    "public.statut_validation_amo": {
+      "name": "statut_validation_amo",
+      "schema": "public",
+      "values": ["en_attente", "logement_eligible", "logement_non_eligible", "accompagnement_refuse", "sans_amo"]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": ["invitation", "choix_amo", "eligibilite", "diagnostic", "devis", "factures"]
+    },
+    "public.sync_run_status": {
+      "name": "sync_run_status",
+      "schema": "public",
+      "values": ["success", "partial", "error"]
+    },
+    "public.sync_run_trigger": {
+      "name": "sync_run_trigger",
+      "schema": "public",
+      "values": ["cron", "manual"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/shared/database/migrations/meta/_journal.json
+++ b/src/shared/database/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1784650000000,
       "tag": "0041_source_acquisition_new_values",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1787577339002,
+      "tag": "0042_white_adam_destine",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/database/schema/dossiers-demarches-simplifiees.ts
+++ b/src/shared/database/schema/dossiers-demarches-simplifiees.ts
@@ -1,41 +1,46 @@
-import { pgTable, uuid, timestamp, varchar } from "drizzle-orm/pg-core";
+import { pgTable, uuid, timestamp, varchar, unique } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import { parcoursPrevention } from "./parcours-prevention";
 import { dsStatusPgEnum, stepPgEnum } from "../enums/enums";
 
 // Table des dossiers Démarches Simplifiées
-export const dossiersDemarchesSimplifiees = pgTable("dossiers_demarches_simplifiees", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  parcoursId: uuid("parcours_id")
-    .notNull()
-    .references(() => parcoursPrevention.id, { onDelete: "cascade" }),
+export const dossiersDemarchesSimplifiees = pgTable(
+  "dossiers_demarches_simplifiees",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    parcoursId: uuid("parcours_id")
+      .notNull()
+      .references(() => parcoursPrevention.id, { onDelete: "cascade" }),
 
-  step: stepPgEnum("step").notNull(),
+    step: stepPgEnum("step").notNull(),
 
-  // Références DS uniquement
-  dsNumber: varchar("ds_number", { length: 50 }).unique(), // Unique directement
-  dsId: varchar("ds_id", { length: 50 }),
-  dsDemarcheId: varchar("ds_demarche_id", { length: 50 }).notNull(),
+    // Références DS uniquement
+    dsNumber: varchar("ds_number", { length: 50 }).unique(), // Unique directement
+    dsId: varchar("ds_id", { length: 50 }),
+    dsDemarcheId: varchar("ds_demarche_id", { length: 50 }).notNull(),
 
-  dsStatus: dsStatusPgEnum("ds_status"),
+    dsStatus: dsStatusPgEnum("ds_status"),
 
-  submittedAt: timestamp("submitted_at", { mode: "date" }),
-  instructedAt: timestamp("instructed_at", { mode: "date" }),
-  processedAt: timestamp("processed_at", { mode: "date" }),
+    submittedAt: timestamp("submitted_at", { mode: "date" }),
+    instructedAt: timestamp("instructed_at", { mode: "date" }),
+    processedAt: timestamp("processed_at", { mode: "date" }),
 
-  dsUrl: varchar("ds_url", { length: 500 }),
+    dsUrl: varchar("ds_url", { length: 500 }),
 
-  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { mode: "date" })
-    .notNull()
-    .defaultNow()
-    .$onUpdate(() => new Date()),
-  lastSyncAt: timestamp("last_sync_at", { mode: "date" }),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+    lastSyncAt: timestamp("last_sync_at", { mode: "date" }),
 
-  // Verdict DN observé au dernier sondage de la sync (état réel côté DN)
-  dnProbeState: varchar("dn_probe_state", { length: 30 }),
-  dnProbeAt: timestamp("dn_probe_at", { mode: "date" }),
-});
+    // Verdict DN observé au dernier sondage de la sync (état réel côté DN)
+    dnProbeState: varchar("dn_probe_state", { length: 30 }),
+    dnProbeAt: timestamp("dn_probe_at", { mode: "date" }),
+  },
+  // Un seul pointeur par (parcours, étape) : `getDossierByStep` serait sinon indéterministe.
+  (t) => [unique("dossiers_ds_parcours_step_unique").on(t.parcoursId, t.step)]
+);
 
 // Relations : un dossier appartient à un parcours
 export const dossiersDemarchesSimplifieeesRelations = relations(dossiersDemarchesSimplifiees, ({ one }) => ({


### PR DESCRIPTION
Application d'ADR-0026, décidé lors du gel du reset. DN masque à l'API instructeur tout dossier non transmis : getDossier répond Dossier not found, ce que la sync interprétait comme une disparition. Résultat : 105 des 116 parcours listés en « sync erreur » sont des préremplis en attente, parfaitement normaux c'est ce bruit qui a motivé la campagne de suppression de juin.

La sync ne journalise plus d'erreur pour un dossier jamais observé, la classification passe par extensions.code, le diagnostic sort ces cas du groupe des anomalies, et deux failles relevées en revue sont fermées : le ds_id renvoyé par DN était jeté, et getDossierByStep pouvait renvoyer une ligne au hasard faute de contrainte d'unicité.

Pas de nouvel ADR : la décision est celle d'ADR-0026, c'est son implémentation.