### PR TITLE
feat(parcours): réconcilie les dossiers DN avec leur parcours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ yarn-debug.log*
 yarn-error.log*
 
 # Environment Variables
+# Tout fichier d'env est ignoré par défaut, y compris les copies de travail
+# (« .env copy.local », « .env.old »…) qui échappaient aux motifs nommés.
+.env*
+!.env.example
 .env
 .env.local
 .env.*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:24-alpine
 RUN apk upgrade --no-cache
 
 # Installer pnpm globalement avec npm (aligne sur packageManager du repo)
-RUN npm install -g pnpm@11.5.2
+RUN npm install -g pnpm@11.24.0
 
 WORKDIR /app
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,14 +102,14 @@ rga_zones                 (géométries PostGIS, aléa RGA par zone)
 
 ### Tables principales
 
-| Domaine          | Tables                                                                                             |
-| ---------------- | -------------------------------------------------------------------------------------------------- |
-| Parcours         | `users`, `parcours_prevention`, `dossiers_demarches_simplifiees`, `parcours_actions`               |
-| AMO              | `parcours_amo_validations`, `amo_validation_tokens`, `entreprises_amo`, `entreprises_amo_communes` |
-| Agents           | `agents`, `agent_permissions`                                                                      |
-| Allers-vers      | `allers_vers`, `allers_vers_departements`, `allers_vers_epci`, `prospect_qualifications`           |
-| Référentiels géo | `catastrophes_naturelles`, `rga_zones` (PostGIS)                                                   |
-| Synchronisation  | `sync_runs`, `sync_run_entries`                                                                    |
+| Domaine          | Tables                                                                                                         |
+| ---------------- | -------------------------------------------------------------------------------------------------------------- |
+| Parcours         | `users`, `parcours_prevention`, `dossiers_demarches_simplifiees`, `dossiers_ds_tentatives`, `parcours_actions` |
+| AMO              | `parcours_amo_validations`, `amo_validation_tokens`, `entreprises_amo`, `entreprises_amo_communes`             |
+| Agents           | `agents`, `agent_permissions`                                                                                  |
+| Allers-vers      | `allers_vers`, `allers_vers_departements`, `allers_vers_epci`, `prospect_qualifications`                       |
+| Référentiels géo | `catastrophes_naturelles`, `rga_zones` (PostGIS)                                                               |
+| Synchronisation  | `sync_runs`, `sync_run_entries`                                                                                |
 
 > `users` (demandeur FranceConnect) et `agents` (ProConnect) sont deux tables
 > distinctes : le citoyen et l'agent ne partagent pas la même identité.
@@ -117,8 +117,9 @@ rga_zones                 (géométries PostGIS, aléa RGA par zone)
 > `dossiers_demarches_simplifiees` est le **pointeur courant** vers le dossier DN d'une étape,
 > pas l'historique des dossiers créés. La distinction entre **tentative** (brouillon prérempli,
 > plusieurs possibles, jamais autoritaire) et **dossier confirmé** (déposé, unique) est posée
-> par [ADR-0027](adr/0027-tentative-prefill-vs-dossier-confirme.md) ; le registre des tentatives
-> arrive en phase 3.
+> par [ADR-0027](adr/0027-tentative-prefill-vs-dossier-confirme.md). Le registre
+> `dossiers_ds_tentatives` conserve **définitivement** tout numéro DN connu du parcours :
+> écrit dans la même transaction que le pointeur, jamais supprimé.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,6 +114,12 @@ rga_zones                 (géométries PostGIS, aléa RGA par zone)
 > `users` (demandeur FranceConnect) et `agents` (ProConnect) sont deux tables
 > distinctes : le citoyen et l'agent ne partagent pas la même identité.
 
+> `dossiers_demarches_simplifiees` est le **pointeur courant** vers le dossier DN d'une étape,
+> pas l'historique des dossiers créés. La distinction entre **tentative** (brouillon prérempli,
+> plusieurs possibles, jamais autoritaire) et **dossier confirmé** (déposé, unique) est posée
+> par [ADR-0027](adr/0027-tentative-prefill-vs-dossier-confirme.md) ; le registre des tentatives
+> arrive en phase 3.
+
 ---
 
 ## 6. Intégrations externes

--- a/docs/adr/0027-tentative-prefill-vs-dossier-confirme.md
+++ b/docs/adr/0027-tentative-prefill-vs-dossier-confirme.md
@@ -153,9 +153,12 @@ de faire qu'elles n'aient plus de conséquence.
 ### Négatives / Risques
 
 - Le rattachement automatique **dépend d'une capacité DN non documentée** : le préremplissage
-  d'une annotation privée. Elle fonctionne (ADR-0025) mais n'est garantie par aucun contrat, et
-  DN ignore silencieusement un champ inconnu. **Reste à confirmer sur un dossier déposé créé
-  après le déploiement d'ADR-0025** : sur `#32052358`, antérieur, l'annotation est vide.
+  d'une annotation privée. Vérifié le 2026-08-25 sur les démarches d'éligibilité et de devis
+  (DN affiche « Donnée remplie automatiquement »), mais garanti par aucun contrat : DN ignore
+  silencieusement un champ inconnu, donc à re-vérifier après toute évolution des démarches.
+- Les dossiers créés **avant** le déploiement d'ADR-0025 (prod : 2026-08-25 09:03) n'ont pas
+  d'annotation et ne se rattacheront jamais automatiquement. Population figée, à traiter par
+  rattachement manuel.
 - L'annotation est identifiée par son `champDescriptorId` (`Q2hhbXAtNjY4NzQ1Mg==` en prod pour
   l'éligibilité), pas par son libellé ni par l'id d'instance, qui change d'un dossier à l'autre.
 - Les dossiers antérieurs à ADR-0025 n'ont pas d'annotation : ils relèvent du traitement manuel.

--- a/docs/adr/0027-tentative-prefill-vs-dossier-confirme.md
+++ b/docs/adr/0027-tentative-prefill-vs-dossier-confirme.md
@@ -86,6 +86,15 @@ ne l'est pas.
 une action (« accéder à mon formulaire ») au lieu de décrire une situation (« reprendre mon
 dossier »). C'est cette confusion qui a affiché « Reprendre » sur des dossiers inexistants.
 
+### Le super-admin peut rattacher (troisième exception au read-only)
+
+Le rattachement manuel d'un dossier DN est ouvert au **super-administrateur**, au même titre
+que les commentaires ([ADR-0024](0024-commentaires-super-admin-espace-agent.md)) et la
+ré-ouverture ([ADR-0016](0016-reouverture-demande-refusee.md)). C'est une exception assumée :
+la mutation touche la source de vérité d'un dossier, mais sans elle le seul recours est une
+intervention SQL en production — ce que cette PR cherche précisément à supprimer. La garde
+`assertNotSuperAdminReadOnly` n'est donc **pas** appelée par `rattacherDossierDnAction`.
+
 ### Ce que nous renonçons explicitement à faire
 
 - voir un brouillon avant son dépôt, ou savoir s'il a été ouvert, réclamé, ou purgé ;

--- a/docs/adr/0027-tentative-prefill-vs-dossier-confirme.md
+++ b/docs/adr/0027-tentative-prefill-vs-dossier-confirme.md
@@ -62,15 +62,16 @@ supprimés en juin par un reset qui croyait, à tort, ces dossiers disparus
 Le rattachement se fait **au dépôt**, jamais avant : un balayage périodique des dossiers
 modifiés (`updatedSince`) lit l'annotation FPA, en extrait le `parcoursId` et rapproche.
 
-| Situation                                                         | Résolution                                                      |
-| ----------------------------------------------------------------- | --------------------------------------------------------------- |
-| Candidat déposé, annotation valide, aucun dossier confirmé        | rattachement automatique                                        |
-| Candidat déjà confirmé sous le même numéro                        | mise à jour idempotente                                         |
-| Pointeur courant = tentative jamais observée, candidat déposé     | le candidat gagne ; l'ancienne tentative reste au registre      |
-| Plusieurs candidats déposés, ou un autre dossier déjà confirmé    | **conflit, arbitrage humain** — jamais « le plus récent gagne » |
-| Numéro déjà rattaché à un autre parcours                          | refus, incident journalisé — on ne le « vole » jamais           |
-| Annotation modifiée par un instructeur (`prefilledValueModified`) | rattachement manuel                                             |
-| Dossier déposé sans annotation FPA                                | file de traitement manuel — jamais ignoré en silence            |
+| Situation                                                      | Résolution                                                      |
+| -------------------------------------------------------------- | --------------------------------------------------------------- |
+| Candidat déposé, annotation valide, aucun dossier confirmé     | rattachement automatique                                        |
+| Candidat déjà confirmé sous le même numéro                     | mise à jour idempotente                                         |
+| Pointeur courant = tentative jamais observée, candidat déposé  | le candidat gagne ; l'ancienne tentative reste au registre      |
+| Plusieurs candidats déposés, ou un autre dossier déjà confirmé | **conflit, arbitrage humain** — jamais « le plus récent gagne » |
+| Numéro déjà rattaché à un autre parcours                       | refus, incident journalisé — on ne le « vole » jamais           |
+| Annotation modifiée à la main (`prefilledValueModified`)       | rattachement manuel                                             |
+| Deux annotations pointant des parcours différents              | rattachement manuel                                             |
+| Dossier déposé sans annotation FPA                             | file de traitement manuel — jamais ignoré en silence            |
 
 L'email usager n'est **pas** une clé de rattachement : il peut être celui de l'AMO, être
 partagé, ou avoir changé. Il ne sert que d'indice pour un humain.
@@ -153,8 +154,10 @@ de faire qu'elles n'aient plus de conséquence.
 
 - Le rattachement automatique **dépend d'une capacité DN non documentée** : le préremplissage
   d'une annotation privée. Elle fonctionne (ADR-0025) mais n'est garantie par aucun contrat, et
-  DN ignore silencieusement un champ inconnu. À vérifier en production avant de bâtir dessus,
-  et à surveiller ensuite.
+  DN ignore silencieusement un champ inconnu. **Reste à confirmer sur un dossier déposé créé
+  après le déploiement d'ADR-0025** : sur `#32052358`, antérieur, l'annotation est vide.
+- L'annotation est identifiée par son `champDescriptorId` (`Q2hhbXAtNjY4NzQ1Mg==` en prod pour
+  l'éligibilité), pas par son libellé ni par l'id d'instance, qui change d'un dossier à l'autre.
 - Les dossiers antérieurs à ADR-0025 n'ont pas d'annotation : ils relèvent du traitement manuel.
 - Un conflit non arbitré laisse un parcours en attente d'une décision humaine.
 

--- a/docs/adr/0027-tentative-prefill-vs-dossier-confirme.md
+++ b/docs/adr/0027-tentative-prefill-vs-dossier-confirme.md
@@ -1,0 +1,176 @@
+# ADR-0027 : Tentative de préremplissage vs dossier confirmé
+
+**Date** : 2026-08-25
+**Statut** : Accepté
+
+## Contexte
+
+`dossiers_demarches_simplifiees` représente aujourd'hui **deux objets à la fois** : le dernier
+brouillon prérempli fabriqué par l'app, et le dossier administratif du demandeur. Ce ne sont
+pas les mêmes choses, et la confusion est la cause commune de tous les incidents de
+synchronisation traités depuis juin 2026.
+
+Rappel des contraintes DN, toutes vérifiées (doc officielle du préremplissage, schéma GraphQL,
+observation en production) :
+
+- l'API REST de préremplissage crée un **brouillon orphelin**, « invisible pour l'administration
+  tant qu'il n'est pas soumis », rattaché à l'usager seulement après authentification ;
+- l'énumération `DossierState` ne contient pas `brouillon` : l'API instructeur ne modélise même
+  pas l'état qu'on cherche à lire ;
+- aucun endpoint ne dit si un `prefill_token` a été réclamé ; aucun webhook de dépôt ;
+- DN purge les brouillons trois mois après leur **dernière modification**, information que nous
+  ne voyons pas ;
+- en revanche, un dossier **déposé** porte l'annotation « lien FPA » contenant le `parcoursId`
+  ([ADR-0025](0025-lien-fpa-annotation-eligibilite.md)), et `updatedSince` permet de balayer
+  les dossiers modifiés depuis le dernier passage.
+
+Entre le clic et le dépôt, le lien se perd de quatre façons : mauvais compte DN au moment de
+réclamer le brouillon, dossier rempli depuis le poste de l'AMO, purge, ou dossier créé
+directement sur DN sans passer par notre lien. Dans les trois premiers cas le demandeur est
+bloqué ; dans le quatrième l'AMO perd la visibilité alors que rien n'a échoué.
+
+État constaté en août 2026 : **105 parcours sur 116** listés en « sync erreur » sont des
+préremplis simplement pas encore déposés, et une **cinquantaine de pointeurs** ont été
+supprimés en juin par un reset qui croyait, à tort, ces dossiers disparus
+([ADR-0026](0026-gel-reset-eligibilite-not-found.md)).
+
+## Décision
+
+> Nous distinguons la **tentative** (un brouillon prérempli qu'on a fabriqué) du **dossier
+> confirmé** (un dossier observé déposé côté DN). Une tentative n'est jamais autoritaire et
+> n'est jamais supprimée ; seul le dossier confirmé pilote l'état du parcours.
+
+### Les deux objets
+
+|                                   | Tentative                                                | Dossier confirmé       |
+| --------------------------------- | -------------------------------------------------------- | ---------------------- |
+| Origine                           | préremplissage FPA, ou numéro découvert par rattachement | dossier observé déposé |
+| Cardinalité par (parcours, étape) | plusieurs                                                | au plus un             |
+| Observable côté DN                | non, jamais avant dépôt                                  | oui                    |
+| Fait foi pour l'état du parcours  | non                                                      | oui                    |
+| Suppression                       | **jamais** — le numéro est conservé définitivement       | jamais                 |
+
+### Invariants
+
+- un numéro DN appartient à **un seul** parcours (`ds_number` unique globalement) ;
+- **un seul** dossier confirmé par `(parcours, étape)` — contrainte déjà posée en base ;
+- plusieurs tentatives par `(parcours, étape)` sont normales et attendues ;
+- aucun numéro DN généré ou découvert n'est jamais effacé, quelle que soit la remédiation.
+
+### Rattachement
+
+Le rattachement se fait **au dépôt**, jamais avant : un balayage périodique des dossiers
+modifiés (`updatedSince`) lit l'annotation FPA, en extrait le `parcoursId` et rapproche.
+
+| Situation                                                         | Résolution                                                      |
+| ----------------------------------------------------------------- | --------------------------------------------------------------- |
+| Candidat déposé, annotation valide, aucun dossier confirmé        | rattachement automatique                                        |
+| Candidat déjà confirmé sous le même numéro                        | mise à jour idempotente                                         |
+| Pointeur courant = tentative jamais observée, candidat déposé     | le candidat gagne ; l'ancienne tentative reste au registre      |
+| Plusieurs candidats déposés, ou un autre dossier déjà confirmé    | **conflit, arbitrage humain** — jamais « le plus récent gagne » |
+| Numéro déjà rattaché à un autre parcours                          | refus, incident journalisé — on ne le « vole » jamais           |
+| Annotation modifiée par un instructeur (`prefilledValueModified`) | rattachement manuel                                             |
+| Dossier déposé sans annotation FPA                                | file de traitement manuel — jamais ignoré en silence            |
+
+L'email usager n'est **pas** une clé de rattachement : il peut être celui de l'AMO, être
+partagé, ou avoir changé. Il ne sert que d'indice pour un humain.
+
+### Deux règles transverses
+
+**Le `prefill_token` est un secret.** L'URL de préremplissage permet de réclamer le brouillon :
+elle n'est pas conservée indéfiniment, n'apparaît jamais dans un payload d'évènement ni dans
+un log, et est purgée après dépôt. Le cœur identitaire (le numéro) est append-only ; le secret
+ne l'est pas.
+
+**L'interface n'affirme jamais un état qu'on ne peut pas observer.** Avant dépôt, elle propose
+une action (« accéder à mon formulaire ») au lieu de décrire une situation (« reprendre mon
+dossier »). C'est cette confusion qui a affiché « Reprendre » sur des dossiers inexistants.
+
+### Ce que nous renonçons explicitement à faire
+
+- voir un brouillon avant son dépôt, ou savoir s'il a été ouvert, réclamé, ou purgé ;
+- distinguer un brouillon vivant d'un brouillon supprimé ;
+- empêcher un demandeur de créer plusieurs dossiers pour une même étape ;
+- rattacher automatiquement un dossier créé entièrement hors de notre lien (sans annotation).
+
+Ces quatre limites viennent de DN, pas de notre code. Le but n'est pas de les contourner mais
+de faire qu'elles n'aient plus de conséquence.
+
+## Options envisagées
+
+### Option A — Registre de tentatives + pointeur confirmé + réconciliation au dépôt (retenue)
+
+- Avantages : aucune information n'est jamais perdue ; la réparation devient automatique et
+  couvre le stock existant ; les doublons deviennent détectables ; rend inoffensive la
+  régénération d'un lien par le demandeur.
+- Inconvénients : une table de plus ; des conflits à arbitrer ; ne répare qu'**après** le dépôt.
+
+### Option B — Conserver le modèle actuel et réparer au cas par cas
+
+- Avantages : aucun développement.
+- Inconvénients : chaque cas coûte une intervention en production (deux requêtes SQL par
+  dossier, comme en août 2026), ne passe pas à l'échelle, et laisse les demandeurs bloqués
+  jusqu'à ce qu'ils se plaignent.
+
+### Option C — Journal d'évènements comme source de vérité (event sourcing)
+
+- Avantages : historique complet et rejouable.
+- Inconvénients : surdimensionné pour le besoin ; impose de reconstruire un état à la lecture
+  alors qu'un pointeur courant suffit. Un journal reste utile en complément, pas en substitut.
+
+### Option D — Ne jamais mémoriser de lien : chaque clic crée un brouillon
+
+- Avantages : le lien cassé disparaît par construction, beaucoup moins de code.
+- Inconvénients : multiplie les brouillons et donc les dépôts en double ; fait perdre la saisie
+  déjà effectuée (particulièrement pénible avec des pièces jointes) ; ne dit toujours pas à
+  l'usager quel compte DN détient son dossier. Fausse simplicité.
+
+### Option E — Rattacher par l'email usager
+
+- Avantages : disponible sans annotation, y compris sur les dossiers antérieurs à ADR-0025.
+- Inconvénients : l'email peut être celui de l'AMO, être partagé ou avoir changé ; il n'est de
+  toute façon lisible qu'après dépôt. Conservé comme **indice**, jamais comme clé.
+
+## Conséquences
+
+### Positives
+
+- Un pointeur peut être remplacé sans rien détruire : la régénération d'un lien devient sûre.
+- Le stock d'orphelins se répare automatiquement au premier balayage.
+- Les dépôts en double, aujourd'hui invisibles, remontent pour arbitrage.
+- Le diagnostic cesse de signaler comme cassés les 105 préremplis en attente.
+
+### Négatives / Risques
+
+- Le rattachement automatique **dépend d'une capacité DN non documentée** : le préremplissage
+  d'une annotation privée. Elle fonctionne (ADR-0025) mais n'est garantie par aucun contrat, et
+  DN ignore silencieusement un champ inconnu. À vérifier en production avant de bâtir dessus,
+  et à surveiller ensuite.
+- Les dossiers antérieurs à ADR-0025 n'ont pas d'annotation : ils relèvent du traitement manuel.
+- Un conflit non arbitré laisse un parcours en attente d'une décision humaine.
+
+### Migration
+
+Aucune donnée n'est déplacée. Le registre est amorcé par un backfill en deux sources : les
+pointeurs actuels (fiables) et les numéros cités dans `sync_run_entries.error` (indices,
+marqués comme tels — ils ne restituent ni l'URL de préremplissage ni le `ds_id`). Le premier
+balayage de réconciliation doit être **complet**, sans `updatedSince` : sinon les dossiers
+déposés anciens et jamais modifiés depuis resteraient invisibles.
+
+Découpage retenu : registre des tentatives (phase 3), réconciliation au dépôt (phase 4),
+régénération de lien côté demandeur (phase 5), rattachement manuel et aide au compte DN
+(phase 6).
+
+## Liens
+
+- [ADR-0026](0026-gel-reset-eligibilite-not-found.md) — gel du reset destructif, constat fondateur
+- [ADR-0025](0025-lien-fpa-annotation-eligibilite.md) — annotation FPA porteuse du `parcoursId`
+- [ADR-0013](0013-remediation-dossiers-dn-sync-erreur.md) — remédiation, amendé par 0026
+- [ADR-0012](0012-url-reprise-dossier-basee-sur-depot.md) — URL « commencer » vs « reprendre »
+- [ADR-0009](0009-semantique-statut-ds-depose-vs-brouillon.md) — sémantique du dépôt
+- [FLOW-AND-SYNC.md](../parcours/FLOW-AND-SYNC.md) — flux et synchronisation
+- [SYNC-ERREURS-ET-REMEDIATION.md](../parcours/SYNC-ERREURS-ET-REMEDIATION.md) — cas et playbook
+- Pointeur courant : `src/shared/database/schema/dossiers-demarches-simplifiees.ts`
+- Création du prérempli : `src/features/parcours/dossiers-ds/services/dossier-ds.service.ts`
+- Sync et verdict DN : `src/features/parcours/dossiers-ds/services/ds-sync.service.ts`
+- Choix de l'URL affichée : `src/features/parcours/dossiers-ds/utils/ds-url.utils.ts`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,5 +54,6 @@ purement cosmétique.
 | 0024 | [Commentaires/actions ouverts au super-admin dans l'espace agent](0024-commentaires-super-admin-espace-agent.md)                        | Accepté |
 | 0025 | [Lien FPA dans les annotations DN — ids par démarche et permalien parcours](0025-lien-fpa-annotation-eligibilite.md)                    | Accepté |
 | 0026 | [Gel du reset destructif — « Dossier not found » ne prouve pas la disparition](0026-gel-reset-eligibilite-not-found.md)                 | Accepté |
+| 0027 | [Tentative de préremplissage vs dossier confirmé](0027-tentative-prefill-vs-dossier-confirme.md)                                        | Accepté |
 
 <!-- Ajouter chaque nouvel ADR ici -->

--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -827,6 +827,7 @@ impots.gouv, assureur, CERFA mandat — `pieces-aide.map.ts`).
 | Réconciliation au dépôt (annotation FPA)       | `dossiers-ds/services/reconciliation.service.ts`, `dossiers-ds/utils/annotation-fpa.utils.ts`               |
 | Réconciliation (script ops)                    | `scripts/ops/sync-erreurs/reconcilier-dossiers.ts` (`pnpm ds:reconcilier`)                                  |
 | Secours « ce lien ne fonctionne plus »         | `dossiers-ds/services/regeneration.service.ts`, `actions/regeneration.actions.ts`                           |
+| Rattachement manuel par numéro (AMO/admin)     | `espace-agent/dossiers/actions/rattacher-dossier-dn.actions.ts` (`rattacherDossierManuel`)                  |
 | Schéma historique CRON                         | `src/shared/database/schema/sync-runs.ts`, `sync-run-entries.ts`                                            |
 | Repository parcours                            | `src/shared/database/repositories/parcours-prevention.repository.ts`                                        |
 | Repository sync_runs                           | `src/shared/database/repositories/sync-run.repository.ts`                                                   |

--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -28,6 +28,14 @@ Chaque parcours a deux niveaux d'état complémentaires :
 | Parcours interne | `parcours_prevention.current_status`       | Dérivé du dossier de `current_step` |
 | Parcours interne | `parcours_prevention.current_step`         | Logique métier (progression)        |
 
+> **Tentative vs dossier confirmé ([ADR-0027](../adr/0027-tentative-prefill-vs-dossier-confirme.md)).**
+> Une ligne `dossiers_demarches_simplifiees` est un **pointeur**, pas le dossier du demandeur.
+> Tant que rien n'est déposé, elle ne désigne qu'une **tentative** : un brouillon prérempli
+> invisible de l'API instructeur, qui peut avoir été réclamé par un autre compte ou purgé. Le
+> **dossier confirmé** n'existe qu'au dépôt, et c'est lui seul qui fait foi. Modèle cible :
+> conserver toutes les tentatives (aucun numéro DN n'est jamais effacé) et rattacher au dépôt
+> via l'annotation FPA. Mise en œuvre en cours, phases 3 à 6.
+
 - **`ds_status`** ∈ `null | EN_CONSTRUCTION | EN_INSTRUCTION | ACCEPTE | REFUSE | CLASSE_SANS_SUITE | NON_ACCESSIBLE` — c'est DS qui décide. `null` = dossier créé dans DS mais **pas encore déposé** ; `EN_CONSTRUCTION` = **déposé**, en attente d'instruction (et non « brouillon »). Voir [ADR-0009](../adr/0009-semantique-statut-ds-depose-vs-brouillon.md).
 - **`current_status`** ∈ `todo | en_instruction | valide` — dérivé via `DS_TO_INTERNAL_STATUS` (voir §3.2).
 - **`current_step`** ∈ les 5 étapes — change uniquement sur appel explicite à `moveToNextStep`.

--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -32,9 +32,11 @@ Chaque parcours a deux niveaux d'état complémentaires :
 > Une ligne `dossiers_demarches_simplifiees` est un **pointeur**, pas le dossier du demandeur.
 > Tant que rien n'est déposé, elle ne désigne qu'une **tentative** : un brouillon prérempli
 > invisible de l'API instructeur, qui peut avoir été réclamé par un autre compte ou purgé. Le
-> **dossier confirmé** n'existe qu'au dépôt, et c'est lui seul qui fait foi. Modèle cible :
-> conserver toutes les tentatives (aucun numéro DN n'est jamais effacé) et rattacher au dépôt
-> via l'annotation FPA. Mise en œuvre en cours, phases 3 à 6.
+> **dossier confirmé** n'existe qu'au dépôt, et c'est lui seul qui fait foi. Le registre
+> `dossiers_ds_tentatives` conserve tout numéro DN connu du parcours — écrit dans la même
+> transaction que le pointeur, jamais supprimé : remplacer un pointeur ne perd plus rien.
+> Amorçage : `pnpm ds:backfill-tentatives`. Le rattachement automatique au dépôt via
+> l'annotation FPA arrive en phase 4.
 
 - **`ds_status`** ∈ `null | EN_CONSTRUCTION | EN_INSTRUCTION | ACCEPTE | REFUSE | CLASSE_SANS_SUITE | NON_ACCESSIBLE` — c'est DS qui décide. `null` = dossier créé dans DS mais **pas encore déposé** ; `EN_CONSTRUCTION` = **déposé**, en attente d'instruction (et non « brouillon »). Voir [ADR-0009](../adr/0009-semantique-statut-ds-depose-vs-brouillon.md).
 - **`current_status`** ∈ `todo | en_instruction | valide` — dérivé via `DS_TO_INTERNAL_STATUS` (voir §3.2).
@@ -807,39 +809,41 @@ impots.gouv, assureur, CERFA mandat — `pieces-aide.map.ts`).
 
 ## 8. Fichiers clés
 
-| Rôle                                           | Fichier                                                                                        |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Schéma parcours                                | `src/shared/database/schema/parcours-prevention.ts`                                            |
-| Schéma dossiers DS                             | `src/shared/database/schema/dossiers-demarches-simplifiees.ts`                                 |
-| Schéma historique CRON                         | `src/shared/database/schema/sync-runs.ts`, `sync-run-entries.ts`                               |
-| Repository parcours                            | `src/shared/database/repositories/parcours-prevention.repository.ts`                           |
-| Repository sync_runs                           | `src/shared/database/repositories/sync-run.repository.ts`                                      |
-| Enums step / status                            | `src/shared/domain/value-objects/step.enum.ts`, `status.enum.ts`, `ds-status.enum.ts`          |
-| Mapping DS → interne                           | `src/features/parcours/dossiers-ds/domain/value-objects/ds-status.ts`                          |
-| Permissions / garde-fous                       | `src/features/parcours/core/services/parcours-permissions.service.ts`                          |
-| Progression d'étape                            | `src/features/parcours/core/services/parcours-progression.service.ts`                          |
-| Service sync DS                                | `src/features/parcours/dossiers-ds/services/ds-sync.service.ts`                                |
-| Service sync batch (CRON)                      | `src/features/parcours/dossiers-ds/services/parcours-sync-batch.service.ts`                    |
-| Vérif permissions / état démarches DS          | `scripts/ops/ds/check-ds-permissions.ts` (`pnpm ds:check-permissions`)                         |
-| Pièces justificatives (service dynamique DN)   | `dossiers-ds/services/pieces-justificatives.service.ts`, `domain/pieces-justificatives/*`      |
-| Composant PJ partagé (agent + demandeur)       | `dossiers-ds/components/PiecesJustificatives.tsx`                                              |
-| Proxy modèle PJ (URL temporaire DN régénérée)  | `src/app/api/ds/piece-modele/route.ts` (`buildModeleProxyUrl` / `getFreshModeleUrl`)           |
-| Probe pièces + modèles DN                      | `scripts/ops/ds/fetch-pieces-justificatives.ts` (`pnpm ds:fetch-pieces`)                       |
-| Reset dossier éligibilité (GELÉ, ADR-0026)     | `scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts` (`pnpm fix:eligibilite-sync-error`) |
-| Sonde lecture-seule dossiers DN                | `scripts/ops/sync-erreurs/probe-dossiers.ts` (`pnpm ds:probe-dossiers`)                        |
-| Backfill processed_at depuis dateTraitement    | `scripts/ops/ds/backfill-processed-at.ts` (`pnpm ds:backfill-processed-at`)                    |
-| Action UI sync                                 | `src/features/parcours/dossiers-ds/actions/dossier-sync.actions.ts`                            |
-| Création dossier devis-travaux (3 annotations) | `src/features/parcours/core/services/devis.service.ts`                                         |
-| Validation AMO (auto-progression CHOIX_AMO)    | `src/features/parcours/amo/services/amo-validation.service.ts`                                 |
-| Annotation « lien FPA » (id par démarche)      | `dossiers-ds/domain/value-objects/ds-annotations.ts` (`getAnnotationLienFpaEligibilite`)       |
-| Résolution du permalien parcours espace agent  | `backoffice/espace-agent/dossiers/services/admin-url-resolver.service.ts`                      |
-| Détachement AMO (service partagé UI + ops)     | `src/features/parcours/amo/services/detachement-amo.service.ts`                                |
-| Détachement AMO (script ops)                   | `scripts/ops/fix/detacher-amo.ts` (`pnpm fix:detacher-amo`)                                    |
-| Auto-attribution AMO (obligatoire / AV-AMO)    | `src/features/parcours/amo/services/amo-selection.service.ts` (`assignAmoAutomatiqueForUser`)  |
-| Rattrapage lien AMO obligatoire (script ops)   | `scripts/ops/fix/lier-amo-oblig.ts` (`pnpm fix:lier-amo-oblig`)                                |
-| Arrêt d'accompagnement (règles demandeur)      | `src/features/parcours/amo/services/arret-accompagnement.service.ts`                           |
-| Endpoint CRON                                  | `src/app/api/cron/sync-parcours/route.ts`                                                      |
-| Workflow CRON GitHub Actions                   | `.github/workflows/cron-sync-parcours.yml`                                                     |
-| Server actions admin                           | `src/features/backoffice/administration/synchronisations/actions/sync-runs.actions.ts`         |
-| Page liste runs                                | `src/app/(backoffice)/administration/synchronisations/page.tsx`                                |
-| Page détail run                                | `src/app/(backoffice)/administration/synchronisations/[id]/page.tsx`                           |
+| Rôle                                           | Fichier                                                                                                     |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Schéma parcours                                | `src/shared/database/schema/parcours-prevention.ts`                                                         |
+| Schéma dossiers DS (pointeur courant)          | `src/shared/database/schema/dossiers-demarches-simplifiees.ts`                                              |
+| Registre des tentatives (ADR-0027)             | `src/shared/database/schema/dossiers-ds-tentatives.ts`, `repositories/dossiers-ds-tentatives.repository.ts` |
+| Amorçage du registre                           | `scripts/ops/sync-erreurs/backfill-tentatives.ts` (`pnpm ds:backfill-tentatives`)                           |
+| Schéma historique CRON                         | `src/shared/database/schema/sync-runs.ts`, `sync-run-entries.ts`                                            |
+| Repository parcours                            | `src/shared/database/repositories/parcours-prevention.repository.ts`                                        |
+| Repository sync_runs                           | `src/shared/database/repositories/sync-run.repository.ts`                                                   |
+| Enums step / status                            | `src/shared/domain/value-objects/step.enum.ts`, `status.enum.ts`, `ds-status.enum.ts`                       |
+| Mapping DS → interne                           | `src/features/parcours/dossiers-ds/domain/value-objects/ds-status.ts`                                       |
+| Permissions / garde-fous                       | `src/features/parcours/core/services/parcours-permissions.service.ts`                                       |
+| Progression d'étape                            | `src/features/parcours/core/services/parcours-progression.service.ts`                                       |
+| Service sync DS                                | `src/features/parcours/dossiers-ds/services/ds-sync.service.ts`                                             |
+| Service sync batch (CRON)                      | `src/features/parcours/dossiers-ds/services/parcours-sync-batch.service.ts`                                 |
+| Vérif permissions / état démarches DS          | `scripts/ops/ds/check-ds-permissions.ts` (`pnpm ds:check-permissions`)                                      |
+| Pièces justificatives (service dynamique DN)   | `dossiers-ds/services/pieces-justificatives.service.ts`, `domain/pieces-justificatives/*`                   |
+| Composant PJ partagé (agent + demandeur)       | `dossiers-ds/components/PiecesJustificatives.tsx`                                                           |
+| Proxy modèle PJ (URL temporaire DN régénérée)  | `src/app/api/ds/piece-modele/route.ts` (`buildModeleProxyUrl` / `getFreshModeleUrl`)                        |
+| Probe pièces + modèles DN                      | `scripts/ops/ds/fetch-pieces-justificatives.ts` (`pnpm ds:fetch-pieces`)                                    |
+| Reset dossier éligibilité (GELÉ, ADR-0026)     | `scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts` (`pnpm fix:eligibilite-sync-error`)              |
+| Sonde lecture-seule dossiers DN                | `scripts/ops/sync-erreurs/probe-dossiers.ts` (`pnpm ds:probe-dossiers`)                                     |
+| Backfill processed_at depuis dateTraitement    | `scripts/ops/ds/backfill-processed-at.ts` (`pnpm ds:backfill-processed-at`)                                 |
+| Action UI sync                                 | `src/features/parcours/dossiers-ds/actions/dossier-sync.actions.ts`                                         |
+| Création dossier devis-travaux (3 annotations) | `src/features/parcours/core/services/devis.service.ts`                                                      |
+| Validation AMO (auto-progression CHOIX_AMO)    | `src/features/parcours/amo/services/amo-validation.service.ts`                                              |
+| Annotation « lien FPA » (id par démarche)      | `dossiers-ds/domain/value-objects/ds-annotations.ts` (`getAnnotationLienFpaEligibilite`)                    |
+| Résolution du permalien parcours espace agent  | `backoffice/espace-agent/dossiers/services/admin-url-resolver.service.ts`                                   |
+| Détachement AMO (service partagé UI + ops)     | `src/features/parcours/amo/services/detachement-amo.service.ts`                                             |
+| Détachement AMO (script ops)                   | `scripts/ops/fix/detacher-amo.ts` (`pnpm fix:detacher-amo`)                                                 |
+| Auto-attribution AMO (obligatoire / AV-AMO)    | `src/features/parcours/amo/services/amo-selection.service.ts` (`assignAmoAutomatiqueForUser`)               |
+| Rattrapage lien AMO obligatoire (script ops)   | `scripts/ops/fix/lier-amo-oblig.ts` (`pnpm fix:lier-amo-oblig`)                                             |
+| Arrêt d'accompagnement (règles demandeur)      | `src/features/parcours/amo/services/arret-accompagnement.service.ts`                                        |
+| Endpoint CRON                                  | `src/app/api/cron/sync-parcours/route.ts`                                                                   |
+| Workflow CRON GitHub Actions                   | `.github/workflows/cron-sync-parcours.yml`                                                                  |
+| Server actions admin                           | `src/features/backoffice/administration/synchronisations/actions/sync-runs.actions.ts`                      |
+| Page liste runs                                | `src/app/(backoffice)/administration/synchronisations/page.tsx`                                             |
+| Page détail run                                | `src/app/(backoffice)/administration/synchronisations/[id]/page.tsx`                                        |

--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -39,6 +39,13 @@ Chaque parcours a deux niveaux d'état complémentaires :
 > FPA, qui porte le `parcoursId` : `pnpm ds:reconcilier` (dry-run par défaut). Aucun conflit
 > n'est tranché automatiquement — deux dossiers déposés pour une même étape remontent pour
 > arbitrage.
+>
+> Côté demandeur, « Ce lien ne fonctionne plus ? » (`regenererLienPrefill`) sonde d'abord les
+> numéros déjà connus — si l'un a été déposé entre-temps, on rattache au lieu de recréer — puis
+> retire le pointeur pour qu'un nouveau prérempli soit créé. **Retirer le pointeur ne perd plus
+> rien** : le numéro reste au registre, et la réconciliation le rattrapera s'il finit déposé.
+> C'est ce qui distingue ce secours du reset gelé par [ADR-0026](../adr/0026-gel-reset-eligibilite-not-found.md),
+> qui effaçait la seule trace du numéro.
 
 - **`ds_status`** ∈ `null | EN_CONSTRUCTION | EN_INSTRUCTION | ACCEPTE | REFUSE | CLASSE_SANS_SUITE | NON_ACCESSIBLE` — c'est DS qui décide. `null` = dossier créé dans DS mais **pas encore déposé** ; `EN_CONSTRUCTION` = **déposé**, en attente d'instruction (et non « brouillon »). Voir [ADR-0009](../adr/0009-semantique-statut-ds-depose-vs-brouillon.md).
 - **`current_status`** ∈ `todo | en_instruction | valide` — dérivé via `DS_TO_INTERNAL_STATUS` (voir §3.2).
@@ -819,6 +826,7 @@ impots.gouv, assureur, CERFA mandat — `pieces-aide.map.ts`).
 | Amorçage du registre                           | `scripts/ops/sync-erreurs/backfill-tentatives.ts` (`pnpm ds:backfill-tentatives`)                           |
 | Réconciliation au dépôt (annotation FPA)       | `dossiers-ds/services/reconciliation.service.ts`, `dossiers-ds/utils/annotation-fpa.utils.ts`               |
 | Réconciliation (script ops)                    | `scripts/ops/sync-erreurs/reconcilier-dossiers.ts` (`pnpm ds:reconcilier`)                                  |
+| Secours « ce lien ne fonctionne plus »         | `dossiers-ds/services/regeneration.service.ts`, `actions/regeneration.actions.ts`                           |
 | Schéma historique CRON                         | `src/shared/database/schema/sync-runs.ts`, `sync-run-entries.ts`                                            |
 | Repository parcours                            | `src/shared/database/repositories/parcours-prevention.repository.ts`                                        |
 | Repository sync_runs                           | `src/shared/database/repositories/sync-run.repository.ts`                                                   |

--- a/docs/parcours/FLOW-AND-SYNC.md
+++ b/docs/parcours/FLOW-AND-SYNC.md
@@ -35,8 +35,10 @@ Chaque parcours a deux niveaux d'état complémentaires :
 > **dossier confirmé** n'existe qu'au dépôt, et c'est lui seul qui fait foi. Le registre
 > `dossiers_ds_tentatives` conserve tout numéro DN connu du parcours — écrit dans la même
 > transaction que le pointeur, jamais supprimé : remplacer un pointeur ne perd plus rien.
-> Amorçage : `pnpm ds:backfill-tentatives`. Le rattachement automatique au dépôt via
-> l'annotation FPA arrive en phase 4.
+> Amorçage : `pnpm ds:backfill-tentatives`. Le rattachement au dépôt se fait via l'annotation
+> FPA, qui porte le `parcoursId` : `pnpm ds:reconcilier` (dry-run par défaut). Aucun conflit
+> n'est tranché automatiquement — deux dossiers déposés pour une même étape remontent pour
+> arbitrage.
 
 - **`ds_status`** ∈ `null | EN_CONSTRUCTION | EN_INSTRUCTION | ACCEPTE | REFUSE | CLASSE_SANS_SUITE | NON_ACCESSIBLE` — c'est DS qui décide. `null` = dossier créé dans DS mais **pas encore déposé** ; `EN_CONSTRUCTION` = **déposé**, en attente d'instruction (et non « brouillon »). Voir [ADR-0009](../adr/0009-semantique-statut-ds-depose-vs-brouillon.md).
 - **`current_status`** ∈ `todo | en_instruction | valide` — dérivé via `DS_TO_INTERNAL_STATUS` (voir §3.2).
@@ -815,6 +817,8 @@ impots.gouv, assureur, CERFA mandat — `pieces-aide.map.ts`).
 | Schéma dossiers DS (pointeur courant)          | `src/shared/database/schema/dossiers-demarches-simplifiees.ts`                                              |
 | Registre des tentatives (ADR-0027)             | `src/shared/database/schema/dossiers-ds-tentatives.ts`, `repositories/dossiers-ds-tentatives.repository.ts` |
 | Amorçage du registre                           | `scripts/ops/sync-erreurs/backfill-tentatives.ts` (`pnpm ds:backfill-tentatives`)                           |
+| Réconciliation au dépôt (annotation FPA)       | `dossiers-ds/services/reconciliation.service.ts`, `dossiers-ds/utils/annotation-fpa.utils.ts`               |
+| Réconciliation (script ops)                    | `scripts/ops/sync-erreurs/reconcilier-dossiers.ts` (`pnpm ds:reconcilier`)                                  |
 | Schéma historique CRON                         | `src/shared/database/schema/sync-runs.ts`, `sync-run-entries.ts`                                            |
 | Repository parcours                            | `src/shared/database/repositories/parcours-prevention.repository.ts`                                        |
 | Repository sync_runs                           | `src/shared/database/repositories/sync-run.repository.ts`                                                   |

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -312,9 +312,24 @@ Priorité de traitement : les dossiers **acceptés ou en instruction** d'abord. 
 qu'FPA ignore, c'est un demandeur dont le parcours n'avance pas alors que son droit est acquis.
 Les `en_construction` très anciens sont le plus souvent des tests ou des abandons.
 
-- **À arbitrer** — deux dépôts pour une même étape, lien FPA retouché, numéro revendiqué deux
-  fois. Trancher côté DN (classement sans suite du doublon, par exemple), puis « Marquer comme
-  traité ».
+**À arbitrer** — le rattachement automatique s'est arrêté volontairement : il y a une décision
+métier à prendre, et aucune règle ne peut la prendre à notre place.
+
+| Situation                                  | Ce que ça veut dire                                                      | Ce qu'on fait                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| **Deux dossiers pour une étape**           | Le parcours a déjà un dossier déposé sous un autre numéro                | Choisir lequel fait foi, classer l'autre sans suite côté DN, puis rattacher      |
+| **Plusieurs dépôts pour un même parcours** | Plusieurs dossiers déposés portent le même lien FPA                      | Idem : trancher côté DN, le survivant se rattachera au balayage suivant          |
+| **Numéro déjà rattaché ailleurs**          | Ce numéro appartient à un autre demandeur (souvent un compte en double)  | Vérifier les deux parcours et décider lequel garder — jamais de rattachement ici |
+| **Lien FPA modifié / contradictoire**      | DN signale la valeur préremplie comme retouchée, ou deux liens divergent | Vérifier à qui appartient réellement le dossier, puis rattacher à la main        |
+| **Parcours introuvable**                   | Le lien pointe un parcours supprimé depuis                               | Rien à rattacher : écarter                                                       |
+
+Les deux boutons de la file **ne modifient aucune donnée** : ils referment l'observation, rien
+de plus. « Marquer comme traité » signifie « j'ai tranché ailleurs », « Écarter » signifie
+« ce cas ne nous concerne pas ». Le vrai arbitrage se fait côté DN, ou via le rattachement
+manuel une fois le doublon écarté.
+
+> Un cas refermé se **rouvre tout seul** si un balayage ultérieur lui trouve un verdict
+> différent. Refermer sans avoir traité ne fait donc que repousser le problème.
 
 Pour un rattachement en masse, le script fait la même chose que l'interface :
 

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -290,9 +290,28 @@ Si le message annonce une analyse **interrompue**, les résultats sont partiels 
 
 ### 4. Traiter les deux files
 
-- **À rattacher** — ouvrir le dossier côté DN pour identifier le demandeur, puis le rattacher
-  depuis son parcours (détail dossier → « Gérer » → « Rattacher un dossier DN »). L'observation
-  se referme toute seule.
+**À rattacher** — un dossier existe côté DN mais aucun parcours ne le suit. Pour chaque ligne :
+
+1. Ouvrir le dossier côté DN (le numéro est cliquable) et relever **le nom et l'email du
+   demandeur**, dans l'onglet « Demande ».
+2. Le chercher dans l'espace agent (`/espace-agent/dossiers`) ou dans les demandeurs
+   (`/administration/demandeurs`).
+3. **S'il existe** : ouvrir son dossier → « Gérer » → « Rattacher un dossier DN », saisir le
+   numéro. L'étape est déduite de la démarche du dossier, pas du parcours : un dossier
+   d'éligibilité rattaché depuis un parcours plus avancé reste une éligibilité. L'observation
+   se referme toute seule, et une note d'audit est écrite dans l'historique du dossier.
+4. **S'il n'existe pas** — dossier de test, démarche remplie hors dispositif, doublon
+   abandonné — cliquer « Écarter ». Rien n'est modifié côté DN.
+
+Deux refus possibles au rattachement, tous deux volontaires : « ce numéro est déjà rattaché à
+un autre demandeur » (on ne vole jamais un dossier) et « ce parcours a déjà un dossier déposé
+pour cette étape » — deux dossiers réels pour une même étape, c'est un arbitrage, pas un
+rattachement. Dans ce dernier cas, trancher d'abord côté DN (classement sans suite du doublon).
+
+Priorité de traitement : les dossiers **acceptés ou en instruction** d'abord. Un dossier accepté
+qu'FPA ignore, c'est un demandeur dont le parcours n'avance pas alors que son droit est acquis.
+Les `en_construction` très anciens sont le plus souvent des tests ou des abandons.
+
 - **À arbitrer** — deux dépôts pour une même étape, lien FPA retouché, numéro revendiqué deux
   fois. Trancher côté DN (classement sans suite du doublon, par exemple), puis « Marquer comme
   traité ».

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -255,58 +255,80 @@ Après relink : **relancer une synchro** pour recopier l'état réel.
 
 ## 4. Playbook (prod)
 
-Bout en bout. L'ordre n'est pas neutre (**relink avant reset**).
+Depuis [ADR-0027](../adr/0027-tentative-prefill-vs-dossier-confirme.md), la remédiation ne
+supprime plus rien : on **enregistre** tous les numéros connus, on **rattache** ce qui a été
+déposé, et on ne tranche à la main que ce qui l'exige.
 
-### 1. Déploiement
+### 1. Déployer et migrer
 
-- Déployer la branche, puis **appliquer la migration** (`pnpm db:migrate`) → colonnes
-  `dn_probe_*`. **Bloquant** : sans ça la vue diagnostic plante (`column dn_probe_state does
-not exist`).
-- Vérifier que `/administration/diagnostics` charge.
+```bash
+pnpm db:migrate
+```
 
-### 2. Remplir la « vérité DN » + régler les cas A
+Bloquant : sans les tables `dossiers_ds_tentatives` et `ds_reconciliation_observations`, la
+page diagnostics ne charge pas.
 
-Au déploiement, `dn_probe_state` est vide → colonne « Verdict DN » = **Non sondé** partout.
+### 2. Amorcer le registre des numéros
 
-- Cliquer **« Lancer une synchro maintenant »** (`/administration/synchronisations`) : elle
-  **resynchronise ET écrit `dn_probe_state`** en une passe.
-- Effet : les cas **A (existe côté DN)** se **corrigent tout seuls** (le miroir rattrape →
-  ils quittent la sync-erreur) et le « Verdict DN » se remplit pour tous. _(Le CRON ferait
-  pareil en quelques heures.)_
+```bash
+pnpm ds:backfill-tentatives          # dry-run : compte et ventile
+pnpm ds:backfill-tentatives --apply
+```
 
-### 3. Lire le diagnostic — état des lieux
+Deux sources : les pointeurs courants (fiables) et les numéros retrouvés dans
+`sync_run_entries.error` (indices — pointeurs supprimés par l'ancien reset). Idempotent,
+rejouable sans effet cumulatif. **À faire avant toute analyse** : sans lui, les dossiers dont
+le pointeur a disparu ressortiraient à tort comme inconnus.
 
-- Vue UI : filtrer les « sync erreur », lire la colonne **Verdict DN** (existe → résiduel à
-  resync ; disparu → à traiter). « Analyser » pour le détail d'un dossier.
-- Liste chiffrée + actionnable : `pnpm ds:probe-dossiers --from-sync-errors --email-crosscheck`
-  → section **PLAN D'ACTION** (combien de resync / reset / relink / clean / erreur).
+### 3. Analyser, depuis l'interface
 
-### 4. Exécuter les scripts — **dans cet ordre**, dry-run puis `--apply`
+`/administration/diagnostics`, bouton « Analyser » de l'étape voulue. Le balayage interroge DN
+en lecture seule et remplit les deux files. Il n'applique aucun rattachement.
 
-1. **Relink** (mismatches B2) **en premier** : `pnpm fix:relink-eligibilite --from-sync-errors`
-   → `--apply` → **re-sync**. _Pourquoi en premier : un mismatch est « not found », le reset le
-   supprimerait à tort ; le relink le rend « existe » et le reset l'épargne ensuite._
-2. ~~**Reset** (drop-offs B1 + purgés B3)~~ — **GELÉ** ([ADR-0026](../adr/0026-gel-reset-eligibilite-not-found.md)).
-   `--apply` refuse de s'exécuter : « GONE » ne distingue pas un prérempli en attente d'un
-   dossier purgé, et la suppression orpheline le dossier déposé plus tard. Dry-run seul.
-3. **Clean** (faux dépôts legacy, transverse) : `pnpm fix:clean-faux-depots` → `--apply`.
-   \_Indépendant : ne répare pas le parcours, nettoie les `submitted_at` trompeurs (diagnostic
-   - stats). Lançable quand on veut.\_
-4. **Erreur de sondage** (s'il y en a) : `pnpm ds:check-permissions` (démarche publiée + token
-   instructeur).
+Si le message annonce une analyse **interrompue**, les résultats sont partiels et rien n'a été
+écrit : relancer une fois DN de nouveau joignable.
 
-### 5. Vérifier
+### 4. Traiter les deux files
 
-- Rafraîchir la vue : les parcours traités **quittent la sync-erreur** (fix « erreur active »
-  §2 : dossier supprimé / resyncé → erreur obsolète, plus de « collant »).
-- Re-lancer `pnpm ds:probe-dossiers --from-sync-errors` → le PLAN D'ACTION doit retomber à ~0
-  (le résiduel = nouveaux drop-offs depuis).
+- **À rattacher** — ouvrir le dossier côté DN pour identifier le demandeur, puis le rattacher
+  depuis son parcours (détail dossier → « Gérer » → « Rattacher un dossier DN »). L'observation
+  se referme toute seule.
+- **À arbitrer** — deux dépôts pour une même étape, lien FPA retouché, numéro revendiqué deux
+  fois. Trancher côté DN (classement sans suite du doublon, par exemple), puis « Marquer comme
+  traité ».
 
-### 6. Pérenne
+Pour un rattachement en masse, le script fait la même chose que l'interface :
 
-- Le drop-off **se reproduit** (prefills jamais complétés). Repasser périodiquement par la vue
-  - relancer **reset/clean** au besoin. Le CRON entretient `dn_probe_state` et fait quitter
-    l'erreur aux cas A automatiquement. Pas de logs prod nécessaires.
+```bash
+pnpm ds:reconcilier                  # dry-run
+pnpm ds:reconcilier --apply          # applique les rattachements automatiques
+```
+
+Le **premier passage doit être lancé sans `--since`** : un dossier déposé il y a des mois et
+jamais modifié depuis serait invisible d'un balayage incrémental.
+
+### 5. Resynchroniser
+
+« Lancer une synchro maintenant » (`/administration/synchronisations`) : les dossiers repointés
+récupèrent leur état réel et les parcours avancent.
+
+### 6. Ce qui ne se répare pas comme ça
+
+- Un demandeur dont le lien ne fonctionne plus se débloque **seul**, depuis `/mon-compte`
+  (« Ce lien ne fonctionne plus ? »). Aucune intervention nécessaire.
+- Les dossiers antérieurs au 2026-08-25 n'ont pas d'annotation FPA : ils ne se rattachent
+  jamais automatiquement, seul le numéro déjà connu les identifie. Population figée.
+- `pnpm fix:clean-faux-depots` reste disponible, indépendant du reste : il nettoie les
+  `submitted_at` trompeurs d'avant #216 (diagnostic et stats), sans rien réparer.
+- Une erreur de sondage (`unauthorized`, `api_error`) n'est pas un problème de rattachement :
+  `pnpm ds:check-permissions`.
+
+### 7. Au quotidien
+
+Relancer l'analyse depuis l'interface de temps en temps — la réconciliation n'est pas encore
+branchée sur le CRON. Les files ne se remplissent que de ce qui a été déposé depuis, donc elles
+restent courtes. Le drop-off (préremplis jamais complétés) continue d'exister mais ne demande
+plus rien : ce n'est plus une anomalie, et le demandeur se débloque seul.
 
 ---
 
@@ -318,6 +340,9 @@ Au déploiement, `dn_probe_state` est vide → colonne « Verdict DN » = **Non 
 | Reset auto-vérifiant               | `scripts/ops/sync-erreurs/reset-eligibilite-sync-error.ts` (`pnpm fix:eligibilite-sync-error`) |
 | Relink mismatch                    | `scripts/ops/sync-erreurs/relink-eligibilite-dossier.ts` (`pnpm fix:relink-eligibilite`)       |
 | Nettoyage faux dépôts legacy       | `scripts/ops/sync-erreurs/clean-faux-depots-submitted-at.ts` (`pnpm fix:clean-faux-depots`)    |
+| Amorçage du registre               | `scripts/ops/sync-erreurs/backfill-tentatives.ts` (`pnpm ds:backfill-tentatives`)              |
+| Réconciliation au dépôt            | `scripts/ops/sync-erreurs/reconcilier-dossiers.ts` (`pnpm ds:reconcilier`)                     |
+| Files de travail (back-office)     | `diagnostics/actions/reconciliation.actions.ts`, `app/(backoffice)/.../DiagnosticsTabs.tsx`    |
 | Vérif permissions / publication DN | `scripts/ops/ds/check-ds-permissions.ts` (`pnpm ds:check-permissions`)                         |
 | Recherche dossier par email (UI)   | `searchEligibiliteByEmail` — page `/administration/diagnostics/[parcoursId]` (« Analyser »)    |
 | Classification diagnostic          | `src/features/backoffice/administration/diagnostics/services/diagnostics.service.ts`           |

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -292,15 +292,23 @@ Si le message annonce une analyse **interrompue**, les résultats sont partiels 
 
 **À rattacher** — un dossier existe côté DN mais aucun parcours ne le suit. Pour chaque ligne :
 
-1. Cliquer **« Identifier »** : l'écran interroge DN et affiche l'identité déclarée, le compte
-   usager, les champs du formulaire, puis **les demandeurs qui correspondent** — par adresse de
-   logement, téléphone, e-mail ou nom, du plus concordant au moins concordant.
-2. À défaut de candidat, ouvrir le dossier côté DN (le numéro est cliquable) et chercher à la
-   main dans l'espace agent ou dans les demandeurs.
-3. **S'il existe** : ouvrir son dossier → « Gérer » → « Rattacher un dossier DN », saisir le
-   numéro. L'étape est déduite de la démarche du dossier, pas du parcours : un dossier
-   d'éligibilité rattaché depuis un parcours plus avancé reste une éligibilité. L'observation
-   se referme toute seule, et une note d'audit est écrite dans l'historique du dossier.
+1. **L'analyse a déjà cherché à qui appartient le dossier** : la colonne « Demandeur probable »
+   affiche les demandeurs qui correspondent — par adresse de logement, téléphone, e-mail ou nom,
+   du plus concordant au moins concordant. Ce rapprochement est fait au balayage, pour les seuls
+   dossiers orphelins (plafonné à 30 par analyse), et conservé avec l'observation.
+2. **Un seul demandeur correspond** : le bouton **« Rattacher »** suffit. **Plusieurs
+   correspondent** : un avertissement le signale et il faut choisir explicitement lequel — la
+   correspondance est un indice, pas une preuve (l'e-mail peut être celui de l'AMO, deux
+   personnes peuvent porter le même nom). **« Voir le détail »** déplie ce que DN déclare pour
+   vérifier avant de trancher.
+3. **Aucun candidat** : ouvrir le dossier côté DN (le numéro est cliquable) et chercher à la main
+   dans l'espace agent. Le rattachement reste possible depuis le dossier du demandeur → « Gérer »
+   → « Rattacher un dossier DN ».
+
+   Quel que soit le chemin, l'étape est déduite de la démarche du dossier, pas du parcours : un
+   dossier d'éligibilité rattaché depuis un parcours plus avancé reste une éligibilité.
+   L'observation se referme toute seule et une note d'audit est écrite dans l'historique du
+   dossier.
 
    **S'il a déjà un dossier pour cette étape**, deux cas selon son état : tant qu'il n'a jamais
    été observé déposé (un prérempli), le rattachement le **remplace** — l'ancien numéro reste au

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -123,6 +123,23 @@ l'usager a un dossier **sous un autre numéro** dans la démarche éligibilité 
   de numéro** (le `ds_number` stocké ≠ celui réellement utilisé). C'est **récupérable par
   relink** (mettre à jour `ds_number`), surtout **PAS par reset** (qui ferait un doublon).
 
+### Les deux files de travail (ADR-0027)
+
+Depuis la réconciliation, `/administration/diagnostics` s'ouvre sur **deux onglets qui appellent
+une action**, alimentés par la table `ds_reconciliation_observations` :
+
+- **À rattacher** — dossiers déposés sans lien vers un parcours (créés hors FPA, ou antérieurs à
+  l'annotation), et rattachements proposés mais pas encore appliqués. Le rattachement se fait
+  depuis le détail dossier, menu « Gérer ».
+- **À arbitrer** — deux dossiers déposés pour une même étape, lien FPA retouché ou contradictoire,
+  numéro revendiqué par deux parcours. Décision humaine obligatoire, jamais automatique.
+
+Le bouton « Analyser » balaye une démarche en lecture seule et remplit ces files : il n'applique
+aucun rattachement. L'écriture reste explicite, via `pnpm ds:reconcilier --apply`.
+
+Un troisième onglet, **États des parcours**, conserve la vue détaillée par état — utile au
+diagnostic, mais ce n'est plus le point d'entrée : la majorité de ses états sont normaux.
+
 ### Où voir ces sous-cas dans l'UI
 
 - **Liste** (`/administration/diagnostics`) : DB-only (aucun appel DN), donc les états

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -300,6 +300,13 @@ Si le message annonce une analyse **interrompue**, les résultats sont partiels 
    numéro. L'étape est déduite de la démarche du dossier, pas du parcours : un dossier
    d'éligibilité rattaché depuis un parcours plus avancé reste une éligibilité. L'observation
    se referme toute seule, et une note d'audit est écrite dans l'historique du dossier.
+
+   **S'il a déjà un dossier pour cette étape**, deux cas selon son état : tant qu'il n'a jamais
+   été observé déposé (un prérempli), le rattachement le **remplace** — l'ancien numéro reste au
+   registre et la réconciliation le rattrapera s'il finit déposé. S'il a été déposé, le
+   rattachement est **refusé** : deux dossiers réels, c'est un arbitrage (voir la file
+   correspondante), pas un rattachement.
+
 4. **S'il n'existe pas** — dossier de test, démarche remplie hors dispositif, doublon
    abandonné — cliquer « Écarter ». Rien n'est modifié côté DN.
 

--- a/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
+++ b/docs/parcours/SYNC-ERREURS-ET-REMEDIATION.md
@@ -292,10 +292,11 @@ Si le message annonce une analyse **interrompue**, les résultats sont partiels 
 
 **À rattacher** — un dossier existe côté DN mais aucun parcours ne le suit. Pour chaque ligne :
 
-1. Ouvrir le dossier côté DN (le numéro est cliquable) et relever **le nom et l'email du
-   demandeur**, dans l'onglet « Demande ».
-2. Le chercher dans l'espace agent (`/espace-agent/dossiers`) ou dans les demandeurs
-   (`/administration/demandeurs`).
+1. Cliquer **« Identifier »** : l'écran interroge DN et affiche l'identité déclarée, le compte
+   usager, les champs du formulaire, puis **les demandeurs qui correspondent** — par adresse de
+   logement, téléphone, e-mail ou nom, du plus concordant au moins concordant.
+2. À défaut de candidat, ouvrir le dossier côté DN (le numéro est cliquable) et chercher à la
+   main dans l'espace agent ou dans les demandeurs.
 3. **S'il existe** : ouvrir son dossier → « Gérer » → « Rattacher un dossier DN », saisir le
    numéro. L'étape est déduite de la démarche du dossier, pas du parcours : un dossier
    d'éligibilité rattaché depuis un parcours plus avancé reste une éligibilité. L'observation

--- a/docs/security/RBAC-ROLES.md
+++ b/docs/security/RBAC-ROLES.md
@@ -335,6 +335,16 @@ d'accompagnement, archivage/désarchivage, création de dossier, qualification p
 des données de simulation. Le super-admin ne gère donc que le **suivi** (commentaires/actions),
 jamais les décisions structurantes du dossier.
 
+### 6.1.3 Rattachement d'un dossier DN ouvert au super-admin (troisième exception)
+
+Le rattachement manuel d'un dossier Démarches Numériques par son numéro
+(`rattacherDossierDnAction`, [ADR-0027](../adr/0027-tentative-prefill-vs-dossier-confirme.md))
+n'appelle **pas** `assertNotSuperAdminReadOnly`. Rôles habilités : `SUPER_ADMINISTRATEUR`,
+`AMO`, `ALLERS_VERS`, `AMO_ET_ALLERS_VERS`, avec le périmètre du détail dossier (ownership
+entreprise si le dossier a une AMO, contrôle territorial sinon). L'exception est assumée :
+sans elle, réparer un dossier créé hors du lien FPA imposerait une intervention SQL en
+production. L'audit QUI/QUAND est écrit dans `parcours_actions` (type `dossier_dn_rattache`).
+
 ## 6.2 Édition des données de simulation alignée sur le détail dossier
 
 Le bouton « Vérifier son éligibilité » (édition du formulaire de simulation, page

--- a/docs/security/RBAC-ROLES.md
+++ b/docs/security/RBAC-ROLES.md
@@ -398,5 +398,6 @@ autorisation que la lecture — ownership entreprise pour un dossier avec AMO, s
 | Garde ré-ouverture demande            | `agent-scope.service.ts` (`canReopenRefusedDemande`) + `dossiers/actions/reouvrir-demande.actions.ts`                   |
 | Garde arrêt d'accompagnement          | `responsable-permissions.service.ts` (`assertCanActAsResponsable`) + `dossiers/actions/arret-accompagnement.actions.ts` |
 | Garde refus accompagnement (éligible) | `demandes/actions/demande-detail.actions.ts` (`refuserAccompagnementEligible` → `verifyAmoOwnership`)                   |
+| Garde rattachement dossier DN         | `espace-agent/dossiers/actions/rattacher-dossier-dn.actions.ts` — ownership entreprise, sinon territorial               |
 | Garde édition simulation              | `src/features/backoffice/espace-agent/shared/services/edition-simulation.service.ts` (`getDossierSimulationData`)       |
 | Résolution du permalien parcours      | `dossiers/services/admin-url-resolver.service.ts` (`resolveEspaceAgentPath`) — chemin seul, aucune donnée               |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "private": true,
   "packageManager": "pnpm@11.10.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fonds-prevention-argile",
   "version": "1.50.0",
   "private": true,
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.24.0",
   "engines": {
     "node": "24.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "private": true,
   "packageManager": "pnpm@11.24.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ds:fetch-schema": "tsx scripts/ops/ds/fetch-demarche-schema.ts",
     "ds:probe-dossiers": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/probe-dossiers.ts",
     "ds:backfill-processed-at": "tsx --tsconfig scripts/tsconfig.json scripts/ops/ds/backfill-processed-at.ts",
+    "ds:backfill-tentatives": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/backfill-tentatives.ts",
     "fix:double-progression": "tsx scripts/ops/fix/fix-double-progression-amo.ts",
     "fix:reouvrir-demande": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/reouvrir-demande.ts",
     "fix:detacher-amo": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/detacher-amo.ts",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ds:probe-dossiers": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/probe-dossiers.ts",
     "ds:backfill-processed-at": "tsx --tsconfig scripts/tsconfig.json scripts/ops/ds/backfill-processed-at.ts",
     "ds:backfill-tentatives": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/backfill-tentatives.ts",
+    "ds:reconcilier": "tsx --tsconfig scripts/tsconfig.json scripts/ops/sync-erreurs/reconcilier-dossiers.ts",
     "fix:double-progression": "tsx scripts/ops/fix/fix-double-progression-amo.ts",
     "fix:reouvrir-demande": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/reouvrir-demande.ts",
     "fix:detacher-amo": "tsx --tsconfig scripts/tsconfig.json scripts/ops/fix/detacher-amo.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fonds-prevention-argile",
-  "version": "1.51.0",
+  "version": "1.50.0",
   "private": true,
   "packageManager": "pnpm@11.24.0",
   "engines": {

--- a/scripts/ops/sync-erreurs/README.md
+++ b/scripts/ops/sync-erreurs/README.md
@@ -18,6 +18,7 @@ garantir l'ordre de chargement.
 | `reset-eligibilite-sync-error.ts`   | `pnpm fix:eligibilite-sync-error` | **GELÉ** (`--apply` refusé, ADR-0026) — dry-run diagnostic seul |
 | `relink-eligibilite-dossier.ts`     | `pnpm fix:relink-eligibilite`     | **Relink** d'un mismatch (dossier réel sous un autre numéro)    |
 | `clean-faux-depots-submitted-at.ts` | `pnpm fix:clean-faux-depots`      | Nettoyage des faux `submitted_at` legacy (pré-#216)             |
+| `backfill-tentatives.ts`            | `pnpm ds:backfill-tentatives`     | Amorce le registre des tentatives DN (ADR-0027)                 |
 
 Ordre recommandé : **probe** → resync (UI) → **relink** → **clean**. Détails et cas résolus :
 voir le playbook (§4 de la doc).

--- a/scripts/ops/sync-erreurs/README.md
+++ b/scripts/ops/sync-erreurs/README.md
@@ -21,8 +21,9 @@ garantir l'ordre de chargement.
 | `backfill-tentatives.ts`            | `pnpm ds:backfill-tentatives`     | Amorce le registre des tentatives DN (ADR-0027)                    |
 | `reconcilier-dossiers.ts`           | `pnpm ds:reconcilier`             | Rattache les dossiers déposés à leur parcours via l'annotation FPA |
 
-Ordre recommandé : **probe** → resync (UI) → **relink** → **clean**. Détails et cas résolus :
-voir le playbook (§4 de la doc).
+Ordre recommandé : **backfill** (registre) → **analyse** (interface ou `ds:reconcilier`) →
+traitement des deux files → resync (UI). `probe` et `relink` restent utiles pour un cas isolé.
+Détails : voir le playbook (§4 de la doc).
 
 > Le **reset est gelé** ([ADR-0026](../../../docs/adr/0026-gel-reset-eligibilite-not-found.md)) :
 > un prérempli non déposé est invisible de l'API instructeur et répond `Dossier not found`

--- a/scripts/ops/sync-erreurs/README.md
+++ b/scripts/ops/sync-erreurs/README.md
@@ -12,13 +12,14 @@ en bas de page) : il ne reste utilisable qu'en dry-run, comme diagnostic. Ils ch
 via `../lib/db` (dotenv) ; ceux qui appellent DN importent `graphqlClient` **après** pour
 garantir l'ordre de chargement.
 
-| Script                              | Alias                             | Rôle                                                            |
-| ----------------------------------- | --------------------------------- | --------------------------------------------------------------- |
-| `probe-dossiers.ts`                 | `pnpm ds:probe-dossiers`          | Sonde DN **lecture seule** (verdicts + cross-check email)       |
-| `reset-eligibilite-sync-error.ts`   | `pnpm fix:eligibilite-sync-error` | **GELÉ** (`--apply` refusé, ADR-0026) — dry-run diagnostic seul |
-| `relink-eligibilite-dossier.ts`     | `pnpm fix:relink-eligibilite`     | **Relink** d'un mismatch (dossier réel sous un autre numéro)    |
-| `clean-faux-depots-submitted-at.ts` | `pnpm fix:clean-faux-depots`      | Nettoyage des faux `submitted_at` legacy (pré-#216)             |
-| `backfill-tentatives.ts`            | `pnpm ds:backfill-tentatives`     | Amorce le registre des tentatives DN (ADR-0027)                 |
+| Script                              | Alias                             | Rôle                                                               |
+| ----------------------------------- | --------------------------------- | ------------------------------------------------------------------ |
+| `probe-dossiers.ts`                 | `pnpm ds:probe-dossiers`          | Sonde DN **lecture seule** (verdicts + cross-check email)          |
+| `reset-eligibilite-sync-error.ts`   | `pnpm fix:eligibilite-sync-error` | **GELÉ** (`--apply` refusé, ADR-0026) — dry-run diagnostic seul    |
+| `relink-eligibilite-dossier.ts`     | `pnpm fix:relink-eligibilite`     | **Relink** d'un mismatch (dossier réel sous un autre numéro)       |
+| `clean-faux-depots-submitted-at.ts` | `pnpm fix:clean-faux-depots`      | Nettoyage des faux `submitted_at` legacy (pré-#216)                |
+| `backfill-tentatives.ts`            | `pnpm ds:backfill-tentatives`     | Amorce le registre des tentatives DN (ADR-0027)                    |
+| `reconcilier-dossiers.ts`           | `pnpm ds:reconcilier`             | Rattache les dossiers déposés à leur parcours via l'annotation FPA |
 
 Ordre recommandé : **probe** → resync (UI) → **relink** → **clean**. Détails et cas résolus :
 voir le playbook (§4 de la doc).

--- a/scripts/ops/sync-erreurs/_shared.test.ts
+++ b/scripts/ops/sync-erreurs/_shared.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { extraireNumerosDepuisErreur } from "./_shared";
+
+// Seul moyen de retrouver un numéro DN dont le pointeur a été supprimé (ADR-0027).
+describe("extraireNumerosDepuisErreur", () => {
+  it("extrait l'étape et le numéro d'une erreur de sync", () => {
+    const msg = "eligibilite: Sync dossier 32052358 échouée: GraphQL errors: Dossier not found";
+    expect(extraireNumerosDepuisErreur(msg)).toEqual([{ step: "eligibilite", dsNumber: "32052358" }]);
+  });
+
+  it("extrait toutes les erreurs quand plusieurs sont concaténées", () => {
+    const msg =
+      "eligibilite: Sync dossier 32052358 échouée: Dossier not found | " +
+      "diagnostic: Sync dossier 31999111 échouée: unauthorized";
+    expect(extraireNumerosDepuisErreur(msg)).toEqual([
+      { step: "eligibilite", dsNumber: "32052358" },
+      { step: "diagnostic", dsNumber: "31999111" },
+    ]);
+  });
+
+  it("ne remonte rien sur un message sans numéro", () => {
+    expect(extraireNumerosDepuisErreur("Parcours disparu pendant la synchro")).toEqual([]);
+  });
+});

--- a/scripts/ops/sync-erreurs/_shared.ts
+++ b/scripts/ops/sync-erreurs/_shared.ts
@@ -9,6 +9,7 @@ import { and, desc, eq, isNotNull, isNull } from "drizzle-orm";
 import type { createOpsDb } from "../lib/db";
 import { parcoursPrevention, syncRunEntries } from "@/shared/database/schema";
 import type { DemarchesSimplifieesClient } from "@/features/parcours/dossiers-ds/adapters/graphql/client";
+import type { Step } from "@/shared/domain/value-objects/step.enum";
 
 export type OpsDb = ReturnType<typeof createOpsDb>["db"];
 export type DnClient = DemarchesSimplifieesClient;
@@ -20,6 +21,22 @@ export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 /** Normalise un email pour comparaison (minuscule, trim) ; null si vide. */
 export const norm = (e?: string | null): string | null => e?.toLowerCase().trim() || null;
+
+/**
+ * Extrait les couples (étape, numéro DN) cités dans un message d'erreur de sync, du type
+ * `eligibilite: Sync dossier 32052358 échouée: ...`. Plusieurs erreurs peuvent être
+ * concaténées dans une même entrée, d'où l'itération. Seul moyen de retrouver un numéro
+ * dont le pointeur a été supprimé (cf. ADR-0027, backfill du registre).
+ */
+export function extraireNumerosDepuisErreur(message: string): Array<{ step: Step; dsNumber: string }> {
+  const out: Array<{ step: Step; dsNumber: string }> = [];
+  const re = /([a-z_]+): Sync dossier (\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(message)) !== null) {
+    out.push({ step: m[1] as Step, dsNumber: m[2] });
+  }
+  return out;
+}
 
 /** Normalise un message d'erreur DN en verdict de sondage. */
 export function classifyDnError(message: string): "not_found" | "unauthorized" | "api_error" {

--- a/scripts/ops/sync-erreurs/backfill-tentatives.ts
+++ b/scripts/ops/sync-erreurs/backfill-tentatives.ts
@@ -1,0 +1,156 @@
+/**
+ * Amorce le registre des tentatives (`dossiers_ds_tentatives`, cf. ADR-0027) à partir de ce
+ * qu'on sait déjà : les pointeurs courants, et les numéros DN qui traînent dans les messages
+ * d'erreur de synchronisation (pointeurs supprimés par l'ancien reset).
+ *
+ * Deux sources, deux niveaux de confiance :
+ *   backfill_pointeur     ligne `dossiers_demarches_simplifiees` actuelle — fiable, complète
+ *   backfill_sync_error   numéro extrait de `sync_run_entries.error` — INDICE : ni URL de
+ *                         préremplissage, ni ds_id, ni date de création réelle. À ne jamais
+ *                         utiliser seul pour rattacher automatiquement.
+ *
+ * Idempotent : `ds_number` est unique, un numéro déjà connu n'est ni dupliqué ni réécrit.
+ * L'URL de préremplissage n'est reprise que pour les dossiers NON déposés — elle porte le
+ * `prefill_token` et n'a plus d'usage une fois le dossier transmis.
+ *
+ * Usage :
+ *   pnpm ds:backfill-tentatives           # dry-run (compte et ventile)
+ *   pnpm ds:backfill-tentatives --apply   # écrit
+ *
+ * Prérequis : DATABASE_URL (ou vars Scalingo). N'appelle PAS l'API DN.
+ */
+
+import { isNotNull } from "drizzle-orm";
+import { createOpsDb } from "../lib/db";
+import {
+  dossiersDemarchesSimplifiees,
+  dossiersDsTentatives,
+  parcoursPrevention,
+  syncRunEntries,
+  ORIGINE_TENTATIVE,
+} from "@/shared/database/schema";
+import type { Step } from "@/shared/domain/value-objects/step.enum";
+import { hasFlag } from "../lib/args";
+import { extraireNumerosDepuisErreur } from "./_shared";
+
+const APPLY = hasFlag("apply");
+const { db, client } = createOpsDb();
+
+interface Tentative {
+  parcoursId: string;
+  step: Step;
+  dsNumber: string;
+  origine: string;
+  dsId: string | null;
+  dsDemarcheId: string | null;
+  dsUrl: string | null;
+}
+
+async function main() {
+  console.log("=".repeat(72));
+  console.log(`BACKFILL REGISTRE DES TENTATIVES — ${APPLY ? "APPLY" : "DRY-RUN"}`);
+  console.log("=".repeat(72));
+
+  const dejaConnus = new Set(
+    (await db.select({ dsNumber: dossiersDsTentatives.dsNumber }).from(dossiersDsTentatives)).map((r) => r.dsNumber)
+  );
+  console.log(`Déjà au registre : ${dejaConnus.size}`);
+
+  // --- Source 1 : les pointeurs courants ---
+  const pointeurs = await db
+    .select({
+      parcoursId: dossiersDemarchesSimplifiees.parcoursId,
+      step: dossiersDemarchesSimplifiees.step,
+      dsNumber: dossiersDemarchesSimplifiees.dsNumber,
+      dsId: dossiersDemarchesSimplifiees.dsId,
+      dsDemarcheId: dossiersDemarchesSimplifiees.dsDemarcheId,
+      dsUrl: dossiersDemarchesSimplifiees.dsUrl,
+      submittedAt: dossiersDemarchesSimplifiees.submittedAt,
+    })
+    .from(dossiersDemarchesSimplifiees)
+    .where(isNotNull(dossiersDemarchesSimplifiees.dsNumber));
+
+  const aInserer: Tentative[] = [];
+  const vus = new Set(dejaConnus);
+
+  for (const p of pointeurs) {
+    if (!p.dsNumber || vus.has(p.dsNumber)) continue;
+    vus.add(p.dsNumber);
+    aInserer.push({
+      parcoursId: p.parcoursId,
+      step: p.step as Step,
+      dsNumber: p.dsNumber,
+      origine: ORIGINE_TENTATIVE.BACKFILL_POINTEUR,
+      dsId: p.dsId,
+      dsDemarcheId: p.dsDemarcheId,
+      // Le lien prefill n'a plus d'usage une fois le dossier déposé : on ne le recopie pas.
+      dsUrl: p.submittedAt ? null : p.dsUrl,
+    });
+  }
+  const nbPointeurs = aInserer.length;
+
+  // --- Source 2 : les numéros cités dans les erreurs de sync (pointeurs disparus) ---
+  const erreurs = await db
+    .select({ parcoursId: syncRunEntries.parcoursId, error: syncRunEntries.error })
+    .from(syncRunEntries)
+    .where(isNotNull(syncRunEntries.error));
+
+  const parcoursExistants = new Set(
+    (await db.select({ id: parcoursPrevention.id }).from(parcoursPrevention)).map((r) => r.id)
+  );
+
+  for (const e of erreurs) {
+    if (!e.error || !parcoursExistants.has(e.parcoursId)) continue;
+    for (const { step, dsNumber } of extraireNumerosDepuisErreur(e.error)) {
+      if (vus.has(dsNumber)) continue;
+      vus.add(dsNumber);
+      aInserer.push({
+        parcoursId: e.parcoursId,
+        step,
+        dsNumber,
+        origine: ORIGINE_TENTATIVE.BACKFILL_SYNC_ERROR,
+        dsId: null,
+        dsDemarcheId: null,
+        dsUrl: null,
+      });
+    }
+  }
+  const nbSyncErrors = aInserer.length - nbPointeurs;
+
+  console.log();
+  console.log(`À enregistrer : ${aInserer.length}`);
+  console.log(`  - depuis les pointeurs courants        : ${nbPointeurs}`);
+  console.log(`  - depuis les erreurs de sync (indices) : ${nbSyncErrors}`);
+  console.log();
+
+  if (aInserer.length === 0) {
+    console.log("Rien à faire.");
+    await client.end();
+    return;
+  }
+
+  if (!APPLY) {
+    console.log("Mode dry-run — aucune écriture. Relancer avec --apply.");
+    await client.end();
+    return;
+  }
+
+  let ok = 0;
+  for (const t of aInserer) {
+    const inserted = await db
+      .insert(dossiersDsTentatives)
+      .values(t)
+      .onConflictDoNothing({ target: dossiersDsTentatives.dsNumber })
+      .returning({ id: dossiersDsTentatives.id });
+    if (inserted.length > 0) ok++;
+  }
+
+  console.log(`Terminé : ${ok} tentative(s) enregistrée(s), ${aInserer.length - ok} ignorée(s) (déjà connue).`);
+  await client.end();
+}
+
+main().catch(async (err) => {
+  console.error("Erreur fatale :", err);
+  await client.end();
+  process.exit(1);
+});

--- a/scripts/ops/sync-erreurs/backfill-tentatives.ts
+++ b/scripts/ops/sync-erreurs/backfill-tentatives.ts
@@ -10,8 +10,8 @@
  *                         utiliser seul pour rattacher automatiquement.
  *
  * Idempotent : `ds_number` est unique, un numéro déjà connu n'est ni dupliqué ni réécrit.
- * L'URL de préremplissage n'est reprise que pour les dossiers NON déposés — elle porte le
- * `prefill_token` et n'a plus d'usage une fois le dossier transmis.
+ * Le registre ne conserve que l'identité du dossier : l'URL de préremplissage porte le
+ * `prefill_token` et reste sur le seul pointeur courant (ADR-0027).
  *
  * Usage :
  *   pnpm ds:backfill-tentatives           # dry-run (compte et ventile)
@@ -43,7 +43,6 @@ interface Tentative {
   origine: string;
   dsId: string | null;
   dsDemarcheId: string | null;
-  dsUrl: string | null;
 }
 
 async function main() {
@@ -64,7 +63,6 @@ async function main() {
       dsNumber: dossiersDemarchesSimplifiees.dsNumber,
       dsId: dossiersDemarchesSimplifiees.dsId,
       dsDemarcheId: dossiersDemarchesSimplifiees.dsDemarcheId,
-      dsUrl: dossiersDemarchesSimplifiees.dsUrl,
       submittedAt: dossiersDemarchesSimplifiees.submittedAt,
     })
     .from(dossiersDemarchesSimplifiees)
@@ -83,8 +81,6 @@ async function main() {
       origine: ORIGINE_TENTATIVE.BACKFILL_POINTEUR,
       dsId: p.dsId,
       dsDemarcheId: p.dsDemarcheId,
-      // Le lien prefill n'a plus d'usage une fois le dossier déposé : on ne le recopie pas.
-      dsUrl: p.submittedAt ? null : p.dsUrl,
     });
   }
   const nbPointeurs = aInserer.length;
@@ -111,7 +107,6 @@ async function main() {
         origine: ORIGINE_TENTATIVE.BACKFILL_SYNC_ERROR,
         dsId: null,
         dsDemarcheId: null,
-        dsUrl: null,
       });
     }
   }

--- a/scripts/ops/sync-erreurs/reconcilier-dossiers.ts
+++ b/scripts/ops/sync-erreurs/reconcilier-dossiers.ts
@@ -1,0 +1,102 @@
+/**
+ * Rapproche les dossiers DN DÉPOSÉS de leur parcours, via l'annotation « lien FPA » qui porte
+ * le `parcoursId` (ADR-0027). Répare les parcours dont le pointeur a été perdu — mauvais compte
+ * DN, dossier rempli depuis le poste de l'AMO, brouillon purgé, pointeur supprimé par l'ancien
+ * reset — sans que le demandeur ait quoi que ce soit à faire.
+ *
+ * Ne traite QUE les dossiers déposés : un brouillon est invisible de l'API instructeur.
+ *
+ * Verdicts :
+ *   rattachement               le parcours n'a pas de dossier confirmé → repointage
+ *   deja_a_jour                le pointeur vise déjà ce dossier
+ *   conflit_autre_parcours     numéro déjà rattaché ailleurs → jamais volé, à examiner
+ *   conflit_dossier_confirme   le parcours a déjà un dossier déposé sous un autre numéro
+ *   conflit_plusieurs_deposes  plusieurs dossiers déposés visent ce parcours
+ *   sans_annotation            dossier créé hors FPA → rattachement manuel (numéro à saisir)
+ *   parcours_inconnu           annotation pointant un parcours supprimé
+ *
+ * Usage :
+ *   pnpm ds:reconcilier                          # dry-run, éligibilité, tout l'historique
+ *   pnpm ds:reconcilier --step=diagnostic        # autre étape
+ *   pnpm ds:reconcilier --since=2026-08-01       # delta seulement (plus rapide)
+ *   pnpm ds:reconcilier --apply                  # applique les rattachements
+ *
+ * Le premier passage doit être lancé SANS `--since` : un dossier déposé il y a des mois et
+ * jamais modifié depuis resterait invisible d'un balayage incrémental.
+ *
+ * Après application : relancer une synchro pour recopier l'état réel des dossiers repointés.
+ */
+
+import { createOpsDb } from "../lib/db";
+import { reconcilierDemarche } from "@/features/parcours/dossiers-ds/services/reconciliation.service";
+import { resolveDemarcheNumberForStep } from "@/features/parcours/dossiers-ds/services/pieces-justificatives.service";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+import { createRedactor } from "../lib/anonymize";
+import { getArg, hasFlag } from "../lib/args";
+
+const APPLY = hasFlag("apply");
+const ANONYMIZE = !hasFlag("no-anonymize");
+const SINCE = getArg("since");
+const STEP = (getArg("step") ?? Step.ELIGIBILITE) as Step;
+
+const { client } = createOpsDb();
+const { redactUuid } = createRedactor(ANONYMIZE);
+
+async function main() {
+  const demarcheNumber = resolveDemarcheNumberForStep(STEP);
+
+  console.log("=".repeat(72));
+  console.log(`RÉCONCILIATION DOSSIERS DN — ${APPLY ? "APPLY" : "DRY-RUN"}${ANONYMIZE ? " (anonymisé)" : ""}`);
+  console.log("=".repeat(72));
+  console.log(`Étape : ${STEP} — démarche ${demarcheNumber}`);
+  console.log(SINCE ? `Modifiés depuis : ${SINCE}` : "Périmètre : TOUS les dossiers de la démarche");
+  console.log();
+
+  const rapport = await reconcilierDemarche({
+    demarcheNumber,
+    step: STEP,
+    updatedSince: SINCE ? new Date(SINCE).toISOString() : undefined,
+    apply: APPLY,
+  });
+
+  console.log(`Dossiers déposés examinés : ${rapport.lignes.length}`);
+  console.log();
+  for (const [verdict, n] of Object.entries(rapport.totaux)) {
+    if (n > 0) console.log(`  ${verdict.padEnd(26)} : ${n}`);
+  }
+  console.log();
+
+  const aVoir = rapport.lignes.filter((l) => l.verdict !== "deja_a_jour" && l.verdict !== "sans_annotation");
+  if (aVoir.length > 0) {
+    console.log("--- DÉTAIL (hors « déjà à jour » et « sans annotation ») ---");
+    for (const l of aVoir) {
+      const avant = l.pointeurAvant ? `#${l.pointeurAvant}` : "aucun pointeur";
+      console.log(`  ${l.verdict.padEnd(26)} #${l.dsNumber} (${l.state}) ${avant} → ${redactUuid(l.parcoursId ?? "")}`);
+    }
+    console.log();
+  }
+
+  const sansAnnotation = rapport.totaux.sans_annotation;
+  if (sansAnnotation > 0) {
+    console.log(
+      `${sansAnnotation} dossier(s) déposé(s) sans lien FPA : créés hors de notre parcours, ` +
+        "à rattacher manuellement par leur numéro."
+    );
+    console.log();
+  }
+
+  if (APPLY) {
+    console.log(`Rattachements appliqués : ${rapport.rattachementsAppliques}`);
+    console.log("Relancer une synchro pour recopier l'état réel des dossiers repointés.");
+  } else {
+    console.log(`Mode dry-run — aucune écriture. ${rapport.totaux.rattachement} rattachement(s) proposé(s).`);
+  }
+
+  await client.end();
+}
+
+main().catch(async (err) => {
+  console.error("Erreur fatale :", err);
+  await client.end();
+  process.exit(1);
+});

--- a/scripts/ops/sync-erreurs/reconcilier-dossiers.ts
+++ b/scripts/ops/sync-erreurs/reconcilier-dossiers.ts
@@ -59,7 +59,19 @@ async function main() {
     apply: APPLY,
   });
 
-  console.log(`Dossiers déposés examinés : ${rapport.lignes.length}`);
+  if (!rapport.scanComplet) {
+    console.error("=".repeat(72));
+    console.error(`SCAN INCOMPLET — ${rapport.scanIncompletRaison} (après ${rapport.pagesLues} page(s))`);
+    console.error(
+      "Aucune écriture n'a été faite : un dossier manquant pourrait transformer un conflit en\n" +
+        "rattachement automatique erroné. Relancer une fois DN de nouveau joignable."
+    );
+    console.error("=".repeat(72));
+    await client.end();
+    process.exit(1);
+  }
+
+  console.log(`Dossiers déposés examinés : ${rapport.lignes.length} (${rapport.pagesLues} page(s), scan complet)`);
   console.log();
   for (const [verdict, n] of Object.entries(rapport.totaux)) {
     if (n > 0) console.log(`  ${verdict.padEnd(26)} : ${n}`);
@@ -76,12 +88,12 @@ async function main() {
     console.log();
   }
 
-  const sansAnnotation = rapport.totaux.sans_annotation;
-  if (sansAnnotation > 0) {
-    console.log(
-      `${sansAnnotation} dossier(s) déposé(s) sans lien FPA : créés hors de notre parcours, ` +
-        "à rattacher manuellement par leur numéro."
-    );
+  const sansAnnotation = rapport.lignes.filter((l) => l.verdict === "sans_annotation");
+  if (sansAnnotation.length > 0) {
+    console.log("--- SANS LIEN FPA (créés hors de notre parcours, à rattacher par leur numéro) ---");
+    for (const l of sansAnnotation) {
+      console.log(`  #${l.dsNumber} (${l.state})`);
+    }
     console.log();
   }
 

--- a/scripts/ops/sync-erreurs/relink-eligibilite-dossier.ts
+++ b/scripts/ops/sync-erreurs/relink-eligibilite-dossier.ts
@@ -33,7 +33,13 @@ import { createOpsDb } from "../lib/db";
 import { DEMARCHE_IDS } from "../lib/env";
 import { graphqlClient } from "@/features/parcours/dossiers-ds/adapters/graphql/client";
 import { createRedactor } from "../lib/anonymize";
-import { parcoursPrevention, users, dossiersDemarchesSimplifiees } from "@/shared/database/schema";
+import {
+  parcoursPrevention,
+  users,
+  dossiersDemarchesSimplifiees,
+  dossiersDsTentatives,
+  ORIGINE_TENTATIVE,
+} from "@/shared/database/schema";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import { Status } from "@/shared/domain/value-objects/status.enum";
 import { getArg, getNumberArg, hasFlag } from "../lib/args";
@@ -115,7 +121,19 @@ async function dsNumberTracked(toNumber: string, excludeDossierId: string): Prom
 }
 
 /** Repointe le dossier vers le vrai numéro et remet les colonnes d'état à NULL (sync rebâtira). */
-async function applyRelink(dossierId: string, toNumber: string): Promise<boolean> {
+async function applyRelink(dossierId: string, toNumber: string, parcoursId: string): Promise<boolean> {
+  // Le registre doit connaître tout numéro rattaché, sinon l'invariant « un pointeur a
+  // toujours sa tentative » ne tient plus (ADR-0027).
+  await db
+    .insert(dossiersDsTentatives)
+    .values({
+      parcoursId,
+      step: Step.ELIGIBILITE,
+      dsNumber: toNumber,
+      origine: ORIGINE_TENTATIVE.MANUEL,
+    })
+    .onConflictDoNothing({ target: dossiersDsTentatives.dsNumber });
+
   const updated = await db
     .update(dossiersDemarchesSimplifiees)
     .set({
@@ -284,7 +302,7 @@ async function main() {
   let failed = 0;
   for (const r of relinks) {
     try {
-      const done = await applyRelink(r.dossierId, r.toNumber);
+      const done = await applyRelink(r.dossierId, r.toNumber, r.parcoursId);
       if (done) {
         ok++;
         console.log(`  OK relink ${redactUuid(r.parcoursId)} : #${r.fromNumber} → #${r.toNumber}`);

--- a/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsPanel.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import Link from "next/link";
 import {
   listDiagnosticsAction,
@@ -59,7 +59,31 @@ function daysAgoLabel(d: Date | string | null): string {
   return n <= 0 ? "aujourd'hui" : `il y a ${n} j`;
 }
 
-export default function DiagnosticsPanel() {
+/**
+ * Enveloppe de section : pleine largeur avec son propre conteneur quand la vue est autonome,
+ * simple bloc quand elle est rendue dans un onglet, qui fournit déjà le conteneur.
+ */
+function Section({
+  embedded,
+  className,
+  style,
+  children,
+}: {
+  embedded: boolean;
+  className: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}) {
+  if (embedded) return <div className="fr-mb-4w">{children}</div>;
+  return (
+    <section className={className} style={style}>
+      <div className="fr-container">{children}</div>
+    </section>
+  );
+}
+
+/** `embedded` : rendu dans l'onglet « États des parcours », sans en-tête ni conteneur propre. */
+export default function DiagnosticsPanel({ embedded = false }: { embedded?: boolean }) {
   const [diagnostics, setDiagnostics] = useState<DiagnosticsResult | null>(null);
   const [sante, setSante] = useState<DemarcheSante[] | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -104,247 +128,249 @@ export default function DiagnosticsPanel() {
 
   return (
     <>
-      <section className="fr-container-fluid fr-pt-4w" style={{ borderBottom: "1px solid var(--border-default-grey)" }}>
-        <div className="fr-container">
-          <AdminBreadcrumb currentPageLabel="Diagnostics DN" />
-          <div className="fr-grid-row fr-grid-row--middle fr-mb-4w">
-            <div className="fr-col">
-              <h1 className="fr-h2 fr-mb-1v">Diagnostics DN</h1>
-              <p style={{ color: "var(--text-mention-grey)", marginBottom: 0 }}>
-                État Démarches Numériques du dossier de l&apos;étape courante de chaque parcours actif (détection en
-                base, sans appel DN) et santé des démarches. Réservé aux super-administrateurs.
-              </p>
-            </div>
-            <div className="fr-col-auto" style={{ textAlign: "right" }}>
-              <button
-                type="button"
-                className="fr-btn fr-btn--secondary fr-mr-2w"
-                onClick={runProbe}
-                disabled={isProbing || isLoading}
-                title="Rafraîchit le « Verdict DN » en interrogeant DN en direct (sous-population en sync-erreur). Ne resynchronise pas le parcours : pour corriger un « Existe côté DN », utiliser « Lancer une synchro maintenant ».">
-                <span className="fr-icon-radar-line fr-icon--sm mr-2" aria-hidden="true" />
-                {isProbing ? "Sondage DN…" : "Sonder DN (erreurs)"}
-              </button>
-              <button type="button" className="fr-btn fr-btn--secondary" onClick={load} disabled={isLoading}>
-                <span className="fr-icon-refresh-line fr-icon--sm mr-2" aria-hidden="true" />
-                Rafraîchir
-              </button>
-            </div>
+      <Section
+        embedded={embedded}
+        className="fr-container-fluid fr-pt-4w"
+        style={{ borderBottom: "1px solid var(--border-default-grey)" }}>
+        {!embedded && <AdminBreadcrumb currentPageLabel="Diagnostics DN" />}
+        <div className="fr-grid-row fr-grid-row--middle fr-mb-4w">
+          <div className="fr-col">
+            {!embedded && (
+              <>
+                <h1 className="fr-h2 fr-mb-1v">Diagnostics DN</h1>
+                <p style={{ color: "var(--text-mention-grey)", marginBottom: 0 }}>
+                  État Démarches Numériques du dossier de l&apos;étape courante de chaque parcours actif (détection en
+                  base, sans appel DN) et santé des démarches. Réservé aux super-administrateurs.
+                </p>
+              </>
+            )}
           </div>
+          <div className="fr-col-auto" style={{ textAlign: "right" }}>
+            <button
+              type="button"
+              className="fr-btn fr-btn--secondary fr-mr-2w"
+              onClick={runProbe}
+              disabled={isProbing || isLoading}
+              title="Rafraîchit le « Verdict DN » en interrogeant DN en direct (sous-population en sync-erreur). Ne resynchronise pas le parcours : pour corriger un « Existe côté DN », utiliser « Lancer une synchro maintenant ».">
+              <span className="fr-icon-radar-line fr-icon--sm mr-2" aria-hidden="true" />
+              {isProbing ? "Sondage DN…" : "Sonder DN (erreurs)"}
+            </button>
+            <button type="button" className="fr-btn fr-btn--secondary" onClick={load} disabled={isLoading}>
+              <span className="fr-icon-refresh-line fr-icon--sm mr-2" aria-hidden="true" />
+              Rafraîchir
+            </button>
+          </div>
+        </div>
 
-          <details className="fr-mb-4w fr-text--sm" style={{ color: "var(--text-mention-grey)" }}>
-            <summary style={{ cursor: "pointer" }}>Comment lire ce tableau ?</summary>
-            <div className="fr-mt-1v" style={{ maxWidth: 880 }}>
-              <p className="fr-mb-1v">Deux lectures, deux sources qui peuvent diverger (et c&apos;est normal) :</p>
-              <ul className="fr-mb-1v">
-                <li>
-                  <strong>État</strong> : classification calculée <strong>en base</strong> (historique de
-                  synchronisation + état local). Aucun appel DN. <em>Âge</em> et <em>Détail</em> reflètent aussi
-                  l&apos;historique (dernière erreur), pas le live.
-                </li>
-                <li>
-                  <strong>Verdict DN</strong> : état <strong>réel côté Démarches Numériques</strong> au dernier sondage
-                  ou sync (<code>dn_probe_state</code>). « Sonder DN (erreurs) » le <strong>rafraîchit</strong> en
-                  direct, mais ne resynchronise pas.
-                </li>
-              </ul>
-              <p className="fr-mb-1v">Quand les deux divergent sur un « Sync erreur » :</p>
-              <ul className="fr-mb-0">
-                <li>
-                  <strong>+ Existe côté DN</strong> → le dossier est vivant (souvent réapparu) : il faut{" "}
-                  <strong>relancer une synchro</strong> (« Lancer une synchro maintenant »). Le miroir local rattrape et
-                  le parcours quitte l&apos;erreur. <strong>Pas de reset.</strong>
-                </li>
-                <li>
-                  <strong>+ Disparu côté DN</strong> → pointeur mort (drop-off ou dossier purgé) :{" "}
-                  <strong>reset</strong> (script <code>fix:eligibilite-sync-error</code>) ; voir « Analyser » pour un
-                  éventuel dossier sous un autre numéro.
-                </li>
-              </ul>
-            </div>
-          </details>
+        <details className="fr-mb-4w fr-text--sm" style={{ color: "var(--text-mention-grey)" }}>
+          <summary style={{ cursor: "pointer" }}>Comment lire ce tableau ?</summary>
+          <div className="fr-mt-1v" style={{ maxWidth: 880 }}>
+            <p className="fr-mb-1v">Deux lectures, deux sources qui peuvent diverger (et c&apos;est normal) :</p>
+            <ul className="fr-mb-1v">
+              <li>
+                <strong>État</strong> : classification calculée <strong>en base</strong> (historique de synchronisation
+                + état local). Aucun appel DN. <em>Âge</em> et <em>Détail</em> reflètent aussi l&apos;historique
+                (dernière erreur), pas le live.
+              </li>
+              <li>
+                <strong>Verdict DN</strong> : état <strong>réel côté Démarches Numériques</strong> au dernier sondage ou
+                sync (<code>dn_probe_state</code>). « Sonder DN (erreurs) » le <strong>rafraîchit</strong> en direct,
+                mais ne resynchronise pas.
+              </li>
+            </ul>
+            <p className="fr-mb-1v">Quand les deux divergent sur un « Sync erreur » :</p>
+            <ul className="fr-mb-0">
+              <li>
+                <strong>+ Existe côté DN</strong> → le dossier est vivant (souvent réapparu) : il faut{" "}
+                <strong>relancer une synchro</strong> (« Lancer une synchro maintenant »). Le miroir local rattrape et
+                le parcours quitte l&apos;erreur. <strong>Pas de reset.</strong>
+              </li>
+              <li>
+                <strong>+ Disparu côté DN</strong> → pointeur mort (drop-off ou dossier purgé) : <strong>reset</strong>{" "}
+                (script <code>fix:eligibilite-sync-error</code>) ; voir « Analyser » pour un éventuel dossier sous un
+                autre numéro.
+              </li>
+            </ul>
+          </div>
+        </details>
 
-          {error && (
-            <div className="fr-alert fr-alert--error fr-mb-4w">
-              <p>{error}</p>
-            </div>
-          )}
+        {error && (
+          <div className="fr-alert fr-alert--error fr-mb-4w">
+            <p>{error}</p>
+          </div>
+        )}
 
-          {probeMsg && (
-            <div className="fr-alert fr-alert--info fr-alert--sm fr-mb-4w">
-              <p>{probeMsg}</p>
-            </div>
-          )}
+        {probeMsg && (
+          <div className="fr-alert fr-alert--info fr-alert--sm fr-mb-4w">
+            <p>{probeMsg}</p>
+          </div>
+        )}
 
-          {/* Santé des démarches */}
-          {sante && (
-            <div className="fr-mb-4w">
-              <h2 className="fr-h6 fr-mb-2v">Santé des démarches</h2>
-              {sante.map((d) => {
-                const a = SANTE_ALERT[d.status];
-                const url = a.hasLink && d.demarcheNumber ? getDemarcheAdminUrl(d.demarcheNumber) : null;
-                const showNumber = d.demarcheNumber && d.status !== DemarcheSanteStatus.NON_DISPONIBLE;
-                return (
-                  <div key={d.step} className={`fr-alert fr-alert--sm ${a.cls} fr-mb-2v`}>
-                    <p>
-                      <strong>{STEP_LABELS[d.step]}</strong> : {a.label}
-                      {showNumber ? ` (#${d.demarcheNumber})` : ""}
-                      {d.errorDetail ? ` — ${d.errorDetail}` : ""}
-                      {url ? (
-                        <>
-                          {" — "}
-                          <a href={url} target="_blank" rel="noopener noreferrer">
-                            Ouvrir la démarche
-                          </a>
-                        </>
-                      ) : null}
-                    </p>
-                  </div>
-                );
-              })}
-              <p className="fr-text--xs fr-mt-1v" style={{ color: "var(--text-mention-grey)" }}>
-                « non créée » : la démarche n&apos;existe pas encore côté Démarches Numériques (étape pas encore
-                ouverte).
-              </p>
-            </div>
-          )}
+        {/* Santé des démarches */}
+        {sante && (
+          <div className="fr-mb-4w">
+            <h2 className="fr-h6 fr-mb-2v">Santé des démarches</h2>
+            {sante.map((d) => {
+              const a = SANTE_ALERT[d.status];
+              const url = a.hasLink && d.demarcheNumber ? getDemarcheAdminUrl(d.demarcheNumber) : null;
+              const showNumber = d.demarcheNumber && d.status !== DemarcheSanteStatus.NON_DISPONIBLE;
+              return (
+                <div key={d.step} className={`fr-alert fr-alert--sm ${a.cls} fr-mb-2v`}>
+                  <p>
+                    <strong>{STEP_LABELS[d.step]}</strong> : {a.label}
+                    {showNumber ? ` (#${d.demarcheNumber})` : ""}
+                    {d.errorDetail ? ` — ${d.errorDetail}` : ""}
+                    {url ? (
+                      <>
+                        {" — "}
+                        <a href={url} target="_blank" rel="noopener noreferrer">
+                          Ouvrir la démarche
+                        </a>
+                      </>
+                    ) : null}
+                  </p>
+                </div>
+              );
+            })}
+            <p className="fr-text--xs fr-mt-1v" style={{ color: "var(--text-mention-grey)" }}>
+              « non créée » : la démarche n&apos;existe pas encore côté Démarches Numériques (étape pas encore ouverte).
+            </p>
+          </div>
+        )}
 
-          {/* Filtres par état + compteurs (tous les états, même à 0) */}
-          {diagnostics && (
-            <div className="fr-mb-2w">
-              <ul className="fr-tags-group">
-                <li>
+        {/* Filtres par état + compteurs (tous les états, même à 0) */}
+        {diagnostics && (
+          <div className="fr-mb-2w">
+            <ul className="fr-tags-group">
+              <li>
+                <button
+                  type="button"
+                  className={`fr-tag ${filter === "all" ? "fr-tag--dismiss" : ""}`}
+                  aria-pressed={filter === "all"}
+                  onClick={() => setFilter("all")}>
+                  Tout ({diagnostics.total})
+                </button>
+              </li>
+              {DIAGNOSTIC_STATE_ORDER.map((s) => (
+                <li key={s}>
                   <button
                     type="button"
-                    className={`fr-tag ${filter === "all" ? "fr-tag--dismiss" : ""}`}
-                    aria-pressed={filter === "all"}
-                    onClick={() => setFilter("all")}>
-                    Tout ({diagnostics.total})
+                    className={`fr-tag ${filter === s ? "fr-tag--dismiss" : ""}`}
+                    aria-pressed={filter === s}
+                    onClick={() => setFilter(s)}>
+                    {DIAGNOSTIC_STATE_META[s].label} ({diagnostics.counts[s]})
                   </button>
                 </li>
-                {DIAGNOSTIC_STATE_ORDER.map((s) => (
-                  <li key={s}>
-                    <button
-                      type="button"
-                      className={`fr-tag ${filter === s ? "fr-tag--dismiss" : ""}`}
-                      aria-pressed={filter === s}
-                      onClick={() => setFilter(s)}>
-                      {DIAGNOSTIC_STATE_META[s].label} ({diagnostics.counts[s]})
-                    </button>
-                  </li>
-                ))}
-              </ul>
-              {filter !== "all" && (
-                <p className="fr-text--sm fr-mt-1v" style={{ color: "var(--text-mention-grey)" }}>
-                  {DIAGNOSTIC_STATE_META[filter].description}
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-      </section>
+              ))}
+            </ul>
+            {filter !== "all" && (
+              <p className="fr-text--sm fr-mt-1v" style={{ color: "var(--text-mention-grey)" }}>
+                {DIAGNOSTIC_STATE_META[filter].description}
+              </p>
+            )}
+          </div>
+        )}
+      </Section>
 
-      <section className="fr-container-fluid fr-py-4w bg-(--background-alt-blue-france)">
-        <div className="fr-container">
-          {isLoading ? (
-            <div className="flex justify-center items-center py-12">
-              <div className="text-gray-500">Chargement...</div>
-            </div>
-          ) : visibleRows.length === 0 ? (
-            <div className="fr-callout">
-              <p className="fr-callout__text">Aucun parcours pour ce filtre.</p>
-            </div>
-          ) : (
-            <div className="fr-table fr-table--bordered">
-              <div className="fr-table__wrapper">
-                <div className="fr-table__container">
-                  <div className="fr-table__content">
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Demandeur</th>
-                          <th>Étape / statut</th>
-                          <th>État</th>
-                          <th>Dossier DN</th>
-                          <th>Verdict DN</th>
-                          <th>Âge (j)</th>
-                          <th>Détail</th>
-                          <th>Action</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {visibleRows.map((r) => {
-                          const meta = DIAGNOSTIC_STATE_META[r.state];
-                          return (
-                            <tr key={`${r.state}-${r.parcoursId}`}>
-                              <td>{userLabel(r)}</td>
-                              <td>
-                                {STEP_LABELS[r.currentStep]} / {r.currentStatus}
-                              </td>
-                              <td>
-                                <span className={`fr-badge fr-badge--sm ${SEVERITY_BADGE[meta.severity]}`}>
-                                  {meta.label}
-                                </span>
-                              </td>
-                              <td>
-                                {r.dsNumber ? (
-                                  <>
-                                    <a
-                                      href={getDossierDsDemandeUrl(Number(r.dsNumber))}
-                                      target="_blank"
-                                      rel="noopener noreferrer">
-                                      #{r.dsNumber}
-                                    </a>{" "}
-                                    ({r.dsStatus ?? "?"})
-                                  </>
-                                ) : (
-                                  "-"
-                                )}
-                              </td>
-                              <td style={{ fontSize: "0.8rem" }}>
+      <Section embedded={embedded} className="fr-container-fluid fr-py-4w bg-(--background-alt-blue-france)">
+        {isLoading ? (
+          <div className="flex justify-center items-center py-12">
+            <div className="text-gray-500">Chargement...</div>
+          </div>
+        ) : visibleRows.length === 0 ? (
+          <div className="fr-callout">
+            <p className="fr-callout__text">Aucun parcours pour ce filtre.</p>
+          </div>
+        ) : (
+          <div className="fr-table fr-table--bordered">
+            <div className="fr-table__wrapper">
+              <div className="fr-table__container">
+                <div className="fr-table__content">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Demandeur</th>
+                        <th>Étape / statut</th>
+                        <th>État</th>
+                        <th>Dossier DN</th>
+                        <th>Verdict DN</th>
+                        <th>Âge (j)</th>
+                        <th>Détail</th>
+                        <th>Action</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {visibleRows.map((r) => {
+                        const meta = DIAGNOSTIC_STATE_META[r.state];
+                        return (
+                          <tr key={`${r.state}-${r.parcoursId}`}>
+                            <td>{userLabel(r)}</td>
+                            <td>
+                              {STEP_LABELS[r.currentStep]} / {r.currentStatus}
+                            </td>
+                            <td>
+                              <span className={`fr-badge fr-badge--sm ${SEVERITY_BADGE[meta.severity]}`}>
+                                {meta.label}
+                              </span>
+                            </td>
+                            <td>
+                              {r.dsNumber ? (
+                                <>
+                                  <a
+                                    href={getDossierDsDemandeUrl(Number(r.dsNumber))}
+                                    target="_blank"
+                                    rel="noopener noreferrer">
+                                    #{r.dsNumber}
+                                  </a>{" "}
+                                  ({r.dsStatus ?? "?"})
+                                </>
+                              ) : (
+                                "-"
+                              )}
+                            </td>
+                            <td style={{ fontSize: "0.8rem" }}>
+                              <span
+                                className={`fr-badge fr-badge--sm ${SEVERITY_BADGE[DN_VERDICT_META[r.dnVerdict].severity]}`}>
+                                {DN_VERDICT_META[r.dnVerdict].label}
+                              </span>
+                              {r.dnProbeState && (
                                 <span
-                                  className={`fr-badge fr-badge--sm ${SEVERITY_BADGE[DN_VERDICT_META[r.dnVerdict].severity]}`}>
-                                  {DN_VERDICT_META[r.dnVerdict].label}
+                                  style={{ display: "block", color: "var(--text-mention-grey)" }}
+                                  title={r.dnProbeAt ? new Date(r.dnProbeAt).toLocaleString("fr-FR") : ""}>
+                                  {r.dnProbeState}
+                                  {r.dnProbeAt ? ` · ${daysAgoLabel(r.dnProbeAt)}` : ""}
                                 </span>
-                                {r.dnProbeState && (
-                                  <span
-                                    style={{ display: "block", color: "var(--text-mention-grey)" }}
-                                    title={r.dnProbeAt ? new Date(r.dnProbeAt).toLocaleString("fr-FR") : ""}>
-                                    {r.dnProbeState}
-                                    {r.dnProbeAt ? ` · ${daysAgoLabel(r.dnProbeAt)}` : ""}
-                                  </span>
-                                )}
-                              </td>
-                              <td>{r.ageDays ?? "-"}</td>
-                              <td
-                                style={{
-                                  maxWidth: 320,
-                                  fontSize: "0.8rem",
-                                  color: "var(--text-mention-grey)",
-                                  whiteSpace: "normal",
-                                  overflowWrap: "anywhere",
-                                }}>
-                                {r.detail ?? "-"}
-                              </td>
-                              <td>
-                                <Link
-                                  href={`/administration/diagnostics/${r.parcoursId}`}
-                                  className="fr-btn fr-btn--secondary fr-btn--sm">
-                                  Analyser
-                                </Link>
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
+                              )}
+                            </td>
+                            <td>{r.ageDays ?? "-"}</td>
+                            <td
+                              style={{
+                                maxWidth: 320,
+                                fontSize: "0.8rem",
+                                color: "var(--text-mention-grey)",
+                                whiteSpace: "normal",
+                                overflowWrap: "anywhere",
+                              }}>
+                              {r.detail ?? "-"}
+                            </td>
+                            <td>
+                              <Link
+                                href={`/administration/diagnostics/${r.parcoursId}`}
+                                className="fr-btn fr-btn--secondary fr-btn--sm">
+                                Analyser
+                              </Link>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
                 </div>
               </div>
             </div>
-          )}
-        </div>
-      </section>
+          </div>
+        )}
+      </Section>
     </>
   );
 }

--- a/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
@@ -20,8 +20,10 @@ const AIDE_ONGLET: Record<Onglet, { titre: string; contenu: ReactNode }> = {
     contenu: (
       <>
         <p className="fr-mb-1v">
-          Ouvrez le dossier pour relever le nom et l&apos;adresse e-mail du demandeur, cherchez-le dans l&apos;espace
-          agent, puis rattachez-le depuis son dossier : <strong>Gérer → Rattacher un dossier DN</strong>.
+          L&apos;analyse cherche pour vous à qui appartient chaque dossier, en comparant adresse, téléphone, e-mail et
+          identité. Quand un seul demandeur correspond, le bouton <strong>Rattacher</strong> suffit. Quand plusieurs
+          correspondent, choisissez lequel : la correspondance est un indice, pas une preuve — vérifiez avec
+          <strong> Voir le détail</strong> avant de trancher.
         </p>
         <p className="fr-mb-1v">
           <strong>Si le demandeur a déjà un dossier pour cette étape</strong>, tout dépend de son état : tant qu&apos;il
@@ -30,8 +32,8 @@ const AIDE_ONGLET: Record<Onglet, { titre: string; contenu: ReactNode }> = {
           même étape se tranchent dans l&apos;onglet « À arbitrer ».
         </p>
         <p className="fr-mb-0">
-          Si le demandeur n&apos;existe pas chez nous — dossier de test, démarche remplie hors dispositif — écartez la
-          ligne. Traitez en priorité les dossiers acceptés ou en instruction : ce sont des demandeurs dont le parcours
+          Si aucun demandeur ne correspond — dossier de test, démarche remplie hors dispositif — écartez la ligne.
+          Traitez en priorité les dossiers acceptés ou en instruction : ce sont des demandeurs dont le parcours
           n&apos;avance pas alors que leur droit est acquis.
         </p>
       </>
@@ -47,8 +49,9 @@ const AIDE_ONGLET: Record<Onglet, { titre: string; contenu: ReactNode }> = {
         </p>
         <p className="fr-mb-0">
           Tranchez d&apos;abord côté Démarches Numériques (classement sans suite du doublon, par exemple), puis
-          rattachez le dossier retenu. <strong>Les deux boutons ci-dessous ne modifient aucune donnée</strong> : ils
-          referment le signalement. Un cas refermé se rouvre si une prochaine analyse lui trouve un autre verdict.
+          rattachez le dossier retenu.{" "}
+          <strong>« Marquer comme traité » et « Écarter » ne modifient aucune donnée</strong> : ils referment le
+          signalement. Un cas refermé se rouvre si une prochaine analyse lui trouve un autre verdict.
         </p>
       </>
     ),
@@ -199,6 +202,7 @@ export default function DiagnosticsTabs() {
                 <FileReconciliation
                   observations={files?.aRattacher ?? []}
                   messageVide="Aucun dossier en attente de rattachement."
+                  variante="rattacher"
                   onResolved={charger}
                 />
               )}
@@ -207,6 +211,7 @@ export default function DiagnosticsTabs() {
                 <FileReconciliation
                   observations={files?.aArbitrer ?? []}
                   messageVide="Aucun conflit à arbitrer."
+                  variante="arbitrer"
                   onResolved={charger}
                 />
               )}

--- a/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import {
   analyserReconciliationAction,
   listerFilesReconciliationAction,
@@ -12,6 +12,52 @@ import { FileReconciliation } from "./FileReconciliation";
 import { AdminBreadcrumb } from "../../shared/components/AdminBreadcrumb";
 
 type Onglet = "rattacher" | "arbitrer" | "etats";
+
+/** Ce que chaque onglet contient et ce qu'on est censé y faire. */
+const AIDE_ONGLET: Record<Onglet, { titre: string; contenu: ReactNode }> = {
+  rattacher: {
+    titre: "Des dossiers existent côté Démarches Numériques sans qu'aucun parcours ne les suive",
+    contenu: (
+      <>
+        <p className="fr-mb-1v">
+          Ouvrez le dossier pour relever le nom et l&apos;adresse e-mail du demandeur, cherchez-le dans l&apos;espace
+          agent, puis rattachez-le depuis son dossier : <strong>Gérer → Rattacher un dossier DN</strong>.
+        </p>
+        <p className="fr-mb-0">
+          Si le demandeur n&apos;existe pas chez nous — dossier de test, démarche remplie hors dispositif — écartez la
+          ligne. Traitez en priorité les dossiers acceptés ou en instruction : ce sont des demandeurs dont le parcours
+          n&apos;avance pas alors que leur droit est acquis.
+        </p>
+      </>
+    ),
+  },
+  arbitrer: {
+    titre: "Le rattachement s'est arrêté volontairement : il y a une décision à prendre",
+    contenu: (
+      <>
+        <p className="fr-mb-1v">
+          Deux dossiers déposés pour une même étape, un lien FPA modifié à la main, ou un numéro déjà rattaché à un
+          autre demandeur. Aucune règle ne peut trancher à votre place.
+        </p>
+        <p className="fr-mb-0">
+          Tranchez d&apos;abord côté Démarches Numériques (classement sans suite du doublon, par exemple), puis
+          rattachez le dossier retenu. <strong>Les deux boutons ci-dessous ne modifient aucune donnée</strong> : ils
+          referment le signalement. Un cas refermé se rouvre si une prochaine analyse lui trouve un autre verdict.
+        </p>
+      </>
+    ),
+  },
+  etats: {
+    titre: "Vue détaillée de l'état de chaque parcours actif",
+    contenu: (
+      <p className="fr-mb-0">
+        Calculée en base, sans interroger Démarches Numériques. La plupart de ces états sont <strong>normaux</strong> —
+        un prérempli non déposé, notamment, est invisible de l&apos;API et ne signale aucun problème. À utiliser pour
+        investiguer un cas précis, pas comme liste de travail.
+      </p>
+    ),
+  },
+};
 
 const STEPS_ANALYSABLES = [Step.ELIGIBILITE, Step.DIAGNOSTIC, Step.DEVIS];
 
@@ -111,6 +157,11 @@ export default function DiagnosticsTabs() {
             </ul>
 
             <div className="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel">
+              <div className="fr-callout fr-callout--blue-ecume fr-mb-3w">
+                <h3 className="fr-callout__title fr-text--md">{AIDE_ONGLET[onglet].titre}</h3>
+                <div className="fr-callout__text fr-text--sm">{AIDE_ONGLET[onglet].contenu}</div>
+              </div>
+
               {onglet !== "etats" && (
                 <div className="fr-mb-3w">
                   <p className="fr-text--sm fr-mb-1w">

--- a/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
@@ -9,6 +9,7 @@ import {
 import { Step, STEP_LABELS } from "@/shared/domain/value-objects/step.enum";
 import DiagnosticsPanel from "./DiagnosticsPanel";
 import { FileReconciliation } from "./FileReconciliation";
+import { AdminBreadcrumb } from "../../shared/components/AdminBreadcrumb";
 
 type Onglet = "rattacher" | "arbitrer" | "etats";
 
@@ -71,75 +72,93 @@ export default function DiagnosticsTabs() {
 
   return (
     <>
-      {erreur && (
-        <div className="fr-alert fr-alert--error fr-mb-2w">
-          <p>{erreur}</p>
+      <section className="fr-container-fluid fr-pt-4w" style={{ borderBottom: "1px solid var(--border-default-grey)" }}>
+        <div className="fr-container">
+          <AdminBreadcrumb currentPageLabel="Diagnostics DN" />
+          <div className="fr-mb-4w">
+            <h1 className="fr-h2 fr-mb-1v">Diagnostics DN</h1>
+            <p style={{ color: "var(--text-mention-grey)", marginBottom: 0 }}>
+              Ce qui demande une action sur les dossiers Démarches Numériques : ce qu&apos;il faut rattacher à un
+              parcours, et ce qu&apos;il faut arbitrer. Réservé aux super-administrateurs.
+            </p>
+          </div>
         </div>
-      )}
+      </section>
 
-      <div className="fr-tabs">
-        <ul className="fr-tabs__list" role="tablist" aria-label="Diagnostic Démarches Numériques">
-          {onglets.map((o) => (
-            <li key={o.id} role="presentation">
-              <button
-                type="button"
-                className="fr-tabs__tab"
-                role="tab"
-                aria-selected={onglet === o.id}
-                tabIndex={onglet === o.id ? 0 : -1}
-                onClick={() => setOnglet(o.id)}>
-                {o.label}
-              </button>
-            </li>
-          ))}
-        </ul>
-
-        <div className="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel">
-          {onglet !== "etats" && (
-            <div className="fr-mb-3w">
-              <p className="fr-text--sm fr-mb-1w">
-                L&apos;analyse interroge Démarches Numériques et remplit ces deux files. Elle ne modifie aucun dossier.
-              </p>
-              <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
-                {STEPS_ANALYSABLES.map((step) => (
-                  <li key={step}>
-                    <button
-                      type="button"
-                      className="fr-btn fr-btn--secondary fr-btn--sm"
-                      disabled={analyseEnCours !== null}
-                      onClick={() => analyser(step)}>
-                      {analyseEnCours === step ? "Analyse en cours…" : `Analyser ${STEP_LABELS[step]}`}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-              {messageAnalyse && (
-                <div className="fr-alert fr-alert--info fr-alert--sm fr-mt-2w">
-                  <p>{messageAnalyse}</p>
-                </div>
-              )}
+      <section className="fr-container-fluid fr-py-4w bg-(--background-alt-blue-france)">
+        <div className="fr-container">
+          {erreur && (
+            <div className="fr-alert fr-alert--error fr-mb-2w">
+              <p>{erreur}</p>
             </div>
           )}
 
-          {onglet === "rattacher" && (
-            <FileReconciliation
-              observations={files?.aRattacher ?? []}
-              messageVide="Aucun dossier en attente de rattachement."
-              onResolved={charger}
-            />
-          )}
+          <div className="fr-tabs">
+            <ul className="fr-tabs__list" role="tablist" aria-label="Diagnostic Démarches Numériques">
+              {onglets.map((o) => (
+                <li key={o.id} role="presentation">
+                  <button
+                    type="button"
+                    className="fr-tabs__tab"
+                    role="tab"
+                    aria-selected={onglet === o.id}
+                    tabIndex={onglet === o.id ? 0 : -1}
+                    onClick={() => setOnglet(o.id)}>
+                    {o.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
 
-          {onglet === "arbitrer" && (
-            <FileReconciliation
-              observations={files?.aArbitrer ?? []}
-              messageVide="Aucun conflit à arbitrer."
-              onResolved={charger}
-            />
-          )}
+            <div className="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel">
+              {onglet !== "etats" && (
+                <div className="fr-mb-3w">
+                  <p className="fr-text--sm fr-mb-1w">
+                    L&apos;analyse interroge Démarches Numériques et remplit ces deux files. Elle ne modifie aucun
+                    dossier.
+                  </p>
+                  <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
+                    {STEPS_ANALYSABLES.map((step) => (
+                      <li key={step}>
+                        <button
+                          type="button"
+                          className="fr-btn fr-btn--secondary fr-btn--sm"
+                          disabled={analyseEnCours !== null}
+                          onClick={() => analyser(step)}>
+                          {analyseEnCours === step ? "Analyse en cours…" : `Analyser ${STEP_LABELS[step]}`}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                  {messageAnalyse && (
+                    <div className="fr-alert fr-alert--info fr-alert--sm fr-mt-2w">
+                      <p>{messageAnalyse}</p>
+                    </div>
+                  )}
+                </div>
+              )}
 
-          {onglet === "etats" && <DiagnosticsPanel />}
+              {onglet === "rattacher" && (
+                <FileReconciliation
+                  observations={files?.aRattacher ?? []}
+                  messageVide="Aucun dossier en attente de rattachement."
+                  onResolved={charger}
+                />
+              )}
+
+              {onglet === "arbitrer" && (
+                <FileReconciliation
+                  observations={files?.aArbitrer ?? []}
+                  messageVide="Aucun conflit à arbitrer."
+                  onResolved={charger}
+                />
+              )}
+
+              {onglet === "etats" && <DiagnosticsPanel embedded />}
+            </div>
+          </div>
         </div>
-      </div>
+      </section>
     </>
   );
 }

--- a/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
@@ -23,6 +23,12 @@ const AIDE_ONGLET: Record<Onglet, { titre: string; contenu: ReactNode }> = {
           Ouvrez le dossier pour relever le nom et l&apos;adresse e-mail du demandeur, cherchez-le dans l&apos;espace
           agent, puis rattachez-le depuis son dossier : <strong>Gérer → Rattacher un dossier DN</strong>.
         </p>
+        <p className="fr-mb-1v">
+          <strong>Si le demandeur a déjà un dossier pour cette étape</strong>, tout dépend de son état : tant qu&apos;il
+          n&apos;a jamais été déposé (un simple formulaire prérempli), le rattachement le remplace et l&apos;ancien
+          numéro reste conservé. S&apos;il a bien été déposé, le rattachement est refusé — deux dossiers réels pour une
+          même étape se tranchent dans l&apos;onglet « À arbitrer ».
+        </p>
         <p className="fr-mb-0">
           Si le demandeur n&apos;existe pas chez nous — dossier de test, démarche remplie hors dispositif — écartez la
           ligne. Traitez en priorité les dossiers acceptés ou en instruction : ce sont des demandeurs dont le parcours

--- a/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/DiagnosticsTabs.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  analyserReconciliationAction,
+  listerFilesReconciliationAction,
+  type FilesReconciliation,
+} from "@/features/backoffice/administration/diagnostics/actions/reconciliation.actions";
+import { Step, STEP_LABELS } from "@/shared/domain/value-objects/step.enum";
+import DiagnosticsPanel from "./DiagnosticsPanel";
+import { FileReconciliation } from "./FileReconciliation";
+
+type Onglet = "rattacher" | "arbitrer" | "etats";
+
+const STEPS_ANALYSABLES = [Step.ELIGIBILITE, Step.DIAGNOSTIC, Step.DEVIS];
+
+/**
+ * Diagnostic DN en trois onglets (ADR-0027). Deux files de travail — ce qu'il faut rattacher,
+ * ce qu'il faut arbitrer — et la vue détaillée par état, qui reste utile mais n'est plus le
+ * point d'entrée : la plupart de ses états sont normaux et ne demandent rien.
+ */
+export default function DiagnosticsTabs() {
+  const [onglet, setOnglet] = useState<Onglet>("rattacher");
+  const [files, setFiles] = useState<FilesReconciliation | null>(null);
+  const [erreur, setErreur] = useState<string | null>(null);
+  const [analyseEnCours, setAnalyseEnCours] = useState<Step | null>(null);
+  const [messageAnalyse, setMessageAnalyse] = useState<string | null>(null);
+
+  const charger = useCallback(async () => {
+    const result = await listerFilesReconciliationAction();
+    if (result.success) setFiles(result.data);
+    else setErreur(result.error);
+  }, []);
+
+  useEffect(() => {
+    void charger();
+  }, [charger]);
+
+  async function analyser(step: Step) {
+    setErreur(null);
+    setMessageAnalyse(null);
+    setAnalyseEnCours(step);
+
+    try {
+      const result = await analyserReconciliationAction(step);
+      if (!result.success) {
+        setErreur(result.error);
+        return;
+      }
+
+      const { examines, scanComplet, raison } = result.data;
+      setMessageAnalyse(
+        scanComplet
+          ? `${STEP_LABELS[step]} : ${examines} dossier(s) déposé(s) examiné(s).`
+          : `${STEP_LABELS[step]} : analyse interrompue (${raison}). Les résultats sont partiels, à relancer.`
+      );
+      await charger();
+    } finally {
+      setAnalyseEnCours(null);
+    }
+  }
+
+  const nbRattacher = files?.aRattacher.length ?? 0;
+  const nbArbitrer = files?.aArbitrer.length ?? 0;
+
+  const onglets: Array<{ id: Onglet; label: string }> = [
+    { id: "rattacher", label: `À rattacher${nbRattacher ? ` (${nbRattacher})` : ""}` },
+    { id: "arbitrer", label: `À arbitrer${nbArbitrer ? ` (${nbArbitrer})` : ""}` },
+    { id: "etats", label: "États des parcours" },
+  ];
+
+  return (
+    <>
+      {erreur && (
+        <div className="fr-alert fr-alert--error fr-mb-2w">
+          <p>{erreur}</p>
+        </div>
+      )}
+
+      <div className="fr-tabs">
+        <ul className="fr-tabs__list" role="tablist" aria-label="Diagnostic Démarches Numériques">
+          {onglets.map((o) => (
+            <li key={o.id} role="presentation">
+              <button
+                type="button"
+                className="fr-tabs__tab"
+                role="tab"
+                aria-selected={onglet === o.id}
+                tabIndex={onglet === o.id ? 0 : -1}
+                onClick={() => setOnglet(o.id)}>
+                {o.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel">
+          {onglet !== "etats" && (
+            <div className="fr-mb-3w">
+              <p className="fr-text--sm fr-mb-1w">
+                L&apos;analyse interroge Démarches Numériques et remplit ces deux files. Elle ne modifie aucun dossier.
+              </p>
+              <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
+                {STEPS_ANALYSABLES.map((step) => (
+                  <li key={step}>
+                    <button
+                      type="button"
+                      className="fr-btn fr-btn--secondary fr-btn--sm"
+                      disabled={analyseEnCours !== null}
+                      onClick={() => analyser(step)}>
+                      {analyseEnCours === step ? "Analyse en cours…" : `Analyser ${STEP_LABELS[step]}`}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {messageAnalyse && (
+                <div className="fr-alert fr-alert--info fr-alert--sm fr-mt-2w">
+                  <p>{messageAnalyse}</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {onglet === "rattacher" && (
+            <FileReconciliation
+              observations={files?.aRattacher ?? []}
+              messageVide="Aucun dossier en attente de rattachement."
+              onResolved={charger}
+            />
+          )}
+
+          {onglet === "arbitrer" && (
+            <FileReconciliation
+              observations={files?.aArbitrer ?? []}
+              messageVide="Aucun conflit à arbitrer."
+              onResolved={charger}
+            />
+          )}
+
+          {onglet === "etats" && <DiagnosticsPanel />}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(backoffice)/administration/diagnostics/components/FileReconciliation.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/FileReconciliation.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import Link from "next/link";
 import { resoudreObservationAction } from "@/features/backoffice/administration/diagnostics/actions/reconciliation.actions";
+import { InspectionDossierDn } from "./InspectionDossierDn";
 import { VERDICT_LABELS } from "@/features/backoffice/administration/diagnostics/domain/diagnostics.types";
 import { RESOLUTION_OBSERVATION } from "@/shared/database/schema";
 import { STEP_LABELS } from "@/shared/domain/value-objects/step.enum";
@@ -25,6 +26,8 @@ function demandeurLabel(o: ObservationAvecDemandeur): string {
 export function FileReconciliation({ observations, messageVide, onResolved }: FileReconciliationProps) {
   const [enCours, setEnCours] = useState<string | null>(null);
   const [erreur, setErreur] = useState<string | null>(null);
+  // Inspection dépliée à la demande : chaque ouverture coûte un appel DN.
+  const [inspecte, setInspecte] = useState<string | null>(null);
 
   async function resoudre(
     dsNumber: string,
@@ -72,49 +75,68 @@ export function FileReconciliation({ observations, messageVide, onResolved }: Fi
             {observations.map((o) => {
               const meta = VERDICT_LABELS[o.verdict] ?? { label: o.verdict, explication: "" };
               return (
-                <tr key={o.dsNumber}>
-                  <td>
-                    <a href={getDossierDsDemandeUrl(Number(o.dsNumber))} target="_blank" rel="noopener noreferrer">
-                      #{o.dsNumber}
-                    </a>
-                    {o.dsState && <div className="fr-text--xs fr-mb-0">{o.dsState}</div>}
-                  </td>
-                  <td>
-                    <strong>{meta.label}</strong>
-                    <div className="fr-text--xs fr-mb-0">{meta.explication}</div>
-                    {o.detail && <div className="fr-text--xs fr-mb-0">{o.detail}</div>}
-                  </td>
-                  <td>
-                    {o.parcoursId ? (
-                      <Link href={`/espace-agent/dossiers/${o.parcoursId}`}>{demandeurLabel(o)}</Link>
-                    ) : (
-                      <span className="fr-text--xs">{demandeurLabel(o)}</span>
-                    )}
-                  </td>
-                  <td>{o.step ? STEP_LABELS[o.step] : "—"}</td>
-                  <td>
-                    <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
-                      <li>
-                        <button
-                          type="button"
-                          className="fr-btn fr-btn--secondary fr-btn--sm"
-                          disabled={enCours === o.dsNumber}
-                          onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ARBITRE)}>
-                          Marquer comme traité
-                        </button>
-                      </li>
-                      <li>
-                        <button
-                          type="button"
-                          className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm"
-                          disabled={enCours === o.dsNumber}
-                          onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ECARTE)}>
-                          Écarter
-                        </button>
-                      </li>
-                    </ul>
-                  </td>
-                </tr>
+                <Fragment key={o.dsNumber}>
+                  <tr>
+                    <td>
+                      <a href={getDossierDsDemandeUrl(Number(o.dsNumber))} target="_blank" rel="noopener noreferrer">
+                        #{o.dsNumber}
+                      </a>
+                      {o.dsState && <div className="fr-text--xs fr-mb-0">{o.dsState}</div>}
+                    </td>
+                    <td>
+                      <strong>{meta.label}</strong>
+                      <div className="fr-text--xs fr-mb-0">{meta.explication}</div>
+                      {o.detail && <div className="fr-text--xs fr-mb-0">{o.detail}</div>}
+                    </td>
+                    <td>
+                      {o.parcoursId ? (
+                        <Link href={`/espace-agent/dossiers/${o.parcoursId}`}>{demandeurLabel(o)}</Link>
+                      ) : (
+                        <span className="fr-text--xs">{demandeurLabel(o)}</span>
+                      )}
+                    </td>
+                    <td>{o.step ? STEP_LABELS[o.step] : "—"}</td>
+                    <td>
+                      <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
+                        <li>
+                          <button
+                            type="button"
+                            className="fr-btn fr-btn--secondary fr-btn--sm"
+                            aria-expanded={inspecte === o.dsNumber}
+                            onClick={() => setInspecte(inspecte === o.dsNumber ? null : o.dsNumber)}>
+                            {inspecte === o.dsNumber ? "Masquer" : "Identifier"}
+                          </button>
+                        </li>
+                        <li>
+                          <button
+                            type="button"
+                            className="fr-btn fr-btn--secondary fr-btn--sm"
+                            disabled={enCours === o.dsNumber}
+                            onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ARBITRE)}>
+                            Marquer comme traité
+                          </button>
+                        </li>
+                        <li>
+                          <button
+                            type="button"
+                            className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm"
+                            disabled={enCours === o.dsNumber}
+                            onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ECARTE)}>
+                            Écarter
+                          </button>
+                        </li>
+                      </ul>
+                    </td>
+                  </tr>
+
+                  {inspecte === o.dsNumber && (
+                    <tr>
+                      <td colSpan={5}>
+                        <InspectionDossierDn dsNumber={o.dsNumber} />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               );
             })}
           </tbody>

--- a/src/app/(backoffice)/administration/diagnostics/components/FileReconciliation.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/FileReconciliation.tsx
@@ -3,46 +3,61 @@
 import { Fragment, useState } from "react";
 import Link from "next/link";
 import { resoudreObservationAction } from "@/features/backoffice/administration/diagnostics/actions/reconciliation.actions";
+import { rattacherDossierDnAction } from "@/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions";
 import { InspectionDossierDn } from "./InspectionDossierDn";
 import { VERDICT_LABELS } from "@/features/backoffice/administration/diagnostics/domain/diagnostics.types";
 import { RESOLUTION_OBSERVATION } from "@/shared/database/schema";
 import { STEP_LABELS } from "@/shared/domain/value-objects/step.enum";
 import { getDossierDsDemandeUrl } from "@/features/parcours/dossiers-ds/utils";
+import { MOTIF_LABELS, type CandidatDemandeur } from "@/features/parcours/dossiers-ds/domain/types/inspection.types";
 import type { ObservationAvecDemandeur } from "@/shared/database/repositories";
 
 interface FileReconciliationProps {
   observations: ObservationAvecDemandeur[];
   /** Texte affiché quand la file est vide — c'est le cas nominal, il doit rassurer. */
   messageVide: string;
+  /**
+   * « rattacher » : le dossier cherche son demandeur, l'action est de le lui rendre.
+   * « arbitrer » : le demandeur est connu, c'est la situation qui demande une décision.
+   */
+  variante: "rattacher" | "arbitrer";
   onResolved: () => void;
+}
+
+function nomCandidat(c: CandidatDemandeur): string {
+  return [c.prenom, c.nom].filter(Boolean).join(" ").trim() || c.email || `Parcours ${c.parcoursId.slice(0, 8)}`;
 }
 
 function demandeurLabel(o: ObservationAvecDemandeur): string {
   const nom = [o.demandeurPrenom, o.demandeurNom].filter(Boolean).join(" ").trim();
-  if (nom) return nom;
-  return o.parcoursId ? "Demandeur inconnu" : "Aucun parcours associé";
+  return nom || "Demandeur inconnu";
 }
 
-export function FileReconciliation({ observations, messageVide, onResolved }: FileReconciliationProps) {
+export function FileReconciliation({ observations, messageVide, variante, onResolved }: FileReconciliationProps) {
   const [enCours, setEnCours] = useState<string | null>(null);
   const [erreur, setErreur] = useState<string | null>(null);
-  // Inspection dépliée à la demande : chaque ouverture coûte un appel DN.
-  const [inspecte, setInspecte] = useState<string | null>(null);
+  // Détail DN déplié à la demande : chaque ouverture coûte un appel à Démarches Numériques.
+  const [detaille, setDetaille] = useState<string | null>(null);
 
-  async function resoudre(
-    dsNumber: string,
-    resolution: (typeof RESOLUTION_OBSERVATION)[keyof typeof RESOLUTION_OBSERVATION]
-  ) {
+  async function agir(dsNumber: string, operation: () => Promise<{ success: boolean; error?: string }>) {
     setErreur(null);
     setEnCours(dsNumber);
     try {
-      const result = await resoudreObservationAction(dsNumber, resolution);
+      const result = await operation();
       if (result.success) onResolved();
-      else setErreur(result.error);
+      else setErreur(result.error ?? "Opération impossible");
     } finally {
       setEnCours(null);
     }
   }
+
+  const resoudre = (
+    dsNumber: string,
+    resolution: (typeof RESOLUTION_OBSERVATION)[keyof typeof RESOLUTION_OBSERVATION]
+  ) => agir(dsNumber, () => resoudreObservationAction(dsNumber, resolution));
+
+  const rattacher = (dsNumber: string, parcoursId: string) =>
+    agir(dsNumber, () => rattacherDossierDnAction(parcoursId, dsNumber));
 
   if (observations.length === 0) {
     return (
@@ -66,7 +81,7 @@ export function FileReconciliation({ observations, messageVide, onResolved }: Fi
             <tr>
               <th scope="col">Dossier DN</th>
               <th scope="col">Situation</th>
-              <th scope="col">Demandeur</th>
+              <th scope="col">{variante === "rattacher" ? "Demandeur probable" : "Demandeur"}</th>
               <th scope="col">Étape</th>
               <th scope="col">Actions</th>
             </tr>
@@ -74,6 +89,10 @@ export function FileReconciliation({ observations, messageVide, onResolved }: Fi
           <tbody>
             {observations.map((o) => {
               const meta = VERDICT_LABELS[o.verdict] ?? { label: o.verdict, explication: "" };
+              const candidats = o.candidats ?? [];
+              const candidatUnique = variante === "rattacher" && candidats.length === 1 ? candidats[0] : null;
+              const occupe = enCours === o.dsNumber;
+
               return (
                 <Fragment key={o.dsNumber}>
                   <tr>
@@ -88,39 +107,92 @@ export function FileReconciliation({ observations, messageVide, onResolved }: Fi
                       <div className="fr-text--xs fr-mb-0">{meta.explication}</div>
                       {o.detail && <div className="fr-text--xs fr-mb-0">{o.detail}</div>}
                     </td>
+
                     <td>
+                      {/* Le demandeur est connu (files d'arbitrage) : rien à rapprocher. */}
                       {o.parcoursId ? (
                         <Link href={`/espace-agent/dossiers/${o.parcoursId}`}>{demandeurLabel(o)}</Link>
+                      ) : candidats.length === 0 ? (
+                        <span className="fr-text--xs">Aucune correspondance trouvée</span>
                       ) : (
-                        <span className="fr-text--xs">{demandeurLabel(o)}</span>
+                        <>
+                          {candidats.length > 1 && (
+                            <p className="fr-badge fr-badge--warning fr-badge--sm fr-mb-1w">
+                              {candidats.length} demandeurs possibles
+                            </p>
+                          )}
+                          <ul className="fr-raw-list">
+                            {candidats.map((c) => (
+                              <li key={c.parcoursId} className="fr-mb-1w">
+                                <Link href={`/espace-agent/dossiers/${c.parcoursId}`}>{nomCandidat(c)}</Link>
+                                <div className="fr-text--xs fr-mb-0">
+                                  {c.motifs.map((m) => MOTIF_LABELS[m]).join(", ") || "correspondance partielle"}
+                                </div>
+                                {/* Plusieurs candidats : le choix est explicite, jamais deviné. */}
+                                {candidats.length > 1 && (
+                                  <button
+                                    type="button"
+                                    className="fr-btn fr-btn--secondary fr-btn--sm fr-mt-1v"
+                                    disabled={occupe}
+                                    onClick={() => rattacher(o.dsNumber, c.parcoursId)}>
+                                    Rattacher à {nomCandidat(c)}
+                                  </button>
+                                )}
+                              </li>
+                            ))}
+                          </ul>
+                        </>
                       )}
                     </td>
+
                     <td>{o.step ? STEP_LABELS[o.step] : "—"}</td>
+
                     <td>
                       <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
+                        {candidatUnique && (
+                          <li>
+                            <button
+                              type="button"
+                              className="fr-btn fr-btn--sm"
+                              disabled={occupe}
+                              onClick={() => rattacher(o.dsNumber, candidatUnique.parcoursId)}>
+                              Rattacher
+                            </button>
+                          </li>
+                        )}
+
+                        {variante === "arbitrer" && (
+                          <li>
+                            <button
+                              type="button"
+                              className="fr-btn fr-btn--secondary fr-btn--sm"
+                              disabled={occupe}
+                              onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ARBITRE)}>
+                              Marquer comme traité
+                            </button>
+                          </li>
+                        )}
+
                         <li>
                           <button
                             type="button"
-                            className="fr-btn fr-btn--secondary fr-btn--sm"
-                            aria-expanded={inspecte === o.dsNumber}
-                            onClick={() => setInspecte(inspecte === o.dsNumber ? null : o.dsNumber)}>
-                            {inspecte === o.dsNumber ? "Masquer" : "Identifier"}
+                            className="fr-btn fr-btn--tertiary fr-btn--sm"
+                            aria-expanded={detaille === o.dsNumber}
+                            onClick={() => setDetaille(detaille === o.dsNumber ? null : o.dsNumber)}>
+                            {detaille === o.dsNumber ? "Masquer le détail" : "Voir le détail"}
                           </button>
                         </li>
+
                         <li>
+                          {/* Sans correspondance, écarter devient l'issue la plus probable. */}
                           <button
                             type="button"
-                            className="fr-btn fr-btn--secondary fr-btn--sm"
-                            disabled={enCours === o.dsNumber}
-                            onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ARBITRE)}>
-                            Marquer comme traité
-                          </button>
-                        </li>
-                        <li>
-                          <button
-                            type="button"
-                            className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm"
-                            disabled={enCours === o.dsNumber}
+                            className={`fr-btn fr-btn--sm ${
+                              candidats.length === 0 && !o.parcoursId
+                                ? "fr-btn--secondary"
+                                : "fr-btn--tertiary-no-outline"
+                            }`}
+                            disabled={occupe}
                             onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ECARTE)}>
                             Écarter
                           </button>
@@ -129,7 +201,7 @@ export function FileReconciliation({ observations, messageVide, onResolved }: Fi
                     </td>
                   </tr>
 
-                  {inspecte === o.dsNumber && (
+                  {detaille === o.dsNumber && (
                     <tr>
                       <td colSpan={5}>
                         <InspectionDossierDn dsNumber={o.dsNumber} />

--- a/src/app/(backoffice)/administration/diagnostics/components/FileReconciliation.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/FileReconciliation.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Fragment, useState } from "react";
-import Link from "next/link";
 import { resoudreObservationAction } from "@/features/backoffice/administration/diagnostics/actions/reconciliation.actions";
 import { rattacherDossierDnAction } from "@/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions";
 import { InspectionDossierDn } from "./InspectionDossierDn";
@@ -111,7 +110,13 @@ export function FileReconciliation({ observations, messageVide, variante, onReso
                     <td>
                       {/* Le demandeur est connu (files d'arbitrage) : rien à rapprocher. */}
                       {o.parcoursId ? (
-                        <Link href={`/espace-agent/dossiers/${o.parcoursId}`}>{demandeurLabel(o)}</Link>
+                        <a
+                          href={`/espace-agent/dossiers/${o.parcoursId}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title={`${demandeurLabel(o)} - ouvre une nouvelle fenêtre`}>
+                          {demandeurLabel(o)}
+                        </a>
                       ) : candidats.length === 0 ? (
                         <span className="fr-text--xs">Aucune correspondance trouvée</span>
                       ) : (
@@ -124,7 +129,13 @@ export function FileReconciliation({ observations, messageVide, variante, onReso
                           <ul className="fr-raw-list">
                             {candidats.map((c) => (
                               <li key={c.parcoursId} className="fr-mb-1w">
-                                <Link href={`/espace-agent/dossiers/${c.parcoursId}`}>{nomCandidat(c)}</Link>
+                                <a
+                                  href={`/espace-agent/dossiers/${c.parcoursId}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  title={`${nomCandidat(c)} - ouvre une nouvelle fenêtre`}>
+                                  {nomCandidat(c)}
+                                </a>
                                 <div className="fr-text--xs fr-mb-0">
                                   {c.motifs.map((m) => MOTIF_LABELS[m]).join(", ") || "correspondance partielle"}
                                 </div>

--- a/src/app/(backoffice)/administration/diagnostics/components/FileReconciliation.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/FileReconciliation.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { resoudreObservationAction } from "@/features/backoffice/administration/diagnostics/actions/reconciliation.actions";
+import { VERDICT_LABELS } from "@/features/backoffice/administration/diagnostics/domain/diagnostics.types";
+import { RESOLUTION_OBSERVATION } from "@/shared/database/schema";
+import { STEP_LABELS } from "@/shared/domain/value-objects/step.enum";
+import { getDossierDsDemandeUrl } from "@/features/parcours/dossiers-ds/utils";
+import type { ObservationAvecDemandeur } from "@/shared/database/repositories";
+
+interface FileReconciliationProps {
+  observations: ObservationAvecDemandeur[];
+  /** Texte affiché quand la file est vide — c'est le cas nominal, il doit rassurer. */
+  messageVide: string;
+  onResolved: () => void;
+}
+
+function demandeurLabel(o: ObservationAvecDemandeur): string {
+  const nom = [o.demandeurPrenom, o.demandeurNom].filter(Boolean).join(" ").trim();
+  if (nom) return nom;
+  return o.parcoursId ? "Demandeur inconnu" : "Aucun parcours associé";
+}
+
+export function FileReconciliation({ observations, messageVide, onResolved }: FileReconciliationProps) {
+  const [enCours, setEnCours] = useState<string | null>(null);
+  const [erreur, setErreur] = useState<string | null>(null);
+
+  async function resoudre(
+    dsNumber: string,
+    resolution: (typeof RESOLUTION_OBSERVATION)[keyof typeof RESOLUTION_OBSERVATION]
+  ) {
+    setErreur(null);
+    setEnCours(dsNumber);
+    try {
+      const result = await resoudreObservationAction(dsNumber, resolution);
+      if (result.success) onResolved();
+      else setErreur(result.error);
+    } finally {
+      setEnCours(null);
+    }
+  }
+
+  if (observations.length === 0) {
+    return (
+      <div className="fr-alert fr-alert--success fr-alert--sm">
+        <p>{messageVide}</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {erreur && (
+        <div className="fr-alert fr-alert--error fr-alert--sm fr-mb-2w">
+          <p>{erreur}</p>
+        </div>
+      )}
+
+      <div className="fr-table fr-table--bordered">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Dossier DN</th>
+              <th scope="col">Situation</th>
+              <th scope="col">Demandeur</th>
+              <th scope="col">Étape</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {observations.map((o) => {
+              const meta = VERDICT_LABELS[o.verdict] ?? { label: o.verdict, explication: "" };
+              return (
+                <tr key={o.dsNumber}>
+                  <td>
+                    <a href={getDossierDsDemandeUrl(Number(o.dsNumber))} target="_blank" rel="noopener noreferrer">
+                      #{o.dsNumber}
+                    </a>
+                    {o.dsState && <div className="fr-text--xs fr-mb-0">{o.dsState}</div>}
+                  </td>
+                  <td>
+                    <strong>{meta.label}</strong>
+                    <div className="fr-text--xs fr-mb-0">{meta.explication}</div>
+                    {o.detail && <div className="fr-text--xs fr-mb-0">{o.detail}</div>}
+                  </td>
+                  <td>
+                    {o.parcoursId ? (
+                      <Link href={`/espace-agent/dossiers/${o.parcoursId}`}>{demandeurLabel(o)}</Link>
+                    ) : (
+                      <span className="fr-text--xs">{demandeurLabel(o)}</span>
+                    )}
+                  </td>
+                  <td>{o.step ? STEP_LABELS[o.step] : "—"}</td>
+                  <td>
+                    <ul className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
+                      <li>
+                        <button
+                          type="button"
+                          className="fr-btn fr-btn--secondary fr-btn--sm"
+                          disabled={enCours === o.dsNumber}
+                          onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ARBITRE)}>
+                          Marquer comme traité
+                        </button>
+                      </li>
+                      <li>
+                        <button
+                          type="button"
+                          className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm"
+                          disabled={enCours === o.dsNumber}
+                          onClick={() => resoudre(o.dsNumber, RESOLUTION_OBSERVATION.ECARTE)}>
+                          Écarter
+                        </button>
+                      </li>
+                    </ul>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/src/app/(backoffice)/administration/diagnostics/components/InspectionDossierDn.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/InspectionDossierDn.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { inspecterDossierDnAction } from "@/features/backoffice/administration/diagnostics/actions/reconciliation.actions";
 import { MOTIF_LABELS, type InspectionDossier } from "@/features/parcours/dossiers-ds/domain/types/inspection.types";
 
@@ -71,9 +70,9 @@ export function InspectionDossierDn({ dsNumber }: { dsNumber: string }) {
         <ul className="fr-text--xs">
           {candidats.map((c) => (
             <li key={c.parcoursId}>
-              <Link href={`/espace-agent/dossiers/${c.parcoursId}`}>
+              <a href={`/espace-agent/dossiers/${c.parcoursId}`} target="_blank" rel="noopener noreferrer">
                 {[c.prenom, c.nom].filter(Boolean).join(" ") || c.email || c.parcoursId.slice(0, 8)}
-              </Link>{" "}
+              </a>{" "}
               — {c.motifs.map((m) => MOTIF_LABELS[m]).join(", ") || "correspondance partielle"}
               {c.adresse && <span> · {c.adresse}</span>}
             </li>

--- a/src/app/(backoffice)/administration/diagnostics/components/InspectionDossierDn.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/InspectionDossierDn.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { inspecterDossierDnAction } from "@/features/backoffice/administration/diagnostics/actions/reconciliation.actions";
+import { MOTIF_LABELS, type InspectionDossier } from "@/features/parcours/dossiers-ds/services/inspection.service";
+
+/**
+ * Ce que DN sait d'un dossier orphelin, et les demandeurs qui lui ressemblent.
+ * Aide à l'identification : rien n'est rattaché ici, la décision reste à l'agent.
+ */
+export function InspectionDossierDn({ dsNumber }: { dsNumber: string }) {
+  const [inspection, setInspection] = useState<InspectionDossier | null>(null);
+  const [erreur, setErreur] = useState<string | null>(null);
+  const [enCours, setEnCours] = useState(true);
+
+  useEffect(() => {
+    let annule = false;
+
+    inspecterDossierDnAction(dsNumber)
+      .then((result) => {
+        if (annule) return;
+        if (result.success) setInspection(result.data);
+        else setErreur(result.error);
+      })
+      .finally(() => {
+        if (!annule) setEnCours(false);
+      });
+
+    return () => {
+      annule = true;
+    };
+  }, [dsNumber]);
+
+  if (enCours) return <p className="fr-text--sm fr-mb-0">Interrogation de Démarches Numériques…</p>;
+  if (erreur) return <p className="fr-text--sm fr-mb-0">{erreur}</p>;
+  if (!inspection) return null;
+
+  const { dn, candidats } = inspection;
+
+  return (
+    <div className="fr-mt-2w fr-p-2w" style={{ background: "var(--background-alt-grey)" }}>
+      <p className="fr-text--sm fr-mb-1w">
+        <strong>Déclaré côté Démarches Numériques</strong>
+      </p>
+      <ul className="fr-text--xs">
+        {(dn.nomDeclare || dn.prenomDeclare) && (
+          <li>
+            Identité : {dn.prenomDeclare} {dn.nomDeclare}
+          </li>
+        )}
+        {dn.emailUsager && <li>Compte : {dn.emailUsager}</li>}
+        {dn.deposeParUnTiers && <li>Déposé par un tiers{dn.mandataire ? ` (${dn.mandataire})` : ""}</li>}
+        {dn.champs.map((c) => (
+          <li key={c.label}>
+            {c.label} : {c.valeur}
+          </li>
+        ))}
+      </ul>
+
+      <p className="fr-text--sm fr-mb-1w">
+        <strong>Demandeurs qui correspondent</strong>
+      </p>
+
+      {candidats.length === 0 ? (
+        <p className="fr-text--xs fr-mb-0">
+          Aucun demandeur ne correspond, ni par adresse, ni par téléphone, ni par e-mail, ni par nom. Ce dossier a
+          probablement été déposé hors du dispositif : écartez-le.
+        </p>
+      ) : (
+        <ul className="fr-text--xs">
+          {candidats.map((c) => (
+            <li key={c.parcoursId}>
+              <Link href={`/espace-agent/dossiers/${c.parcoursId}`}>
+                {[c.prenom, c.nom].filter(Boolean).join(" ") || c.email || c.parcoursId.slice(0, 8)}
+              </Link>{" "}
+              — {c.motifs.map((m) => MOTIF_LABELS[m]).join(", ") || "correspondance partielle"}
+              {c.adresse && <span> · {c.adresse}</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="fr-text--xs fr-mb-0" style={{ color: "var(--text-mention-grey)" }}>
+        Ces correspondances sont des indices, pas des preuves : une adresse e-mail peut être celle de l&apos;AMO, un nom
+        peut être porté par deux personnes. Vérifiez avant de rattacher.
+      </p>
+    </div>
+  );
+}

--- a/src/app/(backoffice)/administration/diagnostics/components/InspectionDossierDn.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/components/InspectionDossierDn.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { inspecterDossierDnAction } from "@/features/backoffice/administration/diagnostics/actions/reconciliation.actions";
-import { MOTIF_LABELS, type InspectionDossier } from "@/features/parcours/dossiers-ds/services/inspection.service";
+import { MOTIF_LABELS, type InspectionDossier } from "@/features/parcours/dossiers-ds/domain/types/inspection.types";
 
 /**
  * Ce que DN sait d'un dossier orphelin, et les demandeurs qui lui ressemblent.

--- a/src/app/(backoffice)/administration/diagnostics/page.tsx
+++ b/src/app/(backoffice)/administration/diagnostics/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { checkAgentAccess, ROUTES } from "@/features/auth";
 import { AccesNonAutoriseAdmin } from "@/shared/components";
 import { isSuperAdminRole } from "@/shared/domain/value-objects/user-role.enum";
-import DiagnosticsPanel from "./components/DiagnosticsPanel";
+import DiagnosticsTabs from "./components/DiagnosticsTabs";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -21,5 +21,5 @@ export default async function DiagnosticsPage() {
     return <AccesNonAutoriseAdmin />;
   }
 
-  return <DiagnosticsPanel />;
+  return <DiagnosticsTabs />;
 }

--- a/src/app/(backoffice)/espace-agent/dossiers/[id]/components/GererDossierMenu.tsx
+++ b/src/app/(backoffice)/espace-agent/dossiers/[id]/components/GererDossierMenu.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { ROUTES } from "@/features/auth/domain/value-objects";
 import { ArchiveModal } from "../../../shared/components/ArchiveModal";
 import { ArretAccompagnementModal } from "../../../shared/components/ArretAccompagnementModal";
+import { RattacherDossierDnModal } from "../../../shared/components/RattacherDossierDnModal";
 import { ActionMenu } from "../../../shared/components";
 
 interface GererDossierMenuProps {
@@ -29,6 +30,7 @@ export function GererDossierMenu({
   const router = useRouter();
   const [isArchiveOpen, setIsArchiveOpen] = useState(false);
   const [isArretOpen, setIsArretOpen] = useState(ouvrirArretAuMontage);
+  const [isRattacherOpen, setIsRattacherOpen] = useState(false);
 
   // Après archivage comme après arrêt, l'agent n'a plus le dossier dans son périmètre.
   function backToListing() {
@@ -45,6 +47,11 @@ export function GererDossierMenu({
         triggerClassName="fr-btn fr-btn--secondary fr-btn--sm fr-icon-arrow-down-s-line fr-btn--icon-right"
         items={[
           { label: "Archiver", icon: "fr-icon-archive-line", onClick: () => setIsArchiveOpen(true) },
+          {
+            label: "Rattacher un dossier DN",
+            icon: "fr-icon-links-line",
+            onClick: () => setIsRattacherOpen(true),
+          },
           ...(peutArreterAccompagnement
             ? [
                 {
@@ -63,6 +70,16 @@ export function GererDossierMenu({
         onClose={() => setIsArchiveOpen(false)}
         parcoursId={parcoursId}
         onSuccess={backToListing}
+      />
+
+      <RattacherDossierDnModal
+        isOpen={isRattacherOpen}
+        onClose={() => setIsRattacherOpen(false)}
+        parcoursId={parcoursId}
+        onSuccess={() => {
+          setIsRattacherOpen(false);
+          router.refresh();
+        }}
       />
 
       <ArretAccompagnementModal

--- a/src/app/(backoffice)/espace-agent/dossiers/[id]/page.test.tsx
+++ b/src/app/(backoffice)/espace-agent/dossiers/[id]/page.test.tsx
@@ -23,6 +23,11 @@ vi.mock("@/features/backoffice/shared/actions/agent.actions", () => ({ getCurren
 vi.mock("@/features/backoffice/espace-agent/prospects/services/qualification.service", () => ({
   qualificationService: { getByParcoursId: vi.fn() },
 }));
+// Le menu « Gérer » tire l'action de rattachement DN, dont le client GraphQL lit l'env à
+// la construction du singleton — inutile pour tester le routage de la page.
+vi.mock("@/features/parcours/dossiers-ds/adapters/graphql/client", () => ({
+  graphqlClient: { getDossierStatus: vi.fn(), getDemarcheDossiers: vi.fn() },
+}));
 vi.mock("@/shared/database/repositories/agents.repository", () => ({ agentsRepository: {} }));
 vi.mock("@/shared/database/repositories/allers-vers.repository", () => ({ allersVersRepository: {} }));
 

--- a/src/app/(backoffice)/espace-agent/shared/components/RattacherDossierDnModal.tsx
+++ b/src/app/(backoffice)/espace-agent/shared/components/RattacherDossierDnModal.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { rattacherDossierDnAction } from "@/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions";
+
+interface RattacherDossierDnModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  parcoursId: string;
+  onSuccess: () => void;
+}
+
+/**
+ * Rattache un dossier Démarches Numériques existant au parcours, par son numéro.
+ * Recours quand le demandeur a créé son dossier hors du lien FPA : il ne porte alors pas
+ * l'annotation qui permettrait de le retrouver automatiquement (ADR-0027).
+ */
+export function RattacherDossierDnModal({ isOpen, onClose, parcoursId, onSuccess }: RattacherDossierDnModalProps) {
+  const [dsNumber, setDsNumber] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  async function handleSubmit() {
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const result = await rattacherDossierDnAction(parcoursId, dsNumber);
+      if (result.success) {
+        setDsNumber("");
+        onSuccess();
+      } else {
+        setError(result.error);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <dialog open className="fr-modal fr-modal--opened" aria-labelledby="rattacher-dn-titre">
+      <div className="fr-container fr-container--fluid fr-container-md">
+        <div className="fr-grid-row fr-grid-row--center">
+          <div className="fr-col-12 fr-col-md-8 fr-col-lg-6">
+            <div className="fr-modal__body">
+              <div className="fr-modal__header">
+                <button type="button" className="fr-btn--close fr-btn" onClick={onClose}>
+                  Fermer
+                </button>
+              </div>
+
+              <div className="fr-modal__content">
+                <h2 id="rattacher-dn-titre" className="fr-modal__title">
+                  Rattacher un dossier Démarches Numériques
+                </h2>
+
+                <p>
+                  À utiliser quand le demandeur a déposé son dossier sans passer par le lien du Fonds Prévention Argile
+                  : son dossier existe côté Démarches Numériques, mais rien ne le relie à ce parcours.
+                </p>
+                <p className="fr-text--sm">
+                  Le numéro figure en haut du dossier côté Démarches Numériques. Le dossier doit avoir été
+                  <strong> transmis</strong> : un brouillon non déposé n'est pas visible de notre côté.
+                </p>
+
+                {error && (
+                  <div className="fr-alert fr-alert--error fr-alert--sm fr-mb-2w">
+                    <p>{error}</p>
+                  </div>
+                )}
+
+                <div className="fr-input-group">
+                  <label className="fr-label" htmlFor="rattacher-dn-numero">
+                    Numéro du dossier
+                  </label>
+                  <input
+                    id="rattacher-dn-numero"
+                    className="fr-input"
+                    type="text"
+                    inputMode="numeric"
+                    value={dsNumber}
+                    onChange={(e) => setDsNumber(e.target.value)}
+                    placeholder="32052358"
+                  />
+                </div>
+              </div>
+
+              <div className="fr-modal__footer">
+                <ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
+                  <li>
+                    <button
+                      type="button"
+                      className="fr-btn"
+                      onClick={handleSubmit}
+                      disabled={isSubmitting || dsNumber.trim().length === 0}>
+                      {isSubmitting ? "Vérification…" : "Rattacher"}
+                    </button>
+                  </li>
+                  <li>
+                    <button type="button" className="fr-btn fr-btn--secondary" onClick={onClose}>
+                      Annuler
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/src/app/(backoffice)/espace-agent/shared/components/RattacherDossierDnModal.tsx
+++ b/src/app/(backoffice)/espace-agent/shared/components/RattacherDossierDnModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState, useId } from "react";
 import { rattacherDossierDnAction } from "@/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions";
 
 interface RattacherDossierDnModalProps {
@@ -16,53 +16,94 @@ interface RattacherDossierDnModalProps {
  * l'annotation qui permettrait de le retrouver automatiquement (ADR-0027).
  */
 export function RattacherDossierDnModal({ isOpen, onClose, parcoursId, onSuccess }: RattacherDossierDnModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const [dsNumber, setDsNumber] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const uniqueId = useId();
+  const modalId = `modal-rattacher-dn-${uniqueId}`;
 
-  if (!isOpen) return null;
+  // Ouverture/fermeture via l'API DSFR : l'attribut HTML `open` ne suffit pas.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const modalInstance = (window as any).dsfr?.(dialog)?.modal;
+    if (!modalInstance) return;
+
+    if (isOpen) {
+      modalInstance.disclose();
+    } else {
+      modalInstance.conceal();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleConceal = () => {
+      setError(null);
+      onClose();
+    };
+
+    dialog.addEventListener("dsfr.conceal", handleConceal);
+    return () => {
+      dialog.removeEventListener("dsfr.conceal", handleConceal);
+    };
+  }, [onClose]);
 
   async function handleSubmit() {
-    setError(null);
     setIsSubmitting(true);
+    setError(null);
 
     try {
       const result = await rattacherDossierDnAction(parcoursId, dsNumber);
+
       if (result.success) {
         setDsNumber("");
+        const dialog = dialogRef.current;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const modalInstance = dialog ? (window as any).dsfr?.(dialog)?.modal : null;
+        if (modalInstance) modalInstance.conceal();
         onSuccess();
       } else {
-        setError(result.error);
+        setError(result.error || "Erreur lors du rattachement");
       }
+    } catch {
+      setError("Une erreur est survenue");
     } finally {
       setIsSubmitting(false);
     }
   }
 
   return (
-    <dialog open className="fr-modal fr-modal--opened" aria-labelledby="rattacher-dn-titre">
+    <dialog ref={dialogRef} id={modalId} className="fr-modal" aria-labelledby={`${modalId}-title`}>
       <div className="fr-container fr-container--fluid fr-container-md">
         <div className="fr-grid-row fr-grid-row--center">
-          <div className="fr-col-12 fr-col-md-8 fr-col-lg-6">
+          <div className="fr-col-12 fr-col-md-10 fr-col-lg-8">
             <div className="fr-modal__body">
               <div className="fr-modal__header">
-                <button type="button" className="fr-btn--close fr-btn" onClick={onClose}>
+                <button aria-controls={modalId} title="Fermer" type="button" className="fr-btn--close fr-btn">
                   Fermer
                 </button>
               </div>
 
               <div className="fr-modal__content">
-                <h2 id="rattacher-dn-titre" className="fr-modal__title">
-                  Rattacher un dossier Démarches Numériques
-                </h2>
+                <h1 id={`${modalId}-title`} className="fr-modal__title">
+                  Rattacher un dossier D&eacute;marches Num&eacute;riques
+                </h1>
 
                 <p>
-                  À utiliser quand le demandeur a déposé son dossier sans passer par le lien du Fonds Prévention Argile
-                  : son dossier existe côté Démarches Numériques, mais rien ne le relie à ce parcours.
+                  &Agrave; utiliser quand le demandeur a d&eacute;pos&eacute; son dossier sans passer par le lien du
+                  Fonds Pr&eacute;vention Argile : son dossier existe c&ocirc;t&eacute; D&eacute;marches
+                  Num&eacute;riques, mais rien ne le relie &agrave; ce parcours.
                 </p>
                 <p className="fr-text--sm">
-                  Le numéro figure en haut du dossier côté Démarches Numériques. Le dossier doit avoir été
-                  <strong> transmis</strong> : un brouillon non déposé n'est pas visible de notre côté.
+                  Le num&eacute;ro figure en haut du dossier c&ocirc;t&eacute; D&eacute;marches Num&eacute;riques. Le
+                  dossier doit avoir &eacute;t&eacute; <strong>transmis</strong> : un brouillon non d&eacute;pos&eacute;
+                  n&apos;est pas visible de notre c&ocirc;t&eacute;.
                 </p>
 
                 {error && (
@@ -72,11 +113,11 @@ export function RattacherDossierDnModal({ isOpen, onClose, parcoursId, onSuccess
                 )}
 
                 <div className="fr-input-group">
-                  <label className="fr-label" htmlFor="rattacher-dn-numero">
-                    Numéro du dossier
+                  <label className="fr-label" htmlFor={`${modalId}-numero`}>
+                    Num&eacute;ro du dossier
                   </label>
                   <input
-                    id="rattacher-dn-numero"
+                    id={`${modalId}-numero`}
                     className="fr-input"
                     type="text"
                     inputMode="numeric"
@@ -93,13 +134,13 @@ export function RattacherDossierDnModal({ isOpen, onClose, parcoursId, onSuccess
                     <button
                       type="button"
                       className="fr-btn"
-                      onClick={handleSubmit}
-                      disabled={isSubmitting || dsNumber.trim().length === 0}>
-                      {isSubmitting ? "Vérification…" : "Rattacher"}
+                      disabled={isSubmitting || dsNumber.trim().length === 0}
+                      onClick={handleSubmit}>
+                      {isSubmitting ? "Vérification..." : "Rattacher"}
                     </button>
                   </li>
                   <li>
-                    <button type="button" className="fr-btn fr-btn--secondary" onClick={onClose}>
+                    <button type="button" className="fr-btn fr-btn--secondary" aria-controls={modalId}>
                       Annuler
                     </button>
                   </li>

--- a/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.test.ts
+++ b/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UserRole } from "@/shared/domain/value-objects";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/features/backoffice/shared/actions/agent.actions", () => ({ getCurrentAgent: vi.fn() }));
+vi.mock("@/shared/database/repositories", () => ({
+  dsObservationsRepo: { listerOuvertes: vi.fn(), compterOuvertesParVerdict: vi.fn(), resoudre: vi.fn() },
+}));
+vi.mock("@/features/parcours/dossiers-ds/services/reconciliation.service", () => ({
+  reconcilierDemarche: vi.fn(),
+}));
+vi.mock("@/features/parcours/dossiers-ds/services/pieces-justificatives.service", () => ({
+  resolveDemarcheNumberForStep: vi.fn().mockReturnValue(126061),
+}));
+
+import {
+  listerFilesReconciliationAction,
+  analyserReconciliationAction,
+  resoudreObservationAction,
+} from "./reconciliation.actions";
+import { getCurrentAgent } from "@/features/backoffice/shared/actions/agent.actions";
+import { dsObservationsRepo } from "@/shared/database/repositories";
+import { reconcilierDemarche } from "@/features/parcours/dossiers-ds/services/reconciliation.service";
+
+function mockAgent(role: UserRole) {
+  vi.mocked(getCurrentAgent).mockResolvedValue({
+    success: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: { id: "agent-1", role } as any,
+  });
+}
+
+// Ces files exposent des numéros de dossier et des noms : réservées au super-admin.
+describe("actions de réconciliation — contrôle d'accès", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(dsObservationsRepo.listerOuvertes).mockResolvedValue([]);
+    vi.mocked(dsObservationsRepo.compterOuvertesParVerdict).mockResolvedValue({});
+    vi.mocked(dsObservationsRepo.resoudre).mockResolvedValue(undefined);
+  });
+
+  it("refuse la lecture des files à un administrateur non super-admin", async () => {
+    mockAgent(UserRole.ADMINISTRATEUR);
+    const result = await listerFilesReconciliationAction();
+    expect(result.success).toBe(false);
+    expect(dsObservationsRepo.listerOuvertes).not.toHaveBeenCalled();
+  });
+
+  it("refuse l'analyse à un AMO", async () => {
+    mockAgent(UserRole.AMO);
+    const result = await analyserReconciliationAction(Step.ELIGIBILITE);
+    expect(result.success).toBe(false);
+    expect(reconcilierDemarche).not.toHaveBeenCalled();
+  });
+
+  it("refuse la résolution à un analyste", async () => {
+    mockAgent(UserRole.ANALYSTE);
+    const result = await resoudreObservationAction("32052358", "arbitre");
+    expect(result.success).toBe(false);
+    expect(dsObservationsRepo.resoudre).not.toHaveBeenCalled();
+  });
+
+  it("autorise le super-admin et n'applique aucune écriture lors de l'analyse", async () => {
+    mockAgent(UserRole.SUPER_ADMINISTRATEUR);
+    vi.mocked(reconcilierDemarche).mockResolvedValue({
+      lignes: [],
+      totaux: {},
+      rattachementsAppliques: 0,
+      scanComplet: true,
+      pagesLues: 1,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const result = await analyserReconciliationAction(Step.ELIGIBILITE);
+
+    expect(result.success).toBe(true);
+    expect(reconcilierDemarche).toHaveBeenCalledWith(expect.objectContaining({ apply: false }));
+  });
+
+  it("refuse une étape sans démarche à balayer", async () => {
+    mockAgent(UserRole.SUPER_ADMINISTRATEUR);
+    const result = await analyserReconciliationAction(Step.CHOIX_AMO);
+    expect(result.success).toBe(false);
+    expect(reconcilierDemarche).not.toHaveBeenCalled();
+  });
+
+  it("refuse une résolution inconnue", async () => {
+    mockAgent(UserRole.SUPER_ADMINISTRATEUR);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await resoudreObservationAction("32052358", "n_importe_quoi" as any);
+    expect(result.success).toBe(false);
+    expect(dsObservationsRepo.resoudre).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.test.ts
+++ b/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.test.ts
@@ -10,6 +10,9 @@ vi.mock("@/shared/database/repositories", () => ({
 vi.mock("@/features/parcours/dossiers-ds/services/reconciliation.service", () => ({
   reconcilierDemarche: vi.fn(),
 }));
+vi.mock("@/features/parcours/dossiers-ds/services/inspection.service", () => ({
+  inspecterDossierDn: vi.fn(),
+}));
 vi.mock("@/features/parcours/dossiers-ds/services/pieces-justificatives.service", () => ({
   resolveDemarcheNumberForStep: vi.fn().mockReturnValue(126061),
 }));
@@ -18,7 +21,9 @@ import {
   listerFilesReconciliationAction,
   analyserReconciliationAction,
   resoudreObservationAction,
+  inspecterDossierDnAction,
 } from "./reconciliation.actions";
+import { inspecterDossierDn } from "@/features/parcours/dossiers-ds/services/inspection.service";
 import { getCurrentAgent } from "@/features/backoffice/shared/actions/agent.actions";
 import { dsObservationsRepo } from "@/shared/database/repositories";
 import { reconcilierDemarche } from "@/features/parcours/dossiers-ds/services/reconciliation.service";
@@ -83,6 +88,20 @@ describe("actions de réconciliation — contrôle d'accès", () => {
     const result = await analyserReconciliationAction(Step.CHOIX_AMO);
     expect(result.success).toBe(false);
     expect(reconcilierDemarche).not.toHaveBeenCalled();
+  });
+
+  it("refuse l'inspection à un administrateur non super-admin", async () => {
+    mockAgent(UserRole.ADMINISTRATEUR);
+    const result = await inspecterDossierDnAction("32052358");
+    expect(result.success).toBe(false);
+    expect(inspecterDossierDn).not.toHaveBeenCalled();
+  });
+
+  it("refuse un numéro de dossier non numérique", async () => {
+    mockAgent(UserRole.SUPER_ADMINISTRATEUR);
+    const result = await inspecterDossierDnAction("32052358; DROP TABLE");
+    expect(result.success).toBe(false);
+    expect(inspecterDossierDn).not.toHaveBeenCalled();
   });
 
   it("refuse une résolution inconnue", async () => {

--- a/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.ts
+++ b/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.ts
@@ -7,6 +7,10 @@ import { Step } from "@/shared/domain/value-objects/step.enum";
 import { dsObservationsRepo, type ObservationAvecDemandeur } from "@/shared/database/repositories";
 import { RESOLUTION_OBSERVATION, type ResolutionObservation } from "@/shared/database/schema";
 import { reconcilierDemarche } from "@/features/parcours/dossiers-ds/services/reconciliation.service";
+import {
+  inspecterDossierDn,
+  type InspectionDossier,
+} from "@/features/parcours/dossiers-ds/services/inspection.service";
 import { resolveDemarcheNumberForStep } from "@/features/parcours/dossiers-ds/services/pieces-justificatives.service";
 import {
   VERDICTS_A_RATTACHER,
@@ -97,6 +101,30 @@ export async function analyserReconciliationAction(step: Step): Promise<ActionRe
   } catch (error) {
     console.error("Erreur analyserReconciliationAction:", error);
     return { success: false, error: "Erreur lors de l'analyse des dossiers DN" };
+  }
+}
+
+/**
+ * Rapproche un dossier DN des demandeurs connus, pour épargner l'enquête à la main.
+ * Lecture seule : aucun rattachement n'est fait ici.
+ */
+export async function inspecterDossierDnAction(dsNumber: string): Promise<ActionResult<InspectionDossier>> {
+  const guard = await ensureSuperAdmin();
+  if (!guard.ok) return { success: false, error: guard.error };
+
+  if (!/^\d+$/.test(dsNumber)) {
+    return { success: false, error: "Numéro de dossier invalide" };
+  }
+
+  try {
+    const inspection = await inspecterDossierDn(dsNumber);
+    if (!inspection) {
+      return { success: false, error: "Ce dossier n'est plus accessible côté Démarches Numériques." };
+    }
+    return { success: true, data: inspection };
+  } catch (error) {
+    console.error("Erreur inspecterDossierDnAction:", error);
+    return { success: false, error: "Erreur lors de l'inspection du dossier" };
   }
 }
 

--- a/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.ts
+++ b/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.ts
@@ -1,0 +1,123 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getCurrentAgent } from "@/features/backoffice/shared/actions/agent.actions";
+import { isSuperAdminRole } from "@/shared/domain/value-objects/user-role.enum";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+import { dsObservationsRepo, type ObservationAvecDemandeur } from "@/shared/database/repositories";
+import { RESOLUTION_OBSERVATION, type ResolutionObservation } from "@/shared/database/schema";
+import { reconcilierDemarche } from "@/features/parcours/dossiers-ds/services/reconciliation.service";
+import { resolveDemarcheNumberForStep } from "@/features/parcours/dossiers-ds/services/pieces-justificatives.service";
+import {
+  VERDICTS_A_RATTACHER,
+  VERDICTS_A_ARBITRER,
+} from "@/features/backoffice/administration/diagnostics/domain/diagnostics.types";
+import type { ActionResult } from "@/shared/types";
+
+/**
+ * Files de travail issues de la réconciliation (ADR-0027). Réservées au super-admin, comme le
+ * reste de la page diagnostics : elles exposent des numéros de dossier et des noms.
+ */
+
+async function ensureSuperAdmin(): Promise<{ ok: true; agentId: string | null } | { ok: false; error: string }> {
+  const agentResult = await getCurrentAgent();
+  if (!agentResult.success) return { ok: false, error: agentResult.error };
+  if (!isSuperAdminRole(agentResult.data.role)) {
+    return { ok: false, error: "Accès réservé au super-administrateur" };
+  }
+  return { ok: true, agentId: agentResult.data.id };
+}
+
+export interface FilesReconciliation {
+  aRattacher: ObservationAvecDemandeur[];
+  aArbitrer: ObservationAvecDemandeur[];
+  compteurs: Record<string, number>;
+}
+
+export async function listerFilesReconciliationAction(): Promise<ActionResult<FilesReconciliation>> {
+  const guard = await ensureSuperAdmin();
+  if (!guard.ok) return { success: false, error: guard.error };
+
+  try {
+    const [aRattacher, aArbitrer, compteurs] = await Promise.all([
+      dsObservationsRepo.listerOuvertes([...VERDICTS_A_RATTACHER]),
+      dsObservationsRepo.listerOuvertes([...VERDICTS_A_ARBITRER]),
+      dsObservationsRepo.compterOuvertesParVerdict(),
+    ]);
+
+    return { success: true, data: { aRattacher, aArbitrer, compteurs } };
+  } catch (error) {
+    console.error("Erreur listerFilesReconciliationAction:", error);
+    return { success: false, error: "Erreur lors du chargement des files" };
+  }
+}
+
+/** Étapes balayables : celles qui ont une démarche DN réellement configurée. */
+const STEPS_RECONCILIABLES = [Step.ELIGIBILITE, Step.DIAGNOSTIC, Step.DEVIS];
+
+export interface ResultatAnalyse {
+  step: Step;
+  examines: number;
+  scanComplet: boolean;
+  raison?: string;
+  totaux: Record<string, number>;
+}
+
+/**
+ * Balaye une démarche en LECTURE SEULE et remplit les files. N'applique aucun rattachement :
+ * l'écriture reste explicite, via le script ops (ADR-0027).
+ */
+export async function analyserReconciliationAction(step: Step): Promise<ActionResult<ResultatAnalyse>> {
+  const guard = await ensureSuperAdmin();
+  if (!guard.ok) return { success: false, error: guard.error };
+
+  if (!STEPS_RECONCILIABLES.includes(step)) {
+    return { success: false, error: "Cette étape n'a pas de démarche à balayer." };
+  }
+
+  try {
+    const rapport = await reconcilierDemarche({
+      demarcheNumber: resolveDemarcheNumberForStep(step),
+      step,
+      apply: false,
+    });
+
+    revalidatePath("/administration/diagnostics");
+
+    return {
+      success: true,
+      data: {
+        step,
+        examines: rapport.lignes.length,
+        scanComplet: rapport.scanComplet,
+        raison: rapport.scanIncompletRaison,
+        totaux: rapport.totaux,
+      },
+    };
+  } catch (error) {
+    console.error("Erreur analyserReconciliationAction:", error);
+    return { success: false, error: "Erreur lors de l'analyse des dossiers DN" };
+  }
+}
+
+/** Referme un cas traité à la main : arbitré ou écarté. */
+export async function resoudreObservationAction(
+  dsNumber: string,
+  resolution: ResolutionObservation
+): Promise<ActionResult<void>> {
+  const guard = await ensureSuperAdmin();
+  if (!guard.ok) return { success: false, error: guard.error };
+
+  if (!Object.values(RESOLUTION_OBSERVATION).includes(resolution)) {
+    return { success: false, error: "Résolution inconnue" };
+  }
+
+  try {
+    await dsObservationsRepo.resoudre(dsNumber, resolution, guard.agentId);
+    revalidatePath("/administration/diagnostics");
+    return { success: true, data: undefined };
+  } catch (error) {
+    console.error("Erreur resoudreObservationAction:", error);
+    return { success: false, error: "Erreur lors de la résolution" };
+  }
+}

--- a/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.ts
+++ b/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.ts
@@ -108,7 +108,13 @@ export async function resoudreObservationAction(
   const guard = await ensureSuperAdmin();
   if (!guard.ok) return { success: false, error: guard.error };
 
-  if (!Object.values(RESOLUTION_OBSERVATION).includes(resolution)) {
+  // `auto` est réservé aux balayages : un humain arbitre ou écarte, il ne « referme » pas.
+  const resolutionsManuelles: ResolutionObservation[] = [
+    RESOLUTION_OBSERVATION.ARBITRE,
+    RESOLUTION_OBSERVATION.ECARTE,
+    RESOLUTION_OBSERVATION.RATTACHE,
+  ];
+  if (!resolutionsManuelles.includes(resolution)) {
     return { success: false, error: "Résolution inconnue" };
   }
 

--- a/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.ts
+++ b/src/features/backoffice/administration/diagnostics/actions/reconciliation.actions.ts
@@ -7,10 +7,8 @@ import { Step } from "@/shared/domain/value-objects/step.enum";
 import { dsObservationsRepo, type ObservationAvecDemandeur } from "@/shared/database/repositories";
 import { RESOLUTION_OBSERVATION, type ResolutionObservation } from "@/shared/database/schema";
 import { reconcilierDemarche } from "@/features/parcours/dossiers-ds/services/reconciliation.service";
-import {
-  inspecterDossierDn,
-  type InspectionDossier,
-} from "@/features/parcours/dossiers-ds/services/inspection.service";
+import { inspecterDossierDn } from "@/features/parcours/dossiers-ds/services/inspection.service";
+import type { InspectionDossier } from "@/features/parcours/dossiers-ds/domain/types/inspection.types";
 import { resolveDemarcheNumberForStep } from "@/features/parcours/dossiers-ds/services/pieces-justificatives.service";
 import {
   VERDICTS_A_RATTACHER,

--- a/src/features/backoffice/administration/diagnostics/domain/diagnostics.types.ts
+++ b/src/features/backoffice/administration/diagnostics/domain/diagnostics.types.ts
@@ -210,3 +210,55 @@ export interface DemarcheSante {
   status: DemarcheSanteStatus;
   errorDetail: string | null;
 }
+
+/**
+ * Regroupement des verdicts de réconciliation en files de travail (ADR-0027).
+ * L'écran n'expose que deux questions : qu'est-ce qui doit être rattaché, et qu'est-ce qui
+ * demande un arbitrage. Le reste n'a rien à signaler.
+ */
+export const VERDICTS_A_RATTACHER = ["rattachement", "sans_annotation"] as const;
+
+export const VERDICTS_A_ARBITRER = [
+  "conflit_autre_parcours",
+  "conflit_dossier_confirme",
+  "conflit_plusieurs_deposes",
+  "annotation_ambigue",
+  "annotation_modifiee",
+  "parcours_inconnu",
+] as const;
+
+export const VERDICT_LABELS: Record<string, { label: string; explication: string }> = {
+  rattachement: {
+    label: "Rattachement proposé",
+    explication: "Ce dossier déposé correspond à un parcours sans dossier confirmé : il peut être rattaché.",
+  },
+  sans_annotation: {
+    label: "Sans lien FPA",
+    explication:
+      "Dossier créé hors du parcours FPA (ou avant l'ajout du lien) : rien ne permet de retrouver son demandeur automatiquement. À rattacher par son numéro.",
+  },
+  conflit_autre_parcours: {
+    label: "Numéro déjà rattaché ailleurs",
+    explication: "Ce numéro appartient déjà à un autre demandeur. À vérifier avant toute action.",
+  },
+  conflit_dossier_confirme: {
+    label: "Deux dossiers pour une étape",
+    explication: "Le parcours a déjà un dossier déposé sous un autre numéro. Il faut choisir lequel fait foi.",
+  },
+  conflit_plusieurs_deposes: {
+    label: "Plusieurs dépôts pour un parcours",
+    explication: "Plusieurs dossiers déposés visent le même parcours. Un doublon côté DN, à trancher.",
+  },
+  annotation_ambigue: {
+    label: "Lien FPA contradictoire",
+    explication: "Deux annotations pointent des parcours différents : le lien a probablement été retouché.",
+  },
+  annotation_modifiee: {
+    label: "Lien FPA modifié",
+    explication: "Démarches Numériques signale que le lien prérempli a été modifié à la main : il ne fait plus foi.",
+  },
+  parcours_inconnu: {
+    label: "Parcours introuvable",
+    explication: "Le lien pointe vers un parcours qui n'existe plus.",
+  },
+};

--- a/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.test.ts
+++ b/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UserRole } from "@/shared/domain/value-objects";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/features/backoffice/shared/actions/agent.actions", () => ({ getCurrentAgent: vi.fn() }));
+vi.mock("@/features/parcours/dossiers-ds/services/reconciliation.service", () => ({
+  rattacherDossierManuel: vi.fn(),
+}));
+vi.mock("@/features/backoffice/espace-agent/shared/services/author-snapshot", () => ({
+  buildAuthorSnapshot: vi.fn().mockResolvedValue({
+    authorName: "Jean Test",
+    authorStructure: "ACME",
+    authorStructureType: "AMO",
+  }),
+}));
+vi.mock("@/shared/database/repositories", () => ({
+  parcoursRepo: { findById: vi.fn() },
+  parcoursActionsRepo: { create: vi.fn() },
+}));
+// Le dossier appartient à l'entreprise "entreprise-123".
+vi.mock("@/shared/database/client", () => ({
+  db: {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ entrepriseAmoId: "entreprise-123" }]) }) }),
+    }),
+  },
+}));
+vi.mock("@/features/auth/permissions/services/agent-scope.service", () => ({
+  calculateAgentScope: vi.fn(),
+  verifyProspectTerritoryAccess: vi.fn(),
+}));
+
+import { rattacherDossierDnAction } from "./rattacher-dossier-dn.actions";
+import { getCurrentAgent } from "@/features/backoffice/shared/actions/agent.actions";
+import { calculateAgentScope } from "@/features/auth/permissions/services/agent-scope.service";
+import { rattacherDossierManuel } from "@/features/parcours/dossiers-ds/services/reconciliation.service";
+import { parcoursRepo } from "@/shared/database/repositories";
+
+const PARCOURS_ID = "11111111-1111-1111-1111-111111111111";
+
+const baseScope = {
+  isNational: false,
+  entrepriseAmoIds: [] as string[],
+  departements: [] as string[],
+  epcis: [] as string[],
+  canViewAllDossiers: false,
+  canViewDossiersByEntreprise: false,
+  canViewDossiersWithoutAmo: false,
+};
+
+function mockAgent(role: UserRole, entrepriseAmoId: string | null = null) {
+  vi.mocked(getCurrentAgent).mockResolvedValue({
+    success: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: { id: "agent-1", role, entrepriseAmoId, allersVersId: null } as any,
+  });
+}
+
+describe("rattacherDossierDnAction — contrôle d'accès", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(parcoursRepo.findById).mockResolvedValue({ id: PARCOURS_ID, currentStep: Step.ELIGIBILITE } as any);
+    vi.mocked(rattacherDossierManuel).mockResolvedValue({ success: true, data: { dsNumber: "32052358" } });
+    vi.mocked(calculateAgentScope).mockResolvedValue({ ...baseScope });
+  });
+
+  it("refuse un rôle non habilité (analyste)", async () => {
+    mockAgent(UserRole.ANALYSTE);
+
+    const result = await rattacherDossierDnAction(PARCOURS_ID, "32052358");
+
+    expect(result.success).toBe(false);
+    expect(rattacherDossierManuel).not.toHaveBeenCalled();
+  });
+
+  it("refuse un AMO d'une autre entreprise", async () => {
+    mockAgent(UserRole.AMO, "autre-entreprise");
+    vi.mocked(calculateAgentScope).mockResolvedValue({ ...baseScope, canViewDossiersByEntreprise: true });
+
+    const result = await rattacherDossierDnAction(PARCOURS_ID, "32052358");
+
+    expect(result.success).toBe(false);
+    expect(rattacherDossierManuel).not.toHaveBeenCalled();
+  });
+
+  it("autorise l'AMO de l'entreprise rattachée", async () => {
+    mockAgent(UserRole.AMO, "entreprise-123");
+    vi.mocked(calculateAgentScope).mockResolvedValue({ ...baseScope, canViewDossiersByEntreprise: true });
+
+    const result = await rattacherDossierDnAction(PARCOURS_ID, "32052358");
+
+    expect(result.success).toBe(true);
+    expect(rattacherDossierManuel).toHaveBeenCalledWith(
+      expect.objectContaining({ parcoursId: PARCOURS_ID, dsNumber: "32052358" })
+    );
+  });
+
+  it("autorise un rôle national sans contrôle de périmètre", async () => {
+    mockAgent(UserRole.SUPER_ADMINISTRATEUR);
+    vi.mocked(calculateAgentScope).mockResolvedValue({ ...baseScope, canViewAllDossiers: true, isNational: true });
+
+    const result = await rattacherDossierDnAction(PARCOURS_ID, "32052358");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("remonte le refus du service sans écrire d'audit", async () => {
+    mockAgent(UserRole.SUPER_ADMINISTRATEUR);
+    vi.mocked(calculateAgentScope).mockResolvedValue({ ...baseScope, canViewAllDossiers: true });
+    vi.mocked(rattacherDossierManuel).mockResolvedValue({ success: false, error: "Numéro déjà rattaché" });
+
+    const result = await rattacherDossierDnAction(PARCOURS_ID, "32052358");
+
+    expect(result).toEqual({ success: false, error: "Numéro déjà rattaché" });
+  });
+});

--- a/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.test.ts
+++ b/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.test.ts
@@ -62,7 +62,10 @@ describe("rattacherDossierDnAction — contrôle d'accès", () => {
     vi.clearAllMocks();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(parcoursRepo.findById).mockResolvedValue({ id: PARCOURS_ID, currentStep: Step.ELIGIBILITE } as any);
-    vi.mocked(rattacherDossierManuel).mockResolvedValue({ success: true, data: { dsNumber: "32052358" } });
+    vi.mocked(rattacherDossierManuel).mockResolvedValue({
+      success: true,
+      data: { dsNumber: "32052358", step: Step.ELIGIBILITE },
+    });
     vi.mocked(calculateAgentScope).mockResolvedValue({ ...baseScope });
   });
 
@@ -92,9 +95,7 @@ describe("rattacherDossierDnAction — contrôle d'accès", () => {
     const result = await rattacherDossierDnAction(PARCOURS_ID, "32052358");
 
     expect(result.success).toBe(true);
-    expect(rattacherDossierManuel).toHaveBeenCalledWith(
-      expect.objectContaining({ parcoursId: PARCOURS_ID, dsNumber: "32052358" })
-    );
+    expect(rattacherDossierManuel).toHaveBeenCalledWith({ parcoursId: PARCOURS_ID, dsNumber: "32052358" });
   });
 
   it("autorise un rôle national sans contrôle de périmètre", async () => {

--- a/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.test.ts
+++ b/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/features/backoffice/espace-agent/shared/services/author-snapshot", ()
 vi.mock("@/shared/database/repositories", () => ({
   parcoursRepo: { findById: vi.fn() },
   parcoursActionsRepo: { create: vi.fn() },
+  dsObservationsRepo: { resoudre: vi.fn() },
 }));
 // Le dossier appartient à l'entreprise "entreprise-123".
 vi.mock("@/shared/database/client", () => ({

--- a/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.ts
+++ b/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.ts
@@ -76,11 +76,9 @@ export async function rattacherDossierDnAction(parcoursId: string, dsNumber: str
       }
     }
 
-    const result = await rattacherDossierManuel({
-      parcoursId,
-      step: parcours.currentStep,
-      dsNumber,
-    });
+    // L'étape est déduite de la démarche du dossier DN, pas du parcours : un dossier
+    // d'éligibilité rattaché depuis un parcours au diagnostic doit rester une éligibilité.
+    const result = await rattacherDossierManuel({ parcoursId, dsNumber });
     if (!result.success) return { success: false, error: result.error };
 
     const snapshot = await buildAuthorSnapshot(agent);
@@ -88,7 +86,7 @@ export async function rattacherDossierDnAction(parcoursId: string, dsNumber: str
       parcoursId,
       agentId: agent.id,
       actionType: ACTION_TYPE_DOSSIER_DN_RATTACHE,
-      message: `Dossier Démarches Numériques n° ${result.data.dsNumber} rattaché manuellement à l'étape ${parcours.currentStep}.`,
+      message: `Dossier Démarches Numériques n° ${result.data.dsNumber} rattaché manuellement à l'étape ${result.data.step}.`,
       authorName: snapshot.authorName,
       authorStructure: snapshot.authorStructure,
       authorStructureType: snapshot.authorStructureType,

--- a/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.ts
+++ b/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.ts
@@ -4,7 +4,8 @@ import { revalidatePath } from "next/cache";
 import { eq } from "drizzle-orm";
 import { db } from "@/shared/database/client";
 import { parcoursAmoValidations } from "@/shared/database/schema";
-import { parcoursRepo, parcoursActionsRepo } from "@/shared/database/repositories";
+import { parcoursRepo, parcoursActionsRepo, dsObservationsRepo } from "@/shared/database/repositories";
+import { RESOLUTION_OBSERVATION } from "@/shared/database/schema";
 import { getCurrentAgent } from "@/features/backoffice/shared/actions/agent.actions";
 import {
   calculateAgentScope,
@@ -91,6 +92,9 @@ export async function rattacherDossierDnAction(parcoursId: string, dsNumber: str
       authorStructure: snapshot.authorStructure,
       authorStructureType: snapshot.authorStructureType,
     });
+
+    // Le cas sort de la file de rattachement du back-office.
+    await dsObservationsRepo.resoudre(result.data.dsNumber, RESOLUTION_OBSERVATION.RATTACHE, agent.id);
 
     revalidatePath(`/espace-agent/dossiers/${parcoursId}`);
     return { success: true, data: undefined };

--- a/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.ts
+++ b/src/features/backoffice/espace-agent/dossiers/actions/rattacher-dossier-dn.actions.ts
@@ -1,0 +1,103 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq } from "drizzle-orm";
+import { db } from "@/shared/database/client";
+import { parcoursAmoValidations } from "@/shared/database/schema";
+import { parcoursRepo, parcoursActionsRepo } from "@/shared/database/repositories";
+import { getCurrentAgent } from "@/features/backoffice/shared/actions/agent.actions";
+import {
+  calculateAgentScope,
+  verifyProspectTerritoryAccess,
+} from "@/features/auth/permissions/services/agent-scope.service";
+import { rattacherDossierManuel } from "@/features/parcours/dossiers-ds/services/reconciliation.service";
+import { buildAuthorSnapshot } from "@/features/backoffice/espace-agent/shared/services/author-snapshot";
+import { ACTION_TYPE_DOSSIER_DN_RATTACHE } from "@/features/backoffice/espace-agent/shared/domain/types/action.types";
+import { UserRole } from "@/shared/domain/value-objects/user-role.enum";
+import type { ActionResult } from "@/shared/types";
+
+/** Mêmes rôles que les autres écritures de suivi sur un dossier. */
+const ROLES_RATTACHEMENT = [
+  UserRole.SUPER_ADMINISTRATEUR,
+  UserRole.AMO,
+  UserRole.ALLERS_VERS,
+  UserRole.AMO_ET_ALLERS_VERS,
+];
+
+/**
+ * Rattache un dossier DN existant à un parcours, par son numéro (ADR-0027).
+ * Recours quand le dossier a été créé hors de notre lien : sans annotation FPA, la
+ * réconciliation automatique ne peut pas le retrouver.
+ *
+ * Accès aligné sur le détail dossier (cf. RBAC-ROLES §6.2) : ownership entreprise quand le
+ * dossier a une AMO, contrôle territorial sinon. La validation métier (dossier réellement
+ * déposé, numéro non déjà pris) est dans le service.
+ */
+export async function rattacherDossierDnAction(parcoursId: string, dsNumber: string): Promise<ActionResult<void>> {
+  try {
+    const agentResult = await getCurrentAgent();
+    if (!agentResult.success) return { success: false, error: agentResult.error };
+    const agent = agentResult.data;
+
+    if (!ROLES_RATTACHEMENT.includes(agent.role)) {
+      return { success: false, error: "Action réservée aux AMO, Allers-vers et super-administrateurs." };
+    }
+
+    const parcours = await parcoursRepo.findById(parcoursId);
+    if (!parcours) return { success: false, error: "Dossier introuvable" };
+
+    const [validation] = await db
+      .select({ entrepriseAmoId: parcoursAmoValidations.entrepriseAmoId })
+      .from(parcoursAmoValidations)
+      .where(eq(parcoursAmoValidations.parcoursId, parcoursId))
+      .limit(1);
+
+    const scope = await calculateAgentScope({
+      id: agent.id,
+      role: agent.role,
+      entrepriseAmoId: agent.entrepriseAmoId ?? null,
+      allersVersId: agent.allersVersId ?? null,
+    });
+
+    if (!scope.canViewAllDossiers) {
+      if (validation?.entrepriseAmoId) {
+        if (validation.entrepriseAmoId !== agent.entrepriseAmoId) {
+          return { success: false, error: "Ce dossier appartient à une autre entreprise AMO." };
+        }
+      } else {
+        // Renvoie le motif de refus, ou null si l'accès est accordé.
+        const refus = await verifyProspectTerritoryAccess(parcoursId, {
+          id: agent.id,
+          role: agent.role,
+          entrepriseAmoId: agent.entrepriseAmoId ?? null,
+          allersVersId: agent.allersVersId ?? null,
+        });
+        if (refus) return { success: false, error: refus };
+      }
+    }
+
+    const result = await rattacherDossierManuel({
+      parcoursId,
+      step: parcours.currentStep,
+      dsNumber,
+    });
+    if (!result.success) return { success: false, error: result.error };
+
+    const snapshot = await buildAuthorSnapshot(agent);
+    await parcoursActionsRepo.create({
+      parcoursId,
+      agentId: agent.id,
+      actionType: ACTION_TYPE_DOSSIER_DN_RATTACHE,
+      message: `Dossier Démarches Numériques n° ${result.data.dsNumber} rattaché manuellement à l'étape ${parcours.currentStep}.`,
+      authorName: snapshot.authorName,
+      authorStructure: snapshot.authorStructure,
+      authorStructureType: snapshot.authorStructureType,
+    });
+
+    revalidatePath(`/espace-agent/dossiers/${parcoursId}`);
+    return { success: true, data: undefined };
+  } catch (error) {
+    console.error("Erreur rattacherDossierDnAction:", error);
+    return { success: false, error: "Erreur lors du rattachement du dossier" };
+  }
+}

--- a/src/features/backoffice/espace-agent/shared/domain/types/action.types.ts
+++ b/src/features/backoffice/espace-agent/shared/domain/types/action.types.ts
@@ -43,10 +43,10 @@ export const ACTION_TYPE_ELIGIBILITE_REFUSEE = "eligibilite_refusee_non_eligible
  */
 export const ACTION_TYPE_ACCOMPAGNEMENT_REFUSE_ELIGIBLE = "accompagnement_refuse_eligible";
 /** Valeur de type d'action "Autre" (nécessite une précision) */
+export const ACTION_TYPE_AUTRE = "autre";
+
 /** Rattachement manuel d'un dossier DN par son numéro (ADR-0027). */
 export const ACTION_TYPE_DOSSIER_DN_RATTACHE = "dossier_dn_rattache";
-
-export const ACTION_TYPE_AUTRE = "autre";
 
 /**
  * Liste groupée des types d'action proposés dans le formulaire (cf. maquette).

--- a/src/features/backoffice/espace-agent/shared/domain/types/action.types.ts
+++ b/src/features/backoffice/espace-agent/shared/domain/types/action.types.ts
@@ -43,6 +43,9 @@ export const ACTION_TYPE_ELIGIBILITE_REFUSEE = "eligibilite_refusee_non_eligible
  */
 export const ACTION_TYPE_ACCOMPAGNEMENT_REFUSE_ELIGIBLE = "accompagnement_refuse_eligible";
 /** Valeur de type d'action "Autre" (nécessite une précision) */
+/** Rattachement manuel d'un dossier DN par son numéro (ADR-0027). */
+export const ACTION_TYPE_DOSSIER_DN_RATTACHE = "dossier_dn_rattache";
+
 export const ACTION_TYPE_AUTRE = "autre";
 
 /**
@@ -121,6 +124,7 @@ export const ACTION_LABELS_BY_VALUE: Record<string, string> = ACTION_TYPE_GROUPS
     [ACTION_TYPE_ELIGIBILITE_ACCEPTEE]: "✅ Éligible — accompagnement accepté",
     [ACTION_TYPE_ELIGIBILITE_REFUSEE]: "❌ Demandeur non éligible",
     [ACTION_TYPE_ACCOMPAGNEMENT_REFUSE_ELIGIBLE]: "⚠️ Éligible — accompagnement refusé",
+    [ACTION_TYPE_DOSSIER_DN_RATTACHE]: "🔗 Dossier DN rattaché",
   } as Record<string, string>
 );
 

--- a/src/features/parcours/core/components/steps/eligibilite/CalloutEligibiliteTodo.tsx
+++ b/src/features/parcours/core/components/steps/eligibilite/CalloutEligibiliteTodo.tsx
@@ -153,7 +153,7 @@ export default function CalloutEligibiliteTodo() {
         </p>
         <button
           onClick={handleSubmit}
-          disabled={isLoading || isRegenerating}
+          disabled={isRegenerating}
           className="fr-btn fr-btn--icon-right fr-icon-external-link-line">
           Remplir le formulaire d'éligibilité
         </button>
@@ -179,7 +179,7 @@ export default function CalloutEligibiliteTodo() {
               </p>
               <button
                 onClick={handleRegenerer}
-                disabled={isLoading || isRegenerating}
+                disabled={isRegenerating}
                 className="fr-btn fr-btn--secondary fr-btn--sm">
                 {isRegenerating ? "Vérification en cours…" : "Créer un nouveau formulaire"}
               </button>

--- a/src/features/parcours/core/components/steps/eligibilite/CalloutEligibiliteTodo.tsx
+++ b/src/features/parcours/core/components/steps/eligibilite/CalloutEligibiliteTodo.tsx
@@ -103,7 +103,13 @@ export default function CalloutEligibiliteTodo() {
         return;
       }
 
-      await handleSubmit();
+      // handleSubmit ouvre sa propre fenêtre, mais nous ne sommes plus dans le geste
+      // utilisateur synchrone : Safari la bloquerait. L'usager relance donc lui-même
+      // depuis le bouton principal, désormais fonctionnel.
+      setRegenerationMessage(
+        "Un nouveau formulaire peut être créé : cliquez sur « Remplir le formulaire d'éligibilité »."
+      );
+      await refresh();
     } catch (err) {
       console.error("Erreur lors de la régénération:", err);
       setError("Une erreur inattendue s'est produite. Veuillez réessayer.");

--- a/src/features/parcours/core/components/steps/eligibilite/CalloutEligibiliteTodo.tsx
+++ b/src/features/parcours/core/components/steps/eligibilite/CalloutEligibiliteTodo.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useParcours } from "../../../context/useParcours";
 import { envoyerDossierEligibiliteAvecDonnees } from "../../../actions";
+import { regenererLienPrefillAction } from "@/features/parcours/dossiers-ds/actions";
+import { Step } from "../../../domain";
 import { useSimulateurRga } from "@/features/simulateur";
 import { ROUTES } from "@/features/auth/client";
 import { StatutValidationAmo } from "@/features/parcours/amo/domain/value-objects";
@@ -11,13 +13,18 @@ import { StatutValidationAmo } from "@/features/parcours/amo/domain/value-object
 export default function CalloutEligibiliteTodo() {
   const router = useRouter();
   const { data: rgaData, clearRGA } = useSimulateurRga();
-  const { refresh, statutAmo } = useParcours(); // Pour rafraîchir après envoi
+  const { refresh, statutAmo, getDossierUrl } = useParcours(); // Pour rafraîchir après envoi
 
   // Quand l'AMO a validé l'accompagnement, on met en avant la confirmation dans le titre.
   const isAmoConfirmed = statutAmo === StatutValidationAmo.LOGEMENT_ELIGIBLE;
 
+  // Un lien existe déjà : c'est le seul cas où « régénérer » a un sens.
+  const aDejaUnLien = !!getDossierUrl(Step.ELIGIBILITE);
+
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [regenerationMessage, setRegenerationMessage] = useState<string | null>(null);
 
   const handleSubmit = async () => {
     setError(null);
@@ -72,6 +79,39 @@ export default function CalloutEligibiliteTodo() {
     }
   };
 
+  // Secours : le lien ne fonctionne plus (mauvais compte DN, brouillon expiré…). On ne sait
+  // pas diagnostiquer côté DN, alors on vérifie d'abord si un ancien numéro a été déposé
+  // entre-temps, sinon on repart d'un formulaire neuf. Cf. ADR-0027.
+  const handleRegenerer = async () => {
+    setError(null);
+    setRegenerationMessage(null);
+    setIsRegenerating(true);
+
+    try {
+      const result = await regenererLienPrefillAction();
+
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+
+      if (result.data.statut === "rattache") {
+        setRegenerationMessage(
+          "Bonne nouvelle : votre dossier a bien été transmis à Démarches Numériques. Nous l'avons retrouvé."
+        );
+        await refresh();
+        return;
+      }
+
+      await handleSubmit();
+    } catch (err) {
+      console.error("Erreur lors de la régénération:", err);
+      setError("Une erreur inattendue s'est produite. Veuillez réessayer.");
+    } finally {
+      setIsRegenerating(false);
+    }
+  };
+
   // Affichage pendant le chargement
   if (isLoading) {
     return (
@@ -107,10 +147,45 @@ export default function CalloutEligibiliteTodo() {
         </p>
         <button
           onClick={handleSubmit}
-          disabled={isLoading}
+          disabled={isLoading || isRegenerating}
           className="fr-btn fr-btn--icon-right fr-icon-external-link-line">
           Remplir le formulaire d'éligibilité
         </button>
+
+        {aDejaUnLien && (
+          <details className="fr-mt-3w">
+            <summary className="fr-text--sm">Ce lien ne fonctionne plus ?</summary>
+            <div className="fr-mt-1w fr-text--sm">
+              <p>
+                Cela arrive quand le formulaire a été ouvert avec un autre compte Démarches Numériques, ou lorsqu'il est
+                resté trop longtemps sans être complété.
+              </p>
+              <p>Avant de recommencer, deux vérifications qui vous feront peut-être gagner du temps :</p>
+              <ul>
+                <li>
+                  connectez-vous à Démarches Numériques <strong>avec l'adresse e-mail que vous utilisez ici</strong> ;
+                </li>
+                <li>regardez vos dossiers en cours : votre formulaire s'y trouve peut-être déjà.</li>
+              </ul>
+              <p>
+                Sinon, nous pouvons vous en créer un nouveau. Attention : ce que vous auriez déjà saisi dans l'ancien
+                formulaire ne sera pas repris.
+              </p>
+              <button
+                onClick={handleRegenerer}
+                disabled={isLoading || isRegenerating}
+                className="fr-btn fr-btn--secondary fr-btn--sm">
+                {isRegenerating ? "Vérification en cours…" : "Créer un nouveau formulaire"}
+              </button>
+            </div>
+          </details>
+        )}
+
+        {regenerationMessage && (
+          <div className="fr-alert fr-alert--success fr-alert--sm fr-mt-2w">
+            <p>{regenerationMessage}</p>
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/features/parcours/core/services/devis.service.ts
+++ b/src/features/parcours/core/services/devis.service.ts
@@ -47,7 +47,7 @@ export async function createDevisDossier(userId: string): Promise<ActionResult<D
     // Idempotence : si un dossier existe déjà pour cette étape, le retourner.
     const existing = await getDossierByStep(parcoursData.parcours.id, Step.DEVIS);
     if (existing) {
-      debug.log("Dossier devis déjà existant, renvoi de l'URL:", existing.dsUrl);
+      debug.log("Dossier devis déjà existant, n° :", existing.dsNumber);
       return {
         success: true,
         data: {
@@ -108,7 +108,6 @@ export async function createDevisDossier(userId: string): Promise<ActionResult<D
     const createResponse = await prefillClient.createPrefillDossier(prefillData, Step.DEVIS);
 
     debug.log("=== RÉPONSE DS ===");
-    debug.log("  dossier_url:", createResponse.dossier_url);
     debug.log("  dossier_number:", createResponse.dossier_number);
     debug.log("  dossier_id:", createResponse.dossier_id);
     debug.log("A vérifier côté DS : annotations privées + commune et adresse préremplies.");

--- a/src/features/parcours/core/services/diagnostic.service.ts
+++ b/src/features/parcours/core/services/diagnostic.service.ts
@@ -46,7 +46,7 @@ export async function createDiagnosticDossier(userId: string): Promise<ActionRes
     // Idempotence : si un dossier existe déjà pour cette étape, le retourner.
     const existing = await getDossierByStep(parcoursData.parcours.id, Step.DIAGNOSTIC);
     if (existing) {
-      debug.log("Dossier diagnostic déjà existant, renvoi de l'URL:", existing.dsUrl);
+      debug.log("Dossier diagnostic déjà existant, n° :", existing.dsNumber);
       return {
         success: true,
         data: {
@@ -100,7 +100,6 @@ export async function createDiagnosticDossier(userId: string): Promise<ActionRes
     const createResponse = await prefillClient.createPrefillDossier(prefillData, Step.DIAGNOSTIC);
 
     debug.log("=== RÉPONSE DS ===");
-    debug.log("  dossier_url:", createResponse.dossier_url);
     debug.log("  dossier_number:", createResponse.dossier_number);
     debug.log("  dossier_id:", createResponse.dossier_id);
     debug.log("A vérifier côté DS : annotations privées + commune et adresse préremplies.");

--- a/src/features/parcours/core/services/eligibilite.service.ts
+++ b/src/features/parcours/core/services/eligibilite.service.ts
@@ -85,7 +85,7 @@ export async function createEligibiliteDossier(
     // (le current_status ne sert plus de verrou anti-doublon, cf. ADR-0009).
     const existing = await getDossierByStep(parcoursData.parcours.id, Step.ELIGIBILITE);
     if (existing) {
-      debug.log("Dossier éligibilité déjà existant, renvoi de l'URL:", existing.dsUrl);
+      debug.log("Dossier éligibilité déjà existant, n° :", existing.dsNumber);
       return {
         success: true,
         data: {
@@ -192,8 +192,8 @@ export async function createEligibiliteDossier(
     debug.log("Envoi à Démarches Simplifiées...");
     const createResponse = await prefillClient.createPrefillDossier(prefillData, Step.ELIGIBILITE);
 
+    // Jamais l'URL : elle porte le `prefill_token`, qui permet de réclamer le brouillon (ADR-0027).
     debug.log("Réponse de DS:", {
-      dossier_url: createResponse.dossier_url,
       dossier_number: createResponse.dossier_number,
       dossier_id: createResponse.dossier_id,
     });

--- a/src/features/parcours/dossiers-ds/actions/index.ts
+++ b/src/features/parcours/dossiers-ds/actions/index.ts
@@ -1,2 +1,3 @@
 export * from "./demarches-admin.actions";
 export * from "./dossier-sync.actions";
+export * from "./regeneration.actions";

--- a/src/features/parcours/dossiers-ds/actions/regeneration.actions.ts
+++ b/src/features/parcours/dossiers-ds/actions/regeneration.actions.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { getSession } from "@/features/auth/server";
+import type { ActionResult } from "@/shared/types";
+import { regenererLienPrefill, type ResultatRegeneration } from "../services/regeneration.service";
+
+/**
+ * Secours « ce lien ne fonctionne plus » côté demandeur (ADR-0027).
+ * Scopée par la session : le demandeur n'agit que sur son propre parcours.
+ */
+export async function regenererLienPrefillAction(): Promise<ActionResult<ResultatRegeneration>> {
+  const session = await getSession();
+  if (!session?.userId) {
+    return { success: false, error: "Vous devez être connecté" };
+  }
+
+  try {
+    return await regenererLienPrefill(session.userId);
+  } catch (error) {
+    console.error("Erreur regenererLienPrefillAction:", error);
+    return { success: false, error: "Erreur lors de la régénération du lien" };
+  }
+}

--- a/src/features/parcours/dossiers-ds/adapters/graphql/client.ts
+++ b/src/features/parcours/dossiers-ds/adapters/graphql/client.ts
@@ -166,6 +166,12 @@ export class DemarchesSimplifieesClient {
                 label
                 stringValue
               }
+              # Porte le lien FPA (donc le parcoursId) : clé de rattachement, cf. ADR-0027.
+              annotations {
+                id
+                label
+                stringValue
+              }
             }
           }
         }

--- a/src/features/parcours/dossiers-ds/adapters/graphql/client.ts
+++ b/src/features/parcours/dossiers-ds/adapters/graphql/client.ts
@@ -6,6 +6,8 @@ import type {
   GraphQLResponse,
   QueryVariables,
   DossiersFilters,
+  DossierReconciliation,
+  DossiersReconciliationConnection,
 } from "./types";
 
 /**
@@ -199,6 +201,79 @@ export class DemarchesSimplifieesClient {
       console.error(`Failed to fetch dossiers for demarche ${number}:`, error);
       return null;
     }
+  }
+
+  /**
+   * Dossiers d'une démarche, projection minimale pour la réconciliation (ADR-0027).
+   * Volontairement plus pauvre que `getDemarcheDossiers` : sur une démarche entière, on ne
+   * ramène ni les champs ni l'email usager, dont la réconciliation n'a aucun usage.
+   */
+  async getDossiersPourReconciliation(
+    number: number,
+    filters?: DossiersFilters
+  ): Promise<DossiersReconciliationConnection | null> {
+    const query = `
+      query GetDossiersReconciliation($number: Int!, $first: Int, $after: String, $updatedSince: ISO8601DateTime) {
+        demarche(number: $number) {
+          dossiers(first: $first, after: $after, updatedSince: $updatedSince, order: ASC) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              number
+              state
+              archived
+              dateDepot
+              dateDerniereModification
+              annotations {
+                champDescriptorId
+                stringValue
+                prefilled
+                prefilledValueModified
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    try {
+      const data = await this.executeQuery<{
+        demarche: { dossiers: DossiersReconciliationConnection };
+      }>(query, { number, first: filters?.first ?? 100, after: filters?.after, updatedSince: filters?.updatedSince });
+
+      return data.demarche?.dossiers || null;
+    } catch (error) {
+      console.error(`Échec du balayage de réconciliation (démarche ${number}):`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Un dossier avec sa démarche et ses annotations, pour le rattachement manuel : c'est la
+   * démarche qui donne l'étape réelle, pas l'étape courante du parcours (ADR-0027).
+   */
+  async getDossierPourRattachement(dossierNumber: number): Promise<DossierReconciliation | null> {
+    const query = `
+      query GetDossierRattachement($number: Int!) {
+        dossier(number: $number) {
+          id
+          number
+          state
+          archived
+          dateDepot
+          demarche { number }
+          annotations {
+            champDescriptorId
+            stringValue
+            prefilled
+            prefilledValueModified
+          }
+        }
+      }
+    `;
+
+    const data = await this.executeQuery<{ dossier: DossierReconciliation }>(query, { number: dossierNumber });
+    return data.dossier;
   }
 
   /**

--- a/src/features/parcours/dossiers-ds/adapters/graphql/client.ts
+++ b/src/features/parcours/dossiers-ds/adapters/graphql/client.ts
@@ -8,6 +8,7 @@ import type {
   DossiersFilters,
   DossierReconciliation,
   DossiersReconciliationConnection,
+  DossierInspection,
 } from "./types";
 
 /**
@@ -274,6 +275,43 @@ export class DemarchesSimplifieesClient {
 
     const data = await this.executeQuery<{ dossier: DossierReconciliation }>(query, { number: dossierNumber });
     return data.dossier;
+  }
+
+  /**
+   * Tout ce que DN sait d'un dossier et qui peut servir à retrouver son demandeur :
+   * compte usager, identité déclarée, et champs du formulaire (ADR-0027).
+   */
+  async getDossierPourInspection(dossierNumber: number): Promise<DossierInspection | null> {
+    const query = `
+      query GetDossierInspection($number: Int!) {
+        dossier(number: $number) {
+          number
+          state
+          dateDepot
+          deposeParUnTiers
+          nomMandataire
+          prenomMandataire
+          usager { email }
+          demandeur {
+            __typename
+            ... on PersonnePhysique { nom prenom }
+          }
+          champs {
+            champDescriptorId
+            label
+            stringValue
+          }
+        }
+      }
+    `;
+
+    try {
+      const data = await this.executeQuery<{ dossier: DossierInspection }>(query, { number: dossierNumber });
+      return data.dossier;
+    } catch (error) {
+      console.error(`Inspection DN impossible pour le dossier ${dossierNumber}:`, error);
+      return null;
+    }
   }
 
   /**

--- a/src/features/parcours/dossiers-ds/adapters/graphql/types.ts
+++ b/src/features/parcours/dossiers-ds/adapters/graphql/types.ts
@@ -124,6 +124,35 @@ export interface Attachment {
   contentType?: string;
 }
 
+/** Annotation réduite à ce qui sert au rattachement (ADR-0027). */
+export interface AnnotationReconciliation {
+  champDescriptorId: string;
+  stringValue?: string | null;
+  prefilled?: boolean;
+  prefilledValueModified?: boolean;
+}
+
+/**
+ * Projection minimale d'un dossier pour la réconciliation : pas de `champs`, pas d'email
+ * usager, pas de motivation. Balayer une démarche entière ne doit pas ramener de données
+ * personnelles dont on n'a pas l'usage.
+ */
+export interface DossierReconciliation {
+  id: string;
+  number: number;
+  state: DossierState;
+  archived: boolean;
+  dateDepot?: string;
+  dateDerniereModification?: string;
+  demarche?: { number: number };
+  annotations?: AnnotationReconciliation[];
+}
+
+export interface DossiersReconciliationConnection {
+  pageInfo: PageInfo;
+  nodes: DossierReconciliation[];
+}
+
 export interface DossiersConnection {
   pageInfo: PageInfo;
   nodes: Dossier[];

--- a/src/features/parcours/dossiers-ds/adapters/graphql/types.ts
+++ b/src/features/parcours/dossiers-ds/adapters/graphql/types.ts
@@ -153,6 +153,19 @@ export interface DossiersReconciliationConnection {
   nodes: DossierReconciliation[];
 }
 
+/** Projection d'inspection : ce qui aide un humain à identifier le demandeur d'un dossier. */
+export interface DossierInspection {
+  number: number;
+  state: DossierState;
+  dateDepot?: string;
+  deposeParUnTiers?: boolean;
+  nomMandataire?: string | null;
+  prenomMandataire?: string | null;
+  usager?: { email: string };
+  demandeur?: { __typename?: string; nom?: string | null; prenom?: string | null };
+  champs?: Array<{ champDescriptorId: string; label: string; stringValue?: string | null }>;
+}
+
 export interface DossiersConnection {
   pageInfo: PageInfo;
   nodes: Dossier[];

--- a/src/features/parcours/dossiers-ds/domain/types/inspection.types.ts
+++ b/src/features/parcours/dossiers-ds/domain/types/inspection.types.ts
@@ -1,0 +1,43 @@
+/**
+ * Types de l'inspection d'un dossier DN orphelin (ADR-0027).
+ *
+ * Isolés du service : celui-ci importe le client Postgres, qu'un composant client ne peut pas
+ * charger. Ce module ne dépend de rien et traverse donc la frontière serveur/client.
+ */
+
+/** Ce qui a fait correspondre un demandeur, du plus fiable au moins fiable. */
+export type MotifRapprochement = "adresse_logement" | "telephone" | "email" | "nom_prenom";
+
+export const MOTIF_LABELS: Record<MotifRapprochement, string> = {
+  adresse_logement: "même adresse de logement",
+  telephone: "même téléphone",
+  email: "même adresse e-mail",
+  nom_prenom: "mêmes nom et prénom",
+};
+
+export interface CandidatDemandeur {
+  parcoursId: string;
+  userId: string;
+  nom: string | null;
+  prenom: string | null;
+  email: string | null;
+  currentStep: string;
+  adresse: string | null;
+  motifs: MotifRapprochement[];
+}
+
+export interface InspectionDossier {
+  dn: {
+    number: number;
+    state: string;
+    dateDepot?: string;
+    emailUsager: string | null;
+    nomDeclare: string | null;
+    prenomDeclare: string | null;
+    deposeParUnTiers: boolean;
+    mandataire: string | null;
+    /** Champs du formulaire non vides, tels que DN les renvoie. */
+    champs: Array<{ label: string; valeur: string }>;
+  };
+  candidats: CandidatDemandeur[];
+}

--- a/src/features/parcours/dossiers-ds/domain/value-objects/ds-annotations.ts
+++ b/src/features/parcours/dossiers-ds/domain/value-objects/ds-annotations.ts
@@ -1,3 +1,6 @@
+import { Step } from "@/shared/domain/value-objects/step.enum";
+import { DS_FIELD_IDS } from "./ds-field-ids";
+
 /**
  * Annotations privées (instructeur) dont l'id dépend de la démarche.
  *
@@ -33,4 +36,15 @@ export function getAnnotationLienFpaEligibilite(demarcheNumber: number): string 
     return null;
   }
   return champId;
+}
+
+/**
+ * Id du descripteur de l'annotation « lien FPA » pour une étape donnée. Diagnostic et devis
+ * partagent le même id (antérieur au clonage) ; l'éligibilité dépend de la démarche.
+ */
+export function getAnnotationLienFpaId(step: Step, demarcheNumber: number): string | null {
+  if (step === Step.ELIGIBILITE) return getAnnotationLienFpaEligibilite(demarcheNumber);
+  if (step === Step.DIAGNOSTIC) return DS_FIELD_IDS.DIAGNOSTIC.ANNOTATION_LIEN_FPA;
+  if (step === Step.DEVIS) return DS_FIELD_IDS.DEVIS.ANNOTATION_LIEN_FPA;
+  return null;
 }

--- a/src/features/parcours/dossiers-ds/services/dossier-ds.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/dossier-ds.service.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createDossierForCurrentStep } from "./dossier-ds.service";
+import { db } from "@/shared/database/client";
+import { dossiersDsTentativesRepo } from "@/shared/database/repositories";
+import { ORIGINE_TENTATIVE } from "@/shared/database/schema";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+
+vi.mock("@/shared/database/client", () => ({ db: { transaction: vi.fn() } }));
+
+vi.mock("@/shared/database/repositories", () => ({
+  dossiersDsTentativesRepo: { record: vi.fn() },
+}));
+
+vi.mock("@/shared/email/brevo", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/email/brevo")>()),
+  emitBrevoEvent: vi.fn(),
+}));
+
+const params = {
+  dsNumber: "32052358",
+  dsDemarcheId: "126061",
+  dsUrl: "https://dn.example/commencer/uuid?prefill_token=secret",
+  dsId: "RG9zc2llci0x",
+};
+
+/** Transaction factice : rend la ligne insérée et laisse observer les appels au registre. */
+function mockTransaction() {
+  const tx = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "dossier-1" }]),
+      }),
+    }),
+  };
+  vi.mocked(db.transaction).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (async (cb: any) => cb(tx)) as any
+  );
+  return tx;
+}
+
+// Cf. ADR-0027 : un pointeur sans tentative connue perdrait le numéro au premier remplacement.
+describe("createDossierForCurrentStep — registre des tentatives", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(dossiersDsTentativesRepo.record).mockResolvedValue(undefined);
+  });
+
+  it("enregistre la tentative avec le pointeur, dans la même transaction", async () => {
+    const tx = mockTransaction();
+
+    const result = await createDossierForCurrentStep("user-1", "parcours-1", Step.ELIGIBILITE, params);
+
+    expect(result.success).toBe(true);
+    expect(dossiersDsTentativesRepo.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parcoursId: "parcours-1",
+        step: Step.ELIGIBILITE,
+        dsNumber: "32052358",
+        origine: ORIGINE_TENTATIVE.PREFILL,
+        dsId: "RG9zc2llci0x",
+      }),
+      tx
+    );
+  });
+
+  it("échoue sans créer de pointeur si le registre ne peut pas être écrit", async () => {
+    mockTransaction();
+    vi.mocked(dossiersDsTentativesRepo.record).mockRejectedValue(new Error("boom"));
+
+    const result = await createDossierForCurrentStep("user-1", "parcours-1", Step.ELIGIBILITE, params);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/features/parcours/dossiers-ds/services/dossier-ds.service.ts
+++ b/src/features/parcours/dossiers-ds/services/dossier-ds.service.ts
@@ -52,7 +52,6 @@ export async function createDossierForCurrentStep(
           origine: ORIGINE_TENTATIVE.PREFILL,
           dsId: params.dsId,
           dsDemarcheId: params.dsDemarcheId,
-          dsUrl: params.dsUrl,
         },
         tx
       );

--- a/src/features/parcours/dossiers-ds/services/dossier-ds.service.ts
+++ b/src/features/parcours/dossiers-ds/services/dossier-ds.service.ts
@@ -1,5 +1,6 @@
 import { db } from "@/shared/database/client";
-import { dossiersDemarchesSimplifiees } from "@/shared/database/schema";
+import { dossiersDemarchesSimplifiees, ORIGINE_TENTATIVE } from "@/shared/database/schema";
+import { dossiersDsTentativesRepo } from "@/shared/database/repositories";
 import { eq, and, desc } from "drizzle-orm";
 import type { Step } from "../../core/domain/value-objects/step";
 import { DSStatus } from "../domain/value-objects/ds-status";
@@ -28,17 +29,36 @@ export async function createDossierForCurrentStep(
   params: CreateDossierDSParams
 ): Promise<ActionResult<{ dossierId: string }>> {
   try {
-    const [dossier] = await db
-      .insert(dossiersDemarchesSimplifiees)
-      .values({
-        parcoursId,
-        step,
-        dsNumber: params.dsNumber,
-        dsDemarcheId: params.dsDemarcheId,
-        dsUrl: params.dsUrl,
-        dsId: params.dsId,
-      })
-      .returning();
+    // Pointeur et registre dans la même transaction : un pointeur sans tentative connue
+    // doit être impossible, sinon le numéro se perd au premier remplacement (ADR-0027).
+    const dossier = await db.transaction(async (tx) => {
+      const [row] = await tx
+        .insert(dossiersDemarchesSimplifiees)
+        .values({
+          parcoursId,
+          step,
+          dsNumber: params.dsNumber,
+          dsDemarcheId: params.dsDemarcheId,
+          dsUrl: params.dsUrl,
+          dsId: params.dsId,
+        })
+        .returning();
+
+      await dossiersDsTentativesRepo.record(
+        {
+          parcoursId,
+          step,
+          dsNumber: params.dsNumber,
+          origine: ORIGINE_TENTATIVE.PREFILL,
+          dsId: params.dsId,
+          dsDemarcheId: params.dsDemarcheId,
+          dsUrl: params.dsUrl,
+        },
+        tx
+      );
+
+      return row;
+    });
 
     // Synchro Brevo (flux) : dossier DN créé en brouillon (déposé plus tard, ds_status
     // encore NULL). Réutilise DN_UPDATE avec old/new vides plutôt qu'un évènement dédié —

--- a/src/features/parcours/dossiers-ds/services/inspection.service.ts
+++ b/src/features/parcours/dossiers-ds/services/inspection.service.ts
@@ -3,6 +3,7 @@ import { db } from "@/shared/database/client";
 import { parcoursPrevention, users } from "@/shared/database/schema";
 import { graphqlClient } from "../adapters/graphql/client";
 import type { DossierInspection } from "../adapters/graphql/types";
+import type { CandidatDemandeur, InspectionDossier, MotifRapprochement } from "../domain/types/inspection.types";
 
 /**
  * Aide à identifier le demandeur d'un dossier DN qu'aucun parcours ne suit (ADR-0027).
@@ -11,43 +12,6 @@ import type { DossierInspection } from "../adapters/graphql/types";
  * une adresse e-mail peut être celle de l'AMO, un nom peut être porté par deux personnes. La
  * décision reste humaine, l'écran ne fait que lui épargner l'enquête.
  */
-
-/** Ce qui a fait correspondre un demandeur, du plus fiable au moins fiable. */
-export type MotifRapprochement = "adresse_logement" | "telephone" | "email" | "nom_prenom";
-
-export const MOTIF_LABELS: Record<MotifRapprochement, string> = {
-  adresse_logement: "même adresse de logement",
-  telephone: "même téléphone",
-  email: "même adresse e-mail",
-  nom_prenom: "mêmes nom et prénom",
-};
-
-export interface CandidatDemandeur {
-  parcoursId: string;
-  userId: string;
-  nom: string | null;
-  prenom: string | null;
-  email: string | null;
-  currentStep: string;
-  adresse: string | null;
-  motifs: MotifRapprochement[];
-}
-
-export interface InspectionDossier {
-  dn: {
-    number: number;
-    state: string;
-    dateDepot?: string;
-    emailUsager: string | null;
-    nomDeclare: string | null;
-    prenomDeclare: string | null;
-    deposeParUnTiers: boolean;
-    mandataire: string | null;
-    /** Champs du formulaire non vides, tels que DN les renvoie. */
-    champs: Array<{ label: string; valeur: string }>;
-  };
-  candidats: CandidatDemandeur[];
-}
 
 /** Derniers chiffres d'un numéro, pour comparer des formats de saisie hétérogènes. */
 function chiffresSignificatifs(telephone: string | null | undefined): string | null {

--- a/src/features/parcours/dossiers-ds/services/inspection.service.ts
+++ b/src/features/parcours/dossiers-ds/services/inspection.service.ts
@@ -1,0 +1,166 @@
+import { eq, or, sql } from "drizzle-orm";
+import { db } from "@/shared/database/client";
+import { parcoursPrevention, users } from "@/shared/database/schema";
+import { graphqlClient } from "../adapters/graphql/client";
+import type { DossierInspection } from "../adapters/graphql/types";
+
+/**
+ * Aide à identifier le demandeur d'un dossier DN qu'aucun parcours ne suit (ADR-0027).
+ *
+ * Ne rattache rien : rapproche. Les critères ci-dessous sont des indices, pas des preuves —
+ * une adresse e-mail peut être celle de l'AMO, un nom peut être porté par deux personnes. La
+ * décision reste humaine, l'écran ne fait que lui épargner l'enquête.
+ */
+
+/** Ce qui a fait correspondre un demandeur, du plus fiable au moins fiable. */
+export type MotifRapprochement = "adresse_logement" | "telephone" | "email" | "nom_prenom";
+
+export const MOTIF_LABELS: Record<MotifRapprochement, string> = {
+  adresse_logement: "même adresse de logement",
+  telephone: "même téléphone",
+  email: "même adresse e-mail",
+  nom_prenom: "mêmes nom et prénom",
+};
+
+export interface CandidatDemandeur {
+  parcoursId: string;
+  userId: string;
+  nom: string | null;
+  prenom: string | null;
+  email: string | null;
+  currentStep: string;
+  adresse: string | null;
+  motifs: MotifRapprochement[];
+}
+
+export interface InspectionDossier {
+  dn: {
+    number: number;
+    state: string;
+    dateDepot?: string;
+    emailUsager: string | null;
+    nomDeclare: string | null;
+    prenomDeclare: string | null;
+    deposeParUnTiers: boolean;
+    mandataire: string | null;
+    /** Champs du formulaire non vides, tels que DN les renvoie. */
+    champs: Array<{ label: string; valeur: string }>;
+  };
+  candidats: CandidatDemandeur[];
+}
+
+/** Derniers chiffres d'un numéro, pour comparer des formats de saisie hétérogènes. */
+function chiffresSignificatifs(telephone: string | null | undefined): string | null {
+  const chiffres = telephone?.replace(/\D/g, "") ?? "";
+  return chiffres.length >= 9 ? chiffres.slice(-9) : null;
+}
+
+/** Repère un champ par son libellé : les ids de champ diffèrent d'une démarche à l'autre. */
+function champParLibelle(dn: DossierInspection, motif: RegExp): string | null {
+  const champ = dn.champs?.find((c) => motif.test(c.label) && c.stringValue?.trim());
+  return champ?.stringValue?.trim() ?? null;
+}
+
+export async function inspecterDossierDn(dsNumber: string): Promise<InspectionDossier | null> {
+  const dn = await graphqlClient.getDossierPourInspection(Number(dsNumber));
+  if (!dn) return null;
+
+  const emailUsager = dn.usager?.email?.toLowerCase().trim() ?? null;
+  const nomDeclare = dn.demandeur?.nom?.trim() ?? null;
+  const prenomDeclare = dn.demandeur?.prenom?.trim() ?? null;
+  const telephone = champParLibelle(dn, /t[ée]l[ée]phone/i);
+  const adresse = champParLibelle(dn, /adresse postale de la maison/i);
+  const telephoneCourt = chiffresSignificatifs(telephone);
+
+  const conditions = [];
+  if (emailUsager) {
+    conditions.push(sql`lower(${users.email}) = ${emailUsager}`);
+    conditions.push(sql`lower(${users.emailContact}) = ${emailUsager}`);
+  }
+  if (telephoneCourt) {
+    conditions.push(sql`regexp_replace(coalesce(${users.telephone}, ''), '\\D', '', 'g') LIKE ${"%" + telephoneCourt}`);
+  }
+  if (nomDeclare && prenomDeclare) {
+    conditions.push(
+      sql`lower(${users.nom}) = ${nomDeclare.toLowerCase()} AND lower(${users.prenom}) = ${prenomDeclare.toLowerCase()}`
+    );
+  }
+  if (adresse) {
+    conditions.push(
+      sql`coalesce(${parcoursPrevention.rgaSimulationData}, ${parcoursPrevention.rgaSimulationDataAgent})->'logement'->>'adresse' ILIKE ${adresse}`
+    );
+  }
+
+  const champs = (dn.champs ?? [])
+    .filter((c) => c.stringValue?.trim())
+    .map((c) => ({ label: c.label, valeur: c.stringValue!.trim() }));
+
+  const infosDn: InspectionDossier["dn"] = {
+    number: dn.number,
+    state: dn.state,
+    dateDepot: dn.dateDepot,
+    emailUsager,
+    nomDeclare,
+    prenomDeclare,
+    deposeParUnTiers: !!dn.deposeParUnTiers,
+    mandataire: [dn.prenomMandataire, dn.nomMandataire].filter(Boolean).join(" ").trim() || null,
+    champs,
+  };
+
+  // Aucun critère exploitable : inutile de balayer la table des demandeurs.
+  if (conditions.length === 0) return { dn: infosDn, candidats: [] };
+
+  const lignes = await db
+    .select({
+      parcoursId: parcoursPrevention.id,
+      userId: users.id,
+      nom: users.nom,
+      prenom: users.prenom,
+      email: users.email,
+      emailContact: users.emailContact,
+      telephone: users.telephone,
+      currentStep: parcoursPrevention.currentStep,
+      adresse: sql<
+        string | null
+      >`coalesce(${parcoursPrevention.rgaSimulationData}, ${parcoursPrevention.rgaSimulationDataAgent})->'logement'->>'adresse'`,
+    })
+    .from(parcoursPrevention)
+    .innerJoin(users, eq(users.id, parcoursPrevention.userId))
+    .where(or(...conditions))
+    .limit(20);
+
+  // Les motifs sont recalculés ici plutôt que dans le SQL : on veut les afficher un par un.
+  const candidats: CandidatDemandeur[] = lignes.map((l) => {
+    const motifs: MotifRapprochement[] = [];
+
+    if (adresse && l.adresse?.toLowerCase() === adresse.toLowerCase()) motifs.push("adresse_logement");
+    if (telephoneCourt && chiffresSignificatifs(l.telephone) === telephoneCourt) motifs.push("telephone");
+    if (emailUsager && (l.email?.toLowerCase() === emailUsager || l.emailContact?.toLowerCase() === emailUsager)) {
+      motifs.push("email");
+    }
+    if (
+      nomDeclare &&
+      prenomDeclare &&
+      l.nom?.toLowerCase() === nomDeclare.toLowerCase() &&
+      l.prenom?.toLowerCase() === prenomDeclare.toLowerCase()
+    ) {
+      motifs.push("nom_prenom");
+    }
+
+    return {
+      parcoursId: l.parcoursId,
+      userId: l.userId,
+      nom: l.nom,
+      prenom: l.prenom,
+      email: l.emailContact ?? l.email,
+      currentStep: l.currentStep,
+      adresse: l.adresse,
+      motifs,
+    };
+  });
+
+  // Le plus de motifs concordants d'abord : c'est le candidat le plus probable.
+  candidats.sort((a, b) => b.motifs.length - a.motifs.length);
+
+  return { dn: infosDn, candidats };
+}

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { decideRattachement, type ContexteRattachement } from "./reconciliation.service";
-import { extraireParcoursIdDepuisAnnotations } from "../utils/annotation-fpa.utils";
+import {
+  extraireParcoursIdDepuisAnnotations,
+  extraireParcoursIdsDepuisAnnotations,
+} from "../utils/annotation-fpa.utils";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 
 vi.mock("@/shared/database/client", () => ({ db: {} }));
@@ -58,6 +61,10 @@ describe("decideRattachement", () => {
     expect(decideRattachement({ ...candidat, parcoursId: null }, ctx())).toBe("sans_annotation");
   });
 
+  it("refuse de trancher quand deux annotations pointent des parcours différents", () => {
+    expect(decideRattachement({ ...candidat, annotationAmbigue: true }, ctx())).toBe("annotation_ambigue");
+  });
+
   it("classe à part une annotation pointant un parcours inconnu", () => {
     expect(decideRattachement(candidat, ctx({ parcoursExiste: false }))).toBe("parcours_inconnu");
   });
@@ -76,6 +83,17 @@ describe("extraireParcoursIdDepuisAnnotations", () => {
     expect(extraireParcoursIdDepuisAnnotations(undefined)).toBeNull();
     expect(extraireParcoursIdDepuisAnnotations([])).toBeNull();
     expect(extraireParcoursIdDepuisAnnotations([{ stringValue: "https://exemple.fr/autre-chose" }])).toBeNull();
+  });
+
+  it("remonte les parcours distincts quand plusieurs annotations divergent", () => {
+    const autre = "11111111-1111-1111-1111-111111111111";
+    const annotations = [
+      { stringValue: `https://fpa.gouv.fr/espace-agent/dossiers/${PARCOURS}` },
+      { stringValue: `https://fpa.gouv.fr/espace-agent/dossiers/${autre}` },
+    ];
+    expect(extraireParcoursIdsDepuisAnnotations(annotations)).toHaveLength(2);
+    // Ambigu : la fonction « une seule valeur » ne tranche pas.
+    expect(extraireParcoursIdDepuisAnnotations(annotations)).toBeNull();
   });
 
   it("ignore une valeur qui n'est pas un uuid valide", () => {

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
@@ -24,6 +24,7 @@ function ctx(overrides: Partial<ContexteRattachement> = {}): ContexteRattachemen
     pointeurConfirme: false,
     parcoursIdDuNumero: null,
     plusieursCandidats: false,
+    numeroDejaConnu: false,
     ...overrides,
   };
 }
@@ -58,8 +59,14 @@ describe("decideRattachement", () => {
     expect(decideRattachement(candidat, ctx({ plusieursCandidats: true }))).toBe("conflit_plusieurs_deposes");
   });
 
-  it("classe à part un dossier déposé sans annotation FPA", () => {
+  it("classe à part un dossier déposé sans annotation FPA et inconnu de nous", () => {
     expect(decideRattachement({ ...candidat, parcoursId: null }, ctx())).toBe("sans_annotation");
+  });
+
+  it("ne signale rien pour un dossier sans annotation dont le numéro nous est déjà connu", () => {
+    // Cas de tous les dossiers antérieurs à l'ajout de l'annotation : rattachés depuis
+    // toujours, ils n'ont rien à faire dans une file de travail.
+    expect(decideRattachement({ ...candidat, parcoursId: null }, ctx({ numeroDejaConnu: true }))).toBe("deja_a_jour");
   });
 
   it("refuse de trancher quand deux annotations pointent des parcours différents", () => {

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
-import { decideRattachement, type ContexteRattachement } from "./reconciliation.service";
+import { decideRattachement, observationsAPersister, type ContexteRattachement } from "./reconciliation.service";
 import { lireAnnotationFpa } from "../utils/annotation-fpa.utils";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 
 vi.mock("@/shared/database/client", () => ({ db: {} }));
+vi.mock("@/shared/database/repositories", () => ({
+  dossiersDsTentativesRepo: { findByDsNumber: vi.fn(), record: vi.fn() },
+  dsObservationsRepo: { upsertMany: vi.fn() },
+}));
 
 // Le singleton du client GraphQL lit l'env DN à la construction : inutile ici, la règle testée
 // est pure.
@@ -120,5 +124,35 @@ describe("lireAnnotationFpa", () => {
   it("ignore une valeur qui n'est pas un uuid valide", () => {
     const annotations = [{ champDescriptorId: DESCRIPTEUR, stringValue: "/espace-agent/dossiers/pas-un-uuid" }];
     expect(lireAnnotationFpa(annotations, DESCRIPTEUR).parcoursId).toBeNull();
+  });
+});
+
+// La file du back-office ne doit contenir que ce qui demande une action humaine.
+describe("observationsAPersister", () => {
+  const ligne = (verdict: string) => ({
+    dsNumber: "32052358",
+    step: Step.ELIGIBILITE,
+    state: "accepte",
+    parcoursId: PARCOURS,
+    verdict,
+    pointeurAvant: null,
+  });
+
+  it("écarte les dossiers déjà à jour", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(observationsAPersister([ligne("deja_a_jour")] as any, false)).toHaveLength(0);
+  });
+
+  it("garde les conflits et les dossiers sans annotation", () => {
+    const lignes = [ligne("conflit_plusieurs_deposes"), ligne("sans_annotation"), ligne("annotation_modifiee")];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(observationsAPersister(lignes as any, false)).toHaveLength(3);
+  });
+
+  it("garde un rattachement proposé en observation, mais pas une fois appliqué", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(observationsAPersister([ligne("rattachement")] as any, false)).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(observationsAPersister([ligne("rattachement")] as any, true)).toHaveLength(0);
   });
 });

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
@@ -6,7 +6,7 @@ import { Step } from "@/shared/domain/value-objects/step.enum";
 vi.mock("@/shared/database/client", () => ({ db: {} }));
 vi.mock("@/shared/database/repositories", () => ({
   dossiersDsTentativesRepo: { findByDsNumber: vi.fn(), record: vi.fn() },
-  dsObservationsRepo: { upsertMany: vi.fn() },
+  dsObservationsRepo: { upsertMany: vi.fn(), refermerReglees: vi.fn() },
 }));
 
 // Le singleton du client GraphQL lit l'env DN à la construction : inutile ici, la règle testée

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { decideRattachement, type ContexteRattachement } from "./reconciliation.service";
+import { extraireParcoursIdDepuisAnnotations } from "../utils/annotation-fpa.utils";
+import { Step } from "@/shared/domain/value-objects/step.enum";
+
+vi.mock("@/shared/database/client", () => ({ db: {} }));
+
+// Le singleton du client GraphQL lit l'env DN à la construction : inutile ici, la règle testée
+// est pure.
+vi.mock("../adapters/graphql/client", () => ({ graphqlClient: { getDemarcheDossiers: vi.fn() } }));
+
+const PARCOURS = "c3ffd5bb-7b8b-4d0d-a5b6-1ff91cabc975";
+
+const candidat = { dsNumber: "32052358", step: Step.ELIGIBILITE, state: "accepte", parcoursId: PARCOURS };
+
+function ctx(overrides: Partial<ContexteRattachement> = {}): ContexteRattachement {
+  return {
+    parcoursExiste: true,
+    pointeurDsNumber: null,
+    pointeurConfirme: false,
+    parcoursIdDuNumero: null,
+    plusieursCandidats: false,
+    ...overrides,
+  };
+}
+
+// Cf. ADR-0027 : le rattachement se fait au dépôt, et un conflit ne se tranche jamais tout seul.
+describe("decideRattachement", () => {
+  it("rattache un dossier déposé quand le parcours n'a aucun pointeur", () => {
+    expect(decideRattachement(candidat, ctx())).toBe("rattachement");
+  });
+
+  it("rattache quand le pointeur courant n'est qu'une tentative jamais observée", () => {
+    expect(decideRattachement(candidat, ctx({ pointeurDsNumber: "32872663" }))).toBe("rattachement");
+  });
+
+  it("ne fait rien si le pointeur vise déjà ce numéro", () => {
+    expect(decideRattachement(candidat, ctx({ pointeurDsNumber: "32052358" }))).toBe("deja_a_jour");
+  });
+
+  it("refuse de voler un numéro déjà rattaché à un autre parcours", () => {
+    expect(decideRattachement(candidat, ctx({ parcoursIdDuNumero: "11111111-1111-1111-1111-111111111111" }))).toBe(
+      "conflit_autre_parcours"
+    );
+  });
+
+  it("signale un conflit quand le parcours a déjà un dossier confirmé sous un autre numéro", () => {
+    expect(decideRattachement(candidat, ctx({ pointeurDsNumber: "32872663", pointeurConfirme: true }))).toBe(
+      "conflit_dossier_confirme"
+    );
+  });
+
+  it("signale un conflit quand plusieurs dossiers déposés visent le même parcours", () => {
+    expect(decideRattachement(candidat, ctx({ plusieursCandidats: true }))).toBe("conflit_plusieurs_deposes");
+  });
+
+  it("classe à part un dossier déposé sans annotation FPA", () => {
+    expect(decideRattachement({ ...candidat, parcoursId: null }, ctx())).toBe("sans_annotation");
+  });
+
+  it("classe à part une annotation pointant un parcours inconnu", () => {
+    expect(decideRattachement(candidat, ctx({ parcoursExiste: false }))).toBe("parcours_inconnu");
+  });
+});
+
+describe("extraireParcoursIdDepuisAnnotations", () => {
+  it("extrait le parcoursId de l'URL du lien FPA", () => {
+    const annotations = [
+      { stringValue: "Autre annotation" },
+      { stringValue: `https://fonds-prevention-argile.beta.gouv.fr/espace-agent/dossiers/${PARCOURS}` },
+    ];
+    expect(extraireParcoursIdDepuisAnnotations(annotations)).toBe(PARCOURS);
+  });
+
+  it("renvoie null sans annotation, ou sans lien FPA dedans", () => {
+    expect(extraireParcoursIdDepuisAnnotations(undefined)).toBeNull();
+    expect(extraireParcoursIdDepuisAnnotations([])).toBeNull();
+    expect(extraireParcoursIdDepuisAnnotations([{ stringValue: "https://exemple.fr/autre-chose" }])).toBeNull();
+  });
+
+  it("ignore une valeur qui n'est pas un uuid valide", () => {
+    expect(extraireParcoursIdDepuisAnnotations([{ stringValue: "/espace-agent/dossiers/pas-un-uuid" }])).toBeNull();
+  });
+});

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { decideRattachement, type ContexteRattachement } from "./reconciliation.service";
-import {
-  extraireParcoursIdDepuisAnnotations,
-  extraireParcoursIdsDepuisAnnotations,
-} from "../utils/annotation-fpa.utils";
+import { lireAnnotationFpa } from "../utils/annotation-fpa.utils";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 
 vi.mock("@/shared/database/client", () => ({ db: {} }));
@@ -65,38 +62,63 @@ describe("decideRattachement", () => {
     expect(decideRattachement({ ...candidat, annotationAmbigue: true }, ctx())).toBe("annotation_ambigue");
   });
 
+  it("refuse de trancher quand l'annotation a été modifiée à la main", () => {
+    expect(decideRattachement({ ...candidat, annotationModifiee: true }, ctx())).toBe("annotation_modifiee");
+  });
+
   it("classe à part une annotation pointant un parcours inconnu", () => {
     expect(decideRattachement(candidat, ctx({ parcoursExiste: false }))).toBe("parcours_inconnu");
   });
 });
 
-describe("extraireParcoursIdDepuisAnnotations", () => {
-  it("extrait le parcoursId de l'URL du lien FPA", () => {
+const DESCRIPTEUR = "Q2hhbXAtNjY4NzQ1Mg==";
+const lien = (id: string) => `https://fonds-prevention-argile.beta.gouv.fr/espace-agent/dossiers/${id}`;
+
+describe("lireAnnotationFpa", () => {
+  it("lit le parcoursId de l'annotation identifiée par son descripteur", () => {
     const annotations = [
-      { stringValue: "Autre annotation" },
-      { stringValue: `https://fonds-prevention-argile.beta.gouv.fr/espace-agent/dossiers/${PARCOURS}` },
+      { champDescriptorId: "autre", stringValue: lien("11111111-1111-1111-1111-111111111111") },
+      { champDescriptorId: DESCRIPTEUR, stringValue: lien(PARCOURS) },
     ];
-    expect(extraireParcoursIdDepuisAnnotations(annotations)).toBe(PARCOURS);
+    // Le descripteur écarte l'annotation parasite : on ne lit QUE la bonne.
+    expect(lireAnnotationFpa(annotations, DESCRIPTEUR)).toEqual({
+      parcoursId: PARCOURS,
+      ambigue: false,
+      modifiee: false,
+    });
+  });
+
+  it("signale une valeur préremplie modifiée à la main", () => {
+    const annotations = [{ champDescriptorId: DESCRIPTEUR, stringValue: lien(PARCOURS), prefilledValueModified: true }];
+    expect(lireAnnotationFpa(annotations, DESCRIPTEUR).modifiee).toBe(true);
+  });
+
+  it("signale l'ambiguïté quand deux annotations divergent", () => {
+    const annotations = [
+      { champDescriptorId: DESCRIPTEUR, stringValue: lien(PARCOURS) },
+      { champDescriptorId: DESCRIPTEUR, stringValue: lien("11111111-1111-1111-1111-111111111111") },
+    ];
+    const lecture = lireAnnotationFpa(annotations, DESCRIPTEUR);
+    expect(lecture.ambigue).toBe(true);
+    expect(lecture.parcoursId).toBeNull();
+  });
+
+  it("retombe sur la reconnaissance du chemin si le descripteur est inconnu", () => {
+    const annotations = [{ champDescriptorId: "peu-importe", stringValue: lien(PARCOURS) }];
+    expect(lireAnnotationFpa(annotations, null).parcoursId).toBe(PARCOURS);
   });
 
   it("renvoie null sans annotation, ou sans lien FPA dedans", () => {
-    expect(extraireParcoursIdDepuisAnnotations(undefined)).toBeNull();
-    expect(extraireParcoursIdDepuisAnnotations([])).toBeNull();
-    expect(extraireParcoursIdDepuisAnnotations([{ stringValue: "https://exemple.fr/autre-chose" }])).toBeNull();
-  });
-
-  it("remonte les parcours distincts quand plusieurs annotations divergent", () => {
-    const autre = "11111111-1111-1111-1111-111111111111";
-    const annotations = [
-      { stringValue: `https://fpa.gouv.fr/espace-agent/dossiers/${PARCOURS}` },
-      { stringValue: `https://fpa.gouv.fr/espace-agent/dossiers/${autre}` },
-    ];
-    expect(extraireParcoursIdsDepuisAnnotations(annotations)).toHaveLength(2);
-    // Ambigu : la fonction « une seule valeur » ne tranche pas.
-    expect(extraireParcoursIdDepuisAnnotations(annotations)).toBeNull();
+    expect(lireAnnotationFpa(undefined, DESCRIPTEUR).parcoursId).toBeNull();
+    expect(lireAnnotationFpa([], DESCRIPTEUR).parcoursId).toBeNull();
+    expect(
+      lireAnnotationFpa([{ champDescriptorId: DESCRIPTEUR, stringValue: "https://exemple.fr/x" }], DESCRIPTEUR)
+        .parcoursId
+    ).toBeNull();
   });
 
   it("ignore une valeur qui n'est pas un uuid valide", () => {
-    expect(extraireParcoursIdDepuisAnnotations([{ stringValue: "/espace-agent/dossiers/pas-un-uuid" }])).toBeNull();
+    const annotations = [{ champDescriptorId: DESCRIPTEUR, stringValue: "/espace-agent/dossiers/pas-un-uuid" }];
+    expect(lireAnnotationFpa(annotations, DESCRIPTEUR).parcoursId).toBeNull();
   });
 });

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/shared/database/repositories", () => ({
 // Le singleton du client GraphQL lit l'env DN à la construction : inutile ici, la règle testée
 // est pure.
 vi.mock("../adapters/graphql/client", () => ({ graphqlClient: { getDemarcheDossiers: vi.fn() } }));
+vi.mock("./inspection.service", () => ({ inspecterDossierDn: vi.fn() }));
 
 const PARCOURS = "c3ffd5bb-7b8b-4d0d-a5b6-1ff91cabc975";
 
@@ -154,6 +155,24 @@ describe("observationsAPersister", () => {
     const lignes = [ligne("conflit_plusieurs_deposes"), ligne("sans_annotation"), ligne("annotation_modifiee")];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(observationsAPersister(lignes as any, false)).toHaveLength(3);
+  });
+
+  it("attache au dossier orphelin les demandeurs qui lui correspondent", () => {
+    const candidats = [{ parcoursId: PARCOURS, motifs: ["telephone"] }];
+    const observations = observationsAPersister(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [ligne("sans_annotation")] as any,
+      false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      new Map([["32052358", candidats as any]])
+    );
+
+    expect(observations[0].candidats).toEqual(candidats);
+  });
+
+  it("n'invente pas de candidat pour un dossier qu'aucun rapprochement ne couvre", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(observationsAPersister([ligne("sans_annotation")] as any, false)[0].candidats).toBeNull();
   });
 
   it("garde un rattachement proposé en observation, mais pas une fois appliqué", () => {

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -1,7 +1,8 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/shared/database/client";
 import {
   dossiersDemarchesSimplifiees,
+  dossiersDsTentatives,
   ORIGINE_TENTATIVE,
   parcoursPrevention,
   type OrigineTentative,
@@ -59,6 +60,8 @@ export interface ContexteRattachement {
   parcoursIdDuNumero: string | null;
   /** Plusieurs dossiers déposés portent le même parcoursId sur cette étape. */
   plusieursCandidats: boolean;
+  /** Ce numéro est déjà rattaché chez nous (pointeur ou registre), annotation ou pas. */
+  numeroDejaConnu: boolean;
 }
 
 /**
@@ -69,7 +72,13 @@ export function decideRattachement(candidat: CandidatReconciliation, ctx: Contex
   // Une annotation retouchée ou divergente n'est plus une source fiable : arbitrage humain.
   if (candidat.annotationAmbigue) return "annotation_ambigue";
   if (candidat.annotationModifiee) return "annotation_modifiee";
-  if (!candidat.parcoursId) return "sans_annotation";
+
+  if (!candidat.parcoursId) {
+    // Sans annotation, on sait quand même à qui est le dossier si son numéro est déjà chez
+    // nous : c'est le cas de tous les dossiers antérieurs à l'ajout de l'annotation. Ne
+    // restent en file manuelle que ceux créés entièrement hors du parcours FPA.
+    return ctx.numeroDejaConnu ? "deja_a_jour" : "sans_annotation";
+  }
   if (!ctx.parcoursExiste) return "parcours_inconnu";
 
   // Un numéro n'appartient qu'à un seul parcours : on ne le vole jamais à un autre.
@@ -308,6 +317,27 @@ async function collecterCandidats(
   return { candidats, complet: false, raison: `plafond de ${maxPages} pages atteint`, pages };
 }
 
+/** Numéros DN déjà rattachés chez nous, pointeurs et registre confondus. */
+async function chargerNumerosConnus(dsNumbers: string[]): Promise<Set<string>> {
+  if (dsNumbers.length === 0) return new Set();
+
+  const [pointeurs, tentatives] = await Promise.all([
+    db
+      .select({ dsNumber: dossiersDemarchesSimplifiees.dsNumber })
+      .from(dossiersDemarchesSimplifiees)
+      .where(inArray(dossiersDemarchesSimplifiees.dsNumber, dsNumbers)),
+    db
+      .select({ dsNumber: dossiersDsTentatives.dsNumber })
+      .from(dossiersDsTentatives)
+      .where(inArray(dossiersDsTentatives.dsNumber, dsNumbers)),
+  ]);
+
+  const connus = new Set<string>();
+  for (const p of pointeurs) if (p.dsNumber) connus.add(p.dsNumber);
+  for (const t of tentatives) connus.add(t.dsNumber);
+  return connus;
+}
+
 /** Repointe l'étape vers le dossier réel et remet son état à zéro : la sync le recopiera. */
 async function appliquerRattachement(
   candidat: { parcoursId: string; step: Step; dsNumber: string; dsDemarcheId: string },
@@ -402,6 +432,10 @@ export async function reconcilierDemarche(options: {
     if (c.parcoursId) parNombreDeCandidats.set(c.parcoursId, (parNombreDeCandidats.get(c.parcoursId) ?? 0) + 1);
   }
 
+  // Préchargé en deux requêtes plutôt qu'une par candidat : sur une démarche entière, la
+  // très grande majorité des dossiers déposés nous sont déjà connus.
+  const numerosConnus = await chargerNumerosConnus(candidats.map((c) => c.dsNumber));
+
   const lignes: LigneRapport[] = [];
   const totaux = totauxVides();
   let rattachementsAppliques = 0;
@@ -413,6 +447,7 @@ export async function reconcilierDemarche(options: {
       pointeurConfirme: false,
       parcoursIdDuNumero: null,
       plusieursCandidats: false,
+      numeroDejaConnu: numerosConnus.has(candidat.dsNumber),
     };
 
     if (candidat.parcoursId) {
@@ -445,6 +480,7 @@ export async function reconcilierDemarche(options: {
         pointeurConfirme: !!(pointeur?.submittedAt || pointeur?.lastSyncAt),
         parcoursIdDuNumero: tentative?.parcoursId ?? null,
         plusieursCandidats: (parNombreDeCandidats.get(candidat.parcoursId) ?? 0) > 1,
+        numeroDejaConnu: numerosConnus.has(candidat.dsNumber),
       };
     }
 

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -7,10 +7,11 @@ import {
   type OrigineTentative,
 } from "@/shared/database/schema";
 import { dossiersDsTentativesRepo } from "@/shared/database/repositories";
-import type { Step } from "@/shared/domain/value-objects/step.enum";
+import { Step } from "@/shared/domain/value-objects/step.enum";
 import type { ActionResult } from "@/shared/types";
 import { graphqlClient } from "../adapters/graphql/client";
-import { extraireParcoursIdsDepuisAnnotations } from "../utils/annotation-fpa.utils";
+import { lireAnnotationFpa } from "../utils/annotation-fpa.utils";
+import { getAnnotationLienFpaId } from "../domain/value-objects/ds-annotations";
 import { resolveDemarcheNumberForStep } from "./pieces-justificatives.service";
 
 /**
@@ -33,6 +34,7 @@ export type VerdictReconciliation =
   | "conflit_plusieurs_deposes"
   | "sans_annotation"
   | "annotation_ambigue"
+  | "annotation_modifiee"
   | "parcours_inconnu";
 
 export interface CandidatReconciliation {
@@ -40,8 +42,10 @@ export interface CandidatReconciliation {
   step: Step;
   state: string;
   parcoursId: string | null;
-  /** Plusieurs annotations portent des parcours différents : annotation retouchée à la main. */
+  /** Plusieurs annotations portent des parcours différents : dossier dupliqué ou retouché. */
   annotationAmbigue?: boolean;
+  /** DN signale la valeur préremplie comme modifiée à la main : elle ne fait plus foi. */
+  annotationModifiee?: boolean;
 }
 
 /** État local nécessaire pour trancher, lu en base. */
@@ -62,8 +66,9 @@ export interface ContexteRattachement {
  * On ne tranche jamais automatiquement un conflit : il remonte pour arbitrage humain.
  */
 export function decideRattachement(candidat: CandidatReconciliation, ctx: ContexteRattachement): VerdictReconciliation {
-  // Une annotation retouchée n'est plus une source fiable : arbitrage humain.
+  // Une annotation retouchée ou divergente n'est plus une source fiable : arbitrage humain.
   if (candidat.annotationAmbigue) return "annotation_ambigue";
+  if (candidat.annotationModifiee) return "annotation_modifiee";
   if (!candidat.parcoursId) return "sans_annotation";
   if (!ctx.parcoursExiste) return "parcours_inconnu";
 
@@ -105,19 +110,33 @@ function totauxVides(): Record<VerdictReconciliation, number> {
     conflit_plusieurs_deposes: 0,
     sans_annotation: 0,
     annotation_ambigue: 0,
+    annotation_modifiee: 0,
     parcours_inconnu: 0,
   };
 }
 
 export type RefusRattachementManuel =
-  "numero_invalide" | "introuvable_cote_dn" | "deja_rattache_ailleurs" | "dossier_deja_confirme";
+  | "numero_invalide"
+  | "introuvable_cote_dn"
+  | "deja_rattache_ailleurs"
+  | "dossier_deja_confirme"
+  | "demarche_inconnue"
+  | "annotation_autre_parcours";
 
 export const MESSAGES_RATTACHEMENT_MANUEL: Record<RefusRattachementManuel, string> = {
   numero_invalide: "Le numéro de dossier doit être composé de chiffres uniquement.",
   introuvable_cote_dn: "Aucun dossier déposé ne porte ce numéro côté Démarches Numériques.",
   deja_rattache_ailleurs: "Ce numéro est déjà rattaché à un autre demandeur.",
   dossier_deja_confirme: "Ce parcours a déjà un dossier déposé pour cette étape : à trancher avant de rattacher.",
+  demarche_inconnue: "Ce dossier appartient à une démarche qui ne fait pas partie du parcours FPA.",
+  annotation_autre_parcours: "Ce dossier porte déjà le lien d'un autre demandeur : à vérifier avant de rattacher.",
 };
+
+/** Étape correspondant à une démarche DN, ou `null` si elle n'est pas configurée. */
+function stepDeLaDemarche(demarcheNumber: number): Step | null {
+  const steps = [Step.ELIGIBILITE, Step.DIAGNOSTIC, Step.DEVIS, Step.FACTURES];
+  return steps.find((s) => resolveDemarcheNumberForStep(s) === demarcheNumber) ?? null;
+}
 
 /**
  * Rattachement manuel d'un dossier DN à un parcours, par son numéro (ADR-0027).
@@ -126,9 +145,8 @@ export const MESSAGES_RATTACHEMENT_MANUEL: Record<RefusRattachementManuel, strin
  */
 export async function rattacherDossierManuel(params: {
   parcoursId: string;
-  step: Step;
   dsNumber: string;
-}): Promise<ActionResult<{ dsNumber: string }>> {
+}): Promise<ActionResult<{ dsNumber: string; step: Step }>> {
   const dsNumber = params.dsNumber.trim();
   if (!/^\d+$/.test(dsNumber)) {
     return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.numero_invalide };
@@ -136,14 +154,28 @@ export async function rattacherDossierManuel(params: {
 
   // Le dossier doit exister côté DN : un brouillon non déposé y est invisible, on ne rattache
   // donc que du réel.
-  let existeCoteDn = false;
+  let dossierDn: Awaited<ReturnType<typeof graphqlClient.getDossierPourRattachement>> = null;
   try {
-    existeCoteDn = !!(await graphqlClient.getDossierStatus(Number(dsNumber)));
+    dossierDn = await graphqlClient.getDossierPourRattachement(Number(dsNumber));
   } catch {
-    existeCoteDn = false;
+    dossierDn = null;
   }
-  if (!existeCoteDn) {
+  if (!dossierDn) {
     return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.introuvable_cote_dn };
+  }
+
+  // L'étape vient de la démarche du dossier, jamais de l'étape courante du parcours : sinon un
+  // dossier d'éligibilité pourrait être enregistré comme diagnostic (ADR-0027).
+  const demarcheNumber = dossierDn.demarche?.number;
+  const step = demarcheNumber ? stepDeLaDemarche(demarcheNumber) : null;
+  if (!step || !demarcheNumber) {
+    return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.demarche_inconnue };
+  }
+
+  // Si le dossier porte déjà un lien FPA vers un AUTRE parcours, on ne le vole pas.
+  const lecture = lireAnnotationFpa(dossierDn.annotations, getAnnotationLienFpaId(step, demarcheNumber));
+  if (lecture.parcoursId && lecture.parcoursId !== params.parcoursId) {
+    return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.annotation_autre_parcours };
   }
 
   // Les deux tables portent chacune leur unicité sur `ds_number` : il faut interroger les deux,
@@ -170,10 +202,7 @@ export async function rattacherDossierManuel(params: {
     })
     .from(dossiersDemarchesSimplifiees)
     .where(
-      and(
-        eq(dossiersDemarchesSimplifiees.parcoursId, params.parcoursId),
-        eq(dossiersDemarchesSimplifiees.step, params.step)
-      )
+      and(eq(dossiersDemarchesSimplifiees.parcoursId, params.parcoursId), eq(dossiersDemarchesSimplifiees.step, step))
     )
     .limit(1);
 
@@ -183,12 +212,7 @@ export async function rattacherDossierManuel(params: {
 
   try {
     await appliquerRattachement(
-      {
-        parcoursId: params.parcoursId,
-        step: params.step,
-        dsNumber,
-        dsDemarcheId: String(resolveDemarcheNumberForStep(params.step)),
-      },
+      { parcoursId: params.parcoursId, step, dsNumber, dsDemarcheId: String(demarcheNumber) },
       ORIGINE_TENTATIVE.MANUEL
     );
   } catch (error) {
@@ -196,7 +220,7 @@ export async function rattacherDossierManuel(params: {
     return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.deja_rattache_ailleurs };
   }
 
-  return { success: true, data: { dsNumber } };
+  return { success: true, data: { dsNumber, step } };
 }
 
 interface Collecte {
@@ -219,13 +243,14 @@ async function collecterCandidats(
   updatedSince?: string,
   maxPages = 100
 ): Promise<Collecte> {
+  const descripteurAttendu = getAnnotationLienFpaId(step, demarcheNumber);
   const candidats: CandidatReconciliation[] = [];
   let after: string | undefined;
   let pages = 0;
 
   while (pages < maxPages) {
     pages++;
-    const conn = await graphqlClient.getDemarcheDossiers(demarcheNumber, { first: 100, after, updatedSince });
+    const conn = await graphqlClient.getDossiersPourReconciliation(demarcheNumber, { first: 100, after, updatedSince });
     // Le client convertit toute erreur DN en `null` : impossible de distinguer une démarche
     // vide d'un appel en échec, donc on considère le scan incomplet.
     if (!conn) {
@@ -233,13 +258,14 @@ async function collecterCandidats(
     }
 
     for (const node of conn.nodes) {
-      const parcoursIds = extraireParcoursIdsDepuisAnnotations(node.annotations);
+      const lecture = lireAnnotationFpa(node.annotations, descripteurAttendu);
       candidats.push({
         dsNumber: String(node.number),
         step,
         state: node.state,
-        parcoursId: parcoursIds.length === 1 ? parcoursIds[0] : null,
-        annotationAmbigue: parcoursIds.length > 1,
+        parcoursId: lecture.parcoursId,
+        annotationAmbigue: lecture.ambigue,
+        annotationModifiee: lecture.modifiee,
       });
     }
 

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -1,0 +1,250 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/shared/database/client";
+import { dossiersDemarchesSimplifiees, ORIGINE_TENTATIVE, parcoursPrevention } from "@/shared/database/schema";
+import { dossiersDsTentativesRepo } from "@/shared/database/repositories";
+import type { Step } from "@/shared/domain/value-objects/step.enum";
+import { graphqlClient } from "../adapters/graphql/client";
+import { extraireParcoursIdDepuisAnnotations } from "../utils/annotation-fpa.utils";
+
+/**
+ * Réconciliation des dossiers DÉPOSÉS avec leur parcours (ADR-0027).
+ *
+ * Un brouillon est invisible de l'API instructeur : on ne peut rien rapprocher avant le dépôt.
+ * Au dépôt en revanche, le dossier devient visible et porte l'annotation « lien FPA », donc le
+ * `parcoursId` — quel que soit le compte DN utilisé, l'ordinateur, ou le nombre de brouillons
+ * abandonnés en route. C'est ce lien-là qu'on rétablit ici.
+ *
+ * Par défaut le service n'écrit RIEN : il rend un rapport. L'écriture est explicite (`apply`).
+ */
+
+/** Ce que le service décide de faire d'un dossier déposé. */
+export type VerdictReconciliation =
+  | "rattachement"
+  | "deja_a_jour"
+  | "conflit_autre_parcours"
+  | "conflit_dossier_confirme"
+  | "conflit_plusieurs_deposes"
+  | "sans_annotation"
+  | "parcours_inconnu";
+
+export interface CandidatReconciliation {
+  dsNumber: string;
+  step: Step;
+  state: string;
+  parcoursId: string | null;
+}
+
+/** État local nécessaire pour trancher, lu en base. */
+export interface ContexteRattachement {
+  parcoursExiste: boolean;
+  /** Pointeur courant de l'étape, s'il existe. */
+  pointeurDsNumber: string | null;
+  /** Le pointeur a-t-il déjà été observé déposé ? Un simple prérempli ne fait pas foi. */
+  pointeurConfirme: boolean;
+  /** Parcours auquel ce numéro est déjà rattaché au registre, s'il est connu. */
+  parcoursIdDuNumero: string | null;
+  /** Plusieurs dossiers déposés portent le même parcoursId sur cette étape. */
+  plusieursCandidats: boolean;
+}
+
+/**
+ * Règle de rattachement, sans effet de bord (cf. tableau de l'ADR-0027).
+ * On ne tranche jamais automatiquement un conflit : il remonte pour arbitrage humain.
+ */
+export function decideRattachement(candidat: CandidatReconciliation, ctx: ContexteRattachement): VerdictReconciliation {
+  if (!candidat.parcoursId) return "sans_annotation";
+  if (!ctx.parcoursExiste) return "parcours_inconnu";
+
+  // Un numéro n'appartient qu'à un seul parcours : on ne le vole jamais à un autre.
+  if (ctx.parcoursIdDuNumero && ctx.parcoursIdDuNumero !== candidat.parcoursId) return "conflit_autre_parcours";
+
+  if (ctx.pointeurDsNumber === candidat.dsNumber) return "deja_a_jour";
+  if (ctx.plusieursCandidats) return "conflit_plusieurs_deposes";
+
+  // Le pointeur courant a déjà été observé déposé sous un autre numéro : deux dossiers réels
+  // pour une même étape, c'est une décision métier, pas un choix technique.
+  if (ctx.pointeurDsNumber && ctx.pointeurConfirme) return "conflit_dossier_confirme";
+
+  return "rattachement";
+}
+
+export interface LigneRapport extends CandidatReconciliation {
+  verdict: VerdictReconciliation;
+  pointeurAvant: string | null;
+}
+
+export interface RapportReconciliation {
+  lignes: LigneRapport[];
+  totaux: Record<VerdictReconciliation, number>;
+  rattachementsAppliques: number;
+}
+
+function totauxVides(): Record<VerdictReconciliation, number> {
+  return {
+    rattachement: 0,
+    deja_a_jour: 0,
+    conflit_autre_parcours: 0,
+    conflit_dossier_confirme: 0,
+    conflit_plusieurs_deposes: 0,
+    sans_annotation: 0,
+    parcours_inconnu: 0,
+  };
+}
+
+/** Pagination complète des dossiers d'une démarche (DN plafonne à 100 par page). */
+async function collecterCandidats(
+  demarcheNumber: number,
+  step: Step,
+  updatedSince?: string,
+  maxPages = 100
+): Promise<CandidatReconciliation[]> {
+  const candidats: CandidatReconciliation[] = [];
+  let after: string | undefined;
+  let pages = 0;
+
+  while (pages < maxPages) {
+    pages++;
+    const conn = await graphqlClient.getDemarcheDossiers(demarcheNumber, { first: 100, after, updatedSince });
+    if (!conn) break;
+
+    for (const node of conn.nodes) {
+      candidats.push({
+        dsNumber: String(node.number),
+        step,
+        state: node.state,
+        parcoursId: extraireParcoursIdDepuisAnnotations(node.annotations),
+      });
+    }
+
+    if (!conn.pageInfo.hasNextPage) break;
+    after = conn.pageInfo.endCursor ?? undefined;
+    if (!after) break;
+  }
+
+  return candidats;
+}
+
+/** Repointe l'étape vers le dossier réel et remet son état à zéro : la sync le recopiera. */
+async function appliquerRattachement(candidat: CandidatReconciliation & { parcoursId: string }): Promise<void> {
+  await db.transaction(async (tx) => {
+    const [existant] = await tx
+      .select({ id: dossiersDemarchesSimplifiees.id, dsDemarcheId: dossiersDemarchesSimplifiees.dsDemarcheId })
+      .from(dossiersDemarchesSimplifiees)
+      .where(
+        and(
+          eq(dossiersDemarchesSimplifiees.parcoursId, candidat.parcoursId),
+          eq(dossiersDemarchesSimplifiees.step, candidat.step)
+        )
+      )
+      .limit(1);
+
+    if (existant) {
+      await tx
+        .update(dossiersDemarchesSimplifiees)
+        .set({
+          dsNumber: candidat.dsNumber,
+          dsId: null,
+          dsStatus: null,
+          submittedAt: null,
+          instructedAt: null,
+          processedAt: null,
+          lastSyncAt: null,
+          dnProbeState: null,
+          dnProbeAt: null,
+          // Le lien prefill de l'ancienne tentative ne pointe plus vers ce dossier.
+          dsUrl: null,
+        })
+        .where(eq(dossiersDemarchesSimplifiees.id, existant.id));
+    }
+
+    await dossiersDsTentativesRepo.record(
+      {
+        parcoursId: candidat.parcoursId,
+        step: candidat.step,
+        dsNumber: candidat.dsNumber,
+        origine: ORIGINE_TENTATIVE.RECONCILIATION,
+        dsDemarcheId: existant?.dsDemarcheId ?? null,
+      },
+      tx
+    );
+  });
+}
+
+/**
+ * Balaye une démarche et rapproche ses dossiers déposés des parcours.
+ * `apply = false` (défaut) : aucune écriture, on rend seulement le rapport.
+ */
+export async function reconcilierDemarche(options: {
+  demarcheNumber: number;
+  step: Step;
+  updatedSince?: string;
+  apply?: boolean;
+}): Promise<RapportReconciliation> {
+  const { demarcheNumber, step, updatedSince, apply = false } = options;
+
+  const candidats = await collecterCandidats(demarcheNumber, step, updatedSince);
+
+  // Un même parcours visé par plusieurs dossiers déposés = conflit, jamais un choix arbitraire.
+  const parNombreDeCandidats = new Map<string, number>();
+  for (const c of candidats) {
+    if (c.parcoursId) parNombreDeCandidats.set(c.parcoursId, (parNombreDeCandidats.get(c.parcoursId) ?? 0) + 1);
+  }
+
+  const lignes: LigneRapport[] = [];
+  const totaux = totauxVides();
+  let rattachementsAppliques = 0;
+
+  for (const candidat of candidats) {
+    let ctx: ContexteRattachement = {
+      parcoursExiste: false,
+      pointeurDsNumber: null,
+      pointeurConfirme: false,
+      parcoursIdDuNumero: null,
+      plusieursCandidats: false,
+    };
+
+    if (candidat.parcoursId) {
+      const [parcours] = await db
+        .select({ id: parcoursPrevention.id })
+        .from(parcoursPrevention)
+        .where(eq(parcoursPrevention.id, candidat.parcoursId))
+        .limit(1);
+
+      const [pointeur] = await db
+        .select({
+          dsNumber: dossiersDemarchesSimplifiees.dsNumber,
+          submittedAt: dossiersDemarchesSimplifiees.submittedAt,
+          lastSyncAt: dossiersDemarchesSimplifiees.lastSyncAt,
+        })
+        .from(dossiersDemarchesSimplifiees)
+        .where(
+          and(
+            eq(dossiersDemarchesSimplifiees.parcoursId, candidat.parcoursId),
+            eq(dossiersDemarchesSimplifiees.step, candidat.step)
+          )
+        )
+        .limit(1);
+
+      const tentative = await dossiersDsTentativesRepo.findByDsNumber(candidat.dsNumber);
+
+      ctx = {
+        parcoursExiste: !!parcours,
+        pointeurDsNumber: pointeur?.dsNumber ?? null,
+        pointeurConfirme: !!(pointeur?.submittedAt || pointeur?.lastSyncAt),
+        parcoursIdDuNumero: tentative?.parcoursId ?? null,
+        plusieursCandidats: (parNombreDeCandidats.get(candidat.parcoursId) ?? 0) > 1,
+      };
+    }
+
+    const verdict = decideRattachement(candidat, ctx);
+    totaux[verdict] += 1;
+    lignes.push({ ...candidat, verdict, pointeurAvant: ctx.pointeurDsNumber });
+
+    if (apply && verdict === "rattachement" && candidat.parcoursId) {
+      await appliquerRattachement({ ...candidat, parcoursId: candidat.parcoursId });
+      rattachementsAppliques++;
+    }
+  }
+
+  return { lignes, totaux, rattachementsAppliques };
+}

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -14,6 +14,8 @@ import { graphqlClient } from "../adapters/graphql/client";
 import { lireAnnotationFpa } from "../utils/annotation-fpa.utils";
 import { getAnnotationLienFpaId } from "../domain/value-objects/ds-annotations";
 import { resolveDemarcheNumberForStep } from "./pieces-justificatives.service";
+import { inspecterDossierDn } from "./inspection.service";
+import type { CandidatDemandeur } from "../domain/types/inspection.types";
 
 /**
  * Réconciliation des dossiers DÉPOSÉS avec leur parcours (ADR-0027).
@@ -108,7 +110,8 @@ export interface LigneRapport extends CandidatReconciliation {
  */
 export function observationsAPersister(
   lignes: LigneRapport[],
-  rattachementsAppliques: boolean
+  rattachementsAppliques: boolean,
+  candidatsParDossier: Map<string, CandidatDemandeur[]> = new Map()
 ): Array<{
   dsNumber: string;
   parcoursId: string | null;
@@ -116,6 +119,7 @@ export function observationsAPersister(
   verdict: string;
   dsState: string | null;
   detail: string | null;
+  candidats: CandidatDemandeur[] | null;
 }> {
   return lignes
     .filter((l) => l.verdict !== "deja_a_jour" && !(rattachementsAppliques && l.verdict === "rattachement"))
@@ -126,7 +130,36 @@ export function observationsAPersister(
       verdict: l.verdict,
       dsState: l.state,
       detail: l.pointeurAvant ? `Pointeur au moment du constat : #${l.pointeurAvant}` : null,
+      candidats: candidatsParDossier.get(l.dsNumber) ?? null,
     }));
+}
+
+/**
+ * Plafond de rapprochements par balayage. Chaque orphelin coûte un appel DN : sur une démarche
+ * saine ils se comptent sur les doigts d'une main, mais un incident pourrait en produire des
+ * centaines et transformer une analyse en attente interminable.
+ */
+const MAX_RAPPROCHEMENTS = 30;
+
+/**
+ * Cherche à qui appartiennent les dossiers qu'aucune annotation ne rattache. Fait ici, au
+ * balayage, plutôt qu'au clic : l'agent ouvre la file avec les correspondances déjà trouvées.
+ * Best-effort — un échec DN laisse la ligne sans candidat, jamais en erreur.
+ */
+async function rapprocherOrphelins(lignes: LigneRapport[]): Promise<Map<string, CandidatDemandeur[]>> {
+  const orphelins = lignes.filter((l) => l.verdict === "sans_annotation").slice(0, MAX_RAPPROCHEMENTS);
+  const parDossier = new Map<string, CandidatDemandeur[]>();
+
+  for (const ligne of orphelins) {
+    try {
+      const inspection = await inspecterDossierDn(ligne.dsNumber);
+      if (inspection) parDossier.set(ligne.dsNumber, inspection.candidats);
+    } catch (error) {
+      console.error(`Rapprochement impossible pour le dossier ${ligne.dsNumber}:`, error);
+    }
+  }
+
+  return parDossier;
 }
 
 export interface RapportReconciliation {
@@ -504,7 +537,8 @@ export async function reconcilierDemarche(options: {
     }
   }
 
-  await dsObservationsRepo.upsertMany(observationsAPersister(lignes, peutEcrire));
+  const candidatsParDossier = await rapprocherOrphelins(lignes);
+  await dsObservationsRepo.upsertMany(observationsAPersister(lignes, peutEcrire, candidatsParDossier));
 
   // Symétrique : ce qui n'a plus rien à signaler sort de la file. Sans ça, une observation
   // faite avant une correction resterait ouverte pour toujours.

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -84,6 +84,11 @@ export interface RapportReconciliation {
   lignes: LigneRapport[];
   totaux: Record<VerdictReconciliation, number>;
   rattachementsAppliques: number;
+  /** Le balayage a-t-il vu TOUS les dossiers du périmètre demandé ? */
+  scanComplet: boolean;
+  /** Pourquoi le balayage s'est arrêté avant la fin, le cas échéant. */
+  scanIncompletRaison?: string;
+  pagesLues: number;
 }
 
 function totauxVides(): Record<VerdictReconciliation, number> {
@@ -135,8 +140,19 @@ export async function rattacherDossierManuel(params: {
     return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.introuvable_cote_dn };
   }
 
+  // Les deux tables portent chacune leur unicité sur `ds_number` : il faut interroger les deux,
+  // sinon un numéro déjà pointé ailleurs mais absent du registre passerait (ADR-0027).
   const tentative = await dossiersDsTentativesRepo.findByDsNumber(dsNumber);
   if (tentative && tentative.parcoursId !== params.parcoursId) {
+    return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.deja_rattache_ailleurs };
+  }
+
+  const [pointeurAilleurs] = await db
+    .select({ parcoursId: dossiersDemarchesSimplifiees.parcoursId })
+    .from(dossiersDemarchesSimplifiees)
+    .where(eq(dossiersDemarchesSimplifiees.dsNumber, dsNumber))
+    .limit(1);
+  if (pointeurAilleurs && pointeurAilleurs.parcoursId !== params.parcoursId) {
     return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.deja_rattache_ailleurs };
   }
 
@@ -159,25 +175,44 @@ export async function rattacherDossierManuel(params: {
     return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.dossier_deja_confirme };
   }
 
-  await appliquerRattachement(
-    {
-      parcoursId: params.parcoursId,
-      step: params.step,
-      dsNumber,
-      dsDemarcheId: String(resolveDemarcheNumberForStep(params.step)),
-    },
-    ORIGINE_TENTATIVE.MANUEL
-  );
+  try {
+    await appliquerRattachement(
+      {
+        parcoursId: params.parcoursId,
+        step: params.step,
+        dsNumber,
+        dsDemarcheId: String(resolveDemarcheNumberForStep(params.step)),
+      },
+      ORIGINE_TENTATIVE.MANUEL
+    );
+  } catch (error) {
+    console.error("rattacherDossierManuel : rattachement refusé", error);
+    return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.deja_rattache_ailleurs };
+  }
+
   return { success: true, data: { dsNumber } };
 }
 
-/** Pagination complète des dossiers d'une démarche (DN plafonne à 100 par page). */
+interface Collecte {
+  candidats: CandidatReconciliation[];
+  complet: boolean;
+  raison?: string;
+  pages: number;
+}
+
+/**
+ * Pagination des dossiers d'une démarche (DN plafonne à 100 par page).
+ *
+ * La complétude est remontée explicitement : un scan tronqué ne doit JAMAIS servir de base à
+ * un rattachement. Un second dossier déposé pourrait se trouver dans les pages manquantes, et
+ * ce qui aurait dû être un conflit deviendrait un rattachement automatique erroné.
+ */
 async function collecterCandidats(
   demarcheNumber: number,
   step: Step,
   updatedSince?: string,
   maxPages = 100
-): Promise<CandidatReconciliation[]> {
+): Promise<Collecte> {
   const candidats: CandidatReconciliation[] = [];
   let after: string | undefined;
   let pages = 0;
@@ -185,7 +220,11 @@ async function collecterCandidats(
   while (pages < maxPages) {
     pages++;
     const conn = await graphqlClient.getDemarcheDossiers(demarcheNumber, { first: 100, after, updatedSince });
-    if (!conn) break;
+    // Le client convertit toute erreur DN en `null` : impossible de distinguer une démarche
+    // vide d'un appel en échec, donc on considère le scan incomplet.
+    if (!conn) {
+      return { candidats, complet: false, raison: `appel DN sans réponse (page ${pages})`, pages };
+    }
 
     for (const node of conn.nodes) {
       candidats.push({
@@ -196,12 +235,15 @@ async function collecterCandidats(
       });
     }
 
-    if (!conn.pageInfo.hasNextPage) break;
+    if (!conn.pageInfo.hasNextPage) return { candidats, complet: true, pages };
+
     after = conn.pageInfo.endCursor ?? undefined;
-    if (!after) break;
+    if (!after) {
+      return { candidats, complet: false, raison: `curseur absent alors qu'il reste des pages (page ${pages})`, pages };
+    }
   }
 
-  return candidats;
+  return { candidats, complet: false, raison: `plafond de ${maxPages} pages atteint`, pages };
 }
 
 /** Repointe l'étape vers le dossier réel et remet son état à zéro : la sync le recopiera. */
@@ -210,6 +252,18 @@ async function appliquerRattachement(
   origine: OrigineTentative
 ): Promise<void> {
   await db.transaction(async (tx) => {
+    // Un numéro pointé par un autre parcours ne doit jamais être volé : la contrainte unique
+    // le rattraperait, mais avec une erreur SQL opaque au lieu d'un refus métier.
+    const [pointeurAilleurs] = await tx
+      .select({ parcoursId: dossiersDemarchesSimplifiees.parcoursId })
+      .from(dossiersDemarchesSimplifiees)
+      .where(eq(dossiersDemarchesSimplifiees.dsNumber, candidat.dsNumber))
+      .limit(1);
+
+    if (pointeurAilleurs && pointeurAilleurs.parcoursId !== candidat.parcoursId) {
+      throw new Error(`Le numéro DN ${candidat.dsNumber} est déjà le dossier d'un autre parcours`);
+    }
+
     const [existant] = await tx
       .select({ id: dossiersDemarchesSimplifiees.id, dsDemarcheId: dossiersDemarchesSimplifiees.dsDemarcheId })
       .from(dossiersDemarchesSimplifiees)
@@ -274,7 +328,11 @@ export async function reconcilierDemarche(options: {
 }): Promise<RapportReconciliation> {
   const { demarcheNumber, step, updatedSince, apply = false } = options;
 
-  const candidats = await collecterCandidats(demarcheNumber, step, updatedSince);
+  const collecte = await collecterCandidats(demarcheNumber, step, updatedSince);
+  const candidats = collecte.candidats;
+
+  // Échec fermé : sur un scan tronqué on rend le rapport (utile au diagnostic) sans rien écrire.
+  const peutEcrire = apply && collecte.complet;
 
   // Un même parcours visé par plusieurs dossiers déposés = conflit, jamais un choix arbitraire.
   const parNombreDeCandidats = new Map<string, number>();
@@ -332,7 +390,7 @@ export async function reconcilierDemarche(options: {
     totaux[verdict] += 1;
     lignes.push({ ...candidat, verdict, pointeurAvant: ctx.pointeurDsNumber });
 
-    if (apply && verdict === "rattachement" && candidat.parcoursId) {
+    if (peutEcrire && verdict === "rattachement" && candidat.parcoursId) {
       await appliquerRattachement(
         {
           parcoursId: candidat.parcoursId,
@@ -346,5 +404,12 @@ export async function reconcilierDemarche(options: {
     }
   }
 
-  return { lignes, totaux, rattachementsAppliques };
+  return {
+    lignes,
+    totaux,
+    rattachementsAppliques,
+    scanComplet: collecte.complet,
+    scanIncompletRaison: collecte.raison,
+    pagesLues: collecte.pages,
+  };
 }

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -23,7 +23,9 @@ import { resolveDemarcheNumberForStep } from "./pieces-justificatives.service";
  * `parcoursId` — quel que soit le compte DN utilisé, l'ordinateur, ou le nombre de brouillons
  * abandonnés en route. C'est ce lien-là qu'on rétablit ici.
  *
- * Par défaut le service n'écrit RIEN : il rend un rapport. L'écriture est explicite (`apply`).
+ * Par défaut, aucun dossier n'est modifié : `apply` seul autorise le repointage. Le balayage
+ * enregistre en revanche toujours ses constats dans `ds_reconciliation_observations`, qui
+ * alimente les files du back-office.
  */
 
 /** Ce que le service décide de faire d'un dossier déposé. */

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -11,6 +11,7 @@ import type { Step } from "@/shared/domain/value-objects/step.enum";
 import type { ActionResult } from "@/shared/types";
 import { graphqlClient } from "../adapters/graphql/client";
 import { extraireParcoursIdDepuisAnnotations } from "../utils/annotation-fpa.utils";
+import { resolveDemarcheNumberForStep } from "./pieces-justificatives.service";
 
 /**
  * Réconciliation des dossiers DÉPOSÉS avec leur parcours (ADR-0027).
@@ -158,7 +159,15 @@ export async function rattacherDossierManuel(params: {
     return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.dossier_deja_confirme };
   }
 
-  await appliquerRattachement({ parcoursId: params.parcoursId, step: params.step, dsNumber }, ORIGINE_TENTATIVE.MANUEL);
+  await appliquerRattachement(
+    {
+      parcoursId: params.parcoursId,
+      step: params.step,
+      dsNumber,
+      dsDemarcheId: String(resolveDemarcheNumberForStep(params.step)),
+    },
+    ORIGINE_TENTATIVE.MANUEL
+  );
   return { success: true, data: { dsNumber } };
 }
 
@@ -197,7 +206,7 @@ async function collecterCandidats(
 
 /** Repointe l'étape vers le dossier réel et remet son état à zéro : la sync le recopiera. */
 async function appliquerRattachement(
-  candidat: { parcoursId: string; step: Step; dsNumber: string },
+  candidat: { parcoursId: string; step: Step; dsNumber: string; dsDemarcheId: string },
   origine: OrigineTentative
 ): Promise<void> {
   await db.transaction(async (tx) => {
@@ -229,6 +238,15 @@ async function appliquerRattachement(
           dsUrl: null,
         })
         .where(eq(dossiersDemarchesSimplifiees.id, existant.id));
+    } else {
+      // Pas de pointeur : c'est le cas des parcours dont la ligne avait été supprimée par
+      // l'ancien reset. On le recrée, sinon leur dossier resterait invisible de l'app.
+      await tx.insert(dossiersDemarchesSimplifiees).values({
+        parcoursId: candidat.parcoursId,
+        step: candidat.step,
+        dsNumber: candidat.dsNumber,
+        dsDemarcheId: candidat.dsDemarcheId,
+      });
     }
 
     await dossiersDsTentativesRepo.record(
@@ -237,7 +255,7 @@ async function appliquerRattachement(
         step: candidat.step,
         dsNumber: candidat.dsNumber,
         origine,
-        dsDemarcheId: existant?.dsDemarcheId ?? null,
+        dsDemarcheId: existant?.dsDemarcheId ?? candidat.dsDemarcheId,
       },
       tx
     );
@@ -316,7 +334,12 @@ export async function reconcilierDemarche(options: {
 
     if (apply && verdict === "rattachement" && candidat.parcoursId) {
       await appliquerRattachement(
-        { parcoursId: candidat.parcoursId, step: candidat.step, dsNumber: candidat.dsNumber },
+        {
+          parcoursId: candidat.parcoursId,
+          step: candidat.step,
+          dsNumber: candidat.dsNumber,
+          dsDemarcheId: String(demarcheNumber),
+        },
         ORIGINE_TENTATIVE.RECONCILIATION
       );
       rattachementsAppliques++;

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -6,7 +6,7 @@ import {
   parcoursPrevention,
   type OrigineTentative,
 } from "@/shared/database/schema";
-import { dossiersDsTentativesRepo } from "@/shared/database/repositories";
+import { dossiersDsTentativesRepo, dsObservationsRepo } from "@/shared/database/repositories";
 import { Step } from "@/shared/domain/value-objects/step.enum";
 import type { ActionResult } from "@/shared/types";
 import { graphqlClient } from "../adapters/graphql/client";
@@ -88,6 +88,34 @@ export function decideRattachement(candidat: CandidatReconciliation, ctx: Contex
 export interface LigneRapport extends CandidatReconciliation {
   verdict: VerdictReconciliation;
   pointeurAvant: string | null;
+}
+
+/**
+ * Ce qui mérite d'être conservé pour le back-office : tout sauf le bruit.
+ * « Déjà à jour » n'a rien à signaler, et un rattachement effectivement appliqué s'est
+ * refermé de lui-même — le garder ouvert ferait une file qui ne se vide jamais.
+ */
+export function observationsAPersister(
+  lignes: LigneRapport[],
+  rattachementsAppliques: boolean
+): Array<{
+  dsNumber: string;
+  parcoursId: string | null;
+  step: Step;
+  verdict: string;
+  dsState: string | null;
+  detail: string | null;
+}> {
+  return lignes
+    .filter((l) => l.verdict !== "deja_a_jour" && !(rattachementsAppliques && l.verdict === "rattachement"))
+    .map((l) => ({
+      dsNumber: l.dsNumber,
+      parcoursId: l.parcoursId,
+      step: l.step,
+      verdict: l.verdict,
+      dsState: l.state,
+      detail: l.pointeurAvant ? `Pointeur au moment du constat : #${l.pointeurAvant}` : null,
+    }));
 }
 
 export interface RapportReconciliation {
@@ -437,6 +465,8 @@ export async function reconcilierDemarche(options: {
       rattachementsAppliques++;
     }
   }
+
+  await dsObservationsRepo.upsertMany(observationsAPersister(lignes, peutEcrire));
 
   return {
     lignes,

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -1,8 +1,14 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/shared/database/client";
-import { dossiersDemarchesSimplifiees, ORIGINE_TENTATIVE, parcoursPrevention } from "@/shared/database/schema";
+import {
+  dossiersDemarchesSimplifiees,
+  ORIGINE_TENTATIVE,
+  parcoursPrevention,
+  type OrigineTentative,
+} from "@/shared/database/schema";
 import { dossiersDsTentativesRepo } from "@/shared/database/repositories";
 import type { Step } from "@/shared/domain/value-objects/step.enum";
+import type { ActionResult } from "@/shared/types";
 import { graphqlClient } from "../adapters/graphql/client";
 import { extraireParcoursIdDepuisAnnotations } from "../utils/annotation-fpa.utils";
 
@@ -91,6 +97,71 @@ function totauxVides(): Record<VerdictReconciliation, number> {
   };
 }
 
+export type RefusRattachementManuel =
+  "numero_invalide" | "introuvable_cote_dn" | "deja_rattache_ailleurs" | "dossier_deja_confirme";
+
+export const MESSAGES_RATTACHEMENT_MANUEL: Record<RefusRattachementManuel, string> = {
+  numero_invalide: "Le numéro de dossier doit être composé de chiffres uniquement.",
+  introuvable_cote_dn: "Aucun dossier déposé ne porte ce numéro côté Démarches Numériques.",
+  deja_rattache_ailleurs: "Ce numéro est déjà rattaché à un autre demandeur.",
+  dossier_deja_confirme: "Ce parcours a déjà un dossier déposé pour cette étape : à trancher avant de rattacher.",
+};
+
+/**
+ * Rattachement manuel d'un dossier DN à un parcours, par son numéro (ADR-0027).
+ * Recours pour les dossiers créés hors de notre lien : sans annotation FPA, la
+ * réconciliation automatique ne peut pas les retrouver.
+ */
+export async function rattacherDossierManuel(params: {
+  parcoursId: string;
+  step: Step;
+  dsNumber: string;
+}): Promise<ActionResult<{ dsNumber: string }>> {
+  const dsNumber = params.dsNumber.trim();
+  if (!/^\d+$/.test(dsNumber)) {
+    return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.numero_invalide };
+  }
+
+  // Le dossier doit exister côté DN : un brouillon non déposé y est invisible, on ne rattache
+  // donc que du réel.
+  let existeCoteDn = false;
+  try {
+    existeCoteDn = !!(await graphqlClient.getDossierStatus(Number(dsNumber)));
+  } catch {
+    existeCoteDn = false;
+  }
+  if (!existeCoteDn) {
+    return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.introuvable_cote_dn };
+  }
+
+  const tentative = await dossiersDsTentativesRepo.findByDsNumber(dsNumber);
+  if (tentative && tentative.parcoursId !== params.parcoursId) {
+    return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.deja_rattache_ailleurs };
+  }
+
+  const [pointeur] = await db
+    .select({
+      dsNumber: dossiersDemarchesSimplifiees.dsNumber,
+      submittedAt: dossiersDemarchesSimplifiees.submittedAt,
+      lastSyncAt: dossiersDemarchesSimplifiees.lastSyncAt,
+    })
+    .from(dossiersDemarchesSimplifiees)
+    .where(
+      and(
+        eq(dossiersDemarchesSimplifiees.parcoursId, params.parcoursId),
+        eq(dossiersDemarchesSimplifiees.step, params.step)
+      )
+    )
+    .limit(1);
+
+  if (pointeur && pointeur.dsNumber !== dsNumber && (pointeur.submittedAt || pointeur.lastSyncAt)) {
+    return { success: false, error: MESSAGES_RATTACHEMENT_MANUEL.dossier_deja_confirme };
+  }
+
+  await appliquerRattachement({ parcoursId: params.parcoursId, step: params.step, dsNumber }, ORIGINE_TENTATIVE.MANUEL);
+  return { success: true, data: { dsNumber } };
+}
+
 /** Pagination complète des dossiers d'une démarche (DN plafonne à 100 par page). */
 async function collecterCandidats(
   demarcheNumber: number,
@@ -125,7 +196,10 @@ async function collecterCandidats(
 }
 
 /** Repointe l'étape vers le dossier réel et remet son état à zéro : la sync le recopiera. */
-async function appliquerRattachement(candidat: CandidatReconciliation & { parcoursId: string }): Promise<void> {
+async function appliquerRattachement(
+  candidat: { parcoursId: string; step: Step; dsNumber: string },
+  origine: OrigineTentative
+): Promise<void> {
   await db.transaction(async (tx) => {
     const [existant] = await tx
       .select({ id: dossiersDemarchesSimplifiees.id, dsDemarcheId: dossiersDemarchesSimplifiees.dsDemarcheId })
@@ -162,7 +236,7 @@ async function appliquerRattachement(candidat: CandidatReconciliation & { parcou
         parcoursId: candidat.parcoursId,
         step: candidat.step,
         dsNumber: candidat.dsNumber,
-        origine: ORIGINE_TENTATIVE.RECONCILIATION,
+        origine,
         dsDemarcheId: existant?.dsDemarcheId ?? null,
       },
       tx
@@ -241,7 +315,10 @@ export async function reconcilierDemarche(options: {
     lignes.push({ ...candidat, verdict, pointeurAvant: ctx.pointeurDsNumber });
 
     if (apply && verdict === "rattachement" && candidat.parcoursId) {
-      await appliquerRattachement({ ...candidat, parcoursId: candidat.parcoursId });
+      await appliquerRattachement(
+        { parcoursId: candidat.parcoursId, step: candidat.step, dsNumber: candidat.dsNumber },
+        ORIGINE_TENTATIVE.RECONCILIATION
+      );
       rattachementsAppliques++;
     }
   }

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -10,7 +10,7 @@ import { dossiersDsTentativesRepo } from "@/shared/database/repositories";
 import type { Step } from "@/shared/domain/value-objects/step.enum";
 import type { ActionResult } from "@/shared/types";
 import { graphqlClient } from "../adapters/graphql/client";
-import { extraireParcoursIdDepuisAnnotations } from "../utils/annotation-fpa.utils";
+import { extraireParcoursIdsDepuisAnnotations } from "../utils/annotation-fpa.utils";
 import { resolveDemarcheNumberForStep } from "./pieces-justificatives.service";
 
 /**
@@ -32,6 +32,7 @@ export type VerdictReconciliation =
   | "conflit_dossier_confirme"
   | "conflit_plusieurs_deposes"
   | "sans_annotation"
+  | "annotation_ambigue"
   | "parcours_inconnu";
 
 export interface CandidatReconciliation {
@@ -39,6 +40,8 @@ export interface CandidatReconciliation {
   step: Step;
   state: string;
   parcoursId: string | null;
+  /** Plusieurs annotations portent des parcours différents : annotation retouchée à la main. */
+  annotationAmbigue?: boolean;
 }
 
 /** État local nécessaire pour trancher, lu en base. */
@@ -59,6 +62,8 @@ export interface ContexteRattachement {
  * On ne tranche jamais automatiquement un conflit : il remonte pour arbitrage humain.
  */
 export function decideRattachement(candidat: CandidatReconciliation, ctx: ContexteRattachement): VerdictReconciliation {
+  // Une annotation retouchée n'est plus une source fiable : arbitrage humain.
+  if (candidat.annotationAmbigue) return "annotation_ambigue";
   if (!candidat.parcoursId) return "sans_annotation";
   if (!ctx.parcoursExiste) return "parcours_inconnu";
 
@@ -99,6 +104,7 @@ function totauxVides(): Record<VerdictReconciliation, number> {
     conflit_dossier_confirme: 0,
     conflit_plusieurs_deposes: 0,
     sans_annotation: 0,
+    annotation_ambigue: 0,
     parcours_inconnu: 0,
   };
 }
@@ -227,11 +233,13 @@ async function collecterCandidats(
     }
 
     for (const node of conn.nodes) {
+      const parcoursIds = extraireParcoursIdsDepuisAnnotations(node.annotations);
       candidats.push({
         dsNumber: String(node.number),
         step,
         state: node.state,
-        parcoursId: extraireParcoursIdDepuisAnnotations(node.annotations),
+        parcoursId: parcoursIds.length === 1 ? parcoursIds[0] : null,
+        annotationAmbigue: parcoursIds.length > 1,
       });
     }
 

--- a/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
+++ b/src/features/parcours/dossiers-ds/services/reconciliation.service.ts
@@ -504,6 +504,14 @@ export async function reconcilierDemarche(options: {
 
   await dsObservationsRepo.upsertMany(observationsAPersister(lignes, peutEcrire));
 
+  // Symétrique : ce qui n'a plus rien à signaler sort de la file. Sans ça, une observation
+  // faite avant une correction resterait ouverte pour toujours.
+  await dsObservationsRepo.refermerReglees(
+    lignes
+      .filter((l) => l.verdict === "deja_a_jour" || (peutEcrire && l.verdict === "rattachement"))
+      .map((l) => l.dsNumber)
+  );
+
   return {
     lignes,
     totaux,

--- a/src/features/parcours/dossiers-ds/services/regeneration.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/regeneration.service.test.ts
@@ -1,8 +1,27 @@
-import { describe, it, expect, vi } from "vitest";
-import { verifierRegeneration, DELAI_MIN_REGENERATION_MINUTES } from "./regeneration.service";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { verifierRegeneration, regenererLienPrefill, DELAI_MIN_REGENERATION_MINUTES } from "./regeneration.service";
+import { graphqlClient, DsGraphQLError } from "../adapters/graphql/client";
+import { dossiersDsTentativesRepo, parcoursRepo } from "@/shared/database/repositories";
+import { getDossierByStep } from "./dossier-ds.service";
+import { Step } from "@/shared/domain/value-objects/step.enum";
 
 vi.mock("@/shared/database/client", () => ({ db: {} }));
-vi.mock("../adapters/graphql/client", () => ({ graphqlClient: { getDossierStatus: vi.fn() } }));
+vi.mock("../adapters/graphql/client", () => {
+  class DsGraphQLError extends Error {
+    readonly code?: string;
+    constructor(message: string, code?: string) {
+      super(message);
+      this.name = "DsGraphQLError";
+      this.code = code;
+    }
+  }
+  return { graphqlClient: { getDossierStatus: vi.fn() }, DsGraphQLError };
+});
+vi.mock("@/shared/database/repositories", () => ({
+  dossiersDsTentativesRepo: { record: vi.fn(), findByParcoursStep: vi.fn() },
+  parcoursRepo: { findByUserId: vi.fn() },
+}));
+vi.mock("./dossier-ds.service", () => ({ getDossierByStep: vi.fn() }));
 
 const MAINTENANT = new Date("2026-08-25T12:00:00Z");
 const ilYA = (minutes: number) => new Date(MAINTENANT.getTime() - minutes * 60_000);
@@ -33,10 +52,48 @@ describe("verifierRegeneration", () => {
     expect(verifierRegeneration(dossier({ dsStatus: "en_instruction" }), MAINTENANT)).toBe("dossier_depose");
   });
 
+  it("expose un refus dédié quand DN est injoignable", () => {
+    // Le message doit exister : c'est lui qui remplace la suppression à l'aveugle.
+    expect(verifierRegeneration(dossier(), MAINTENANT)).toBeNull();
+  });
+
   it("refuse un lien tout juste créé, pour éviter d'empiler les brouillons", () => {
     expect(verifierRegeneration(dossier({ createdAt: ilYA(1) }), MAINTENANT)).toBe("trop_recent");
     expect(
       verifierRegeneration(dossier({ createdAt: ilYA(DELAI_MIN_REGENERATION_MINUTES + 1) }), MAINTENANT)
     ).toBeNull();
+  });
+});
+
+// Cf. revue ADR-0027 : une panne DN ne doit jamais faire retirer un pointeur peut-être vivant.
+describe("regenererLienPrefill — panne DN", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(parcoursRepo.findByUserId).mockResolvedValue({
+      id: "parcours-1",
+      currentStep: Step.ELIGIBILITE,
+    } as never);
+    vi.mocked(getDossierByStep).mockResolvedValue({
+      id: "dossier-1",
+      dsNumber: "32872663",
+      dsId: null,
+      dsDemarcheId: "126061",
+      createdAt: ilYA(120),
+      submittedAt: null,
+      lastSyncAt: null,
+      dsStatus: null,
+    } as never);
+    vi.mocked(dossiersDsTentativesRepo.record).mockResolvedValue(undefined);
+    vi.mocked(dossiersDsTentativesRepo.findByParcoursStep).mockResolvedValue([{ dsNumber: "32872663" }] as never);
+  });
+
+  it("abandonne sans rien supprimer si le sondage échoue autrement qu'en not_found", async () => {
+    vi.mocked(graphqlClient.getDossierStatus).mockRejectedValue(
+      new DsGraphQLError("GraphQL errors: unauthorized", "unauthorized")
+    );
+
+    const result = await regenererLienPrefill("user-1");
+
+    expect(result.success).toBe(false);
   });
 });

--- a/src/features/parcours/dossiers-ds/services/regeneration.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/regeneration.service.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { verifierRegeneration, DELAI_MIN_REGENERATION_MINUTES } from "./regeneration.service";
+
+vi.mock("@/shared/database/client", () => ({ db: {} }));
+vi.mock("../adapters/graphql/client", () => ({ graphqlClient: { getDossierStatus: vi.fn() } }));
+
+const MAINTENANT = new Date("2026-08-25T12:00:00Z");
+const ilYA = (minutes: number) => new Date(MAINTENANT.getTime() - minutes * 60_000);
+
+function dossier(overrides: Partial<Parameters<typeof verifierRegeneration>[0]> = {}) {
+  return {
+    createdAt: ilYA(60),
+    submittedAt: null,
+    lastSyncAt: null,
+    dsStatus: null,
+    ...overrides,
+  };
+}
+
+// Cf. ADR-0027 : on ne régénère que ce qui n'a jamais été observé déposé.
+describe("verifierRegeneration", () => {
+  it("autorise la régénération d'un prérempli jamais déposé", () => {
+    expect(verifierRegeneration(dossier(), MAINTENANT)).toBeNull();
+  });
+
+  it("refuse s'il n'y a aucun dossier à régénérer", () => {
+    expect(verifierRegeneration(null, MAINTENANT)).toBe("aucun_dossier");
+  });
+
+  it("refuse sur un dossier déposé : son lien est valide", () => {
+    expect(verifierRegeneration(dossier({ submittedAt: ilYA(120) }), MAINTENANT)).toBe("dossier_depose");
+    expect(verifierRegeneration(dossier({ lastSyncAt: ilYA(30) }), MAINTENANT)).toBe("dossier_depose");
+    expect(verifierRegeneration(dossier({ dsStatus: "en_instruction" }), MAINTENANT)).toBe("dossier_depose");
+  });
+
+  it("refuse un lien tout juste créé, pour éviter d'empiler les brouillons", () => {
+    expect(verifierRegeneration(dossier({ createdAt: ilYA(1) }), MAINTENANT)).toBe("trop_recent");
+    expect(
+      verifierRegeneration(dossier({ createdAt: ilYA(DELAI_MIN_REGENERATION_MINUTES + 1) }), MAINTENANT)
+    ).toBeNull();
+  });
+});

--- a/src/features/parcours/dossiers-ds/services/regeneration.service.test.ts
+++ b/src/features/parcours/dossiers-ds/services/regeneration.service.test.ts
@@ -52,11 +52,6 @@ describe("verifierRegeneration", () => {
     expect(verifierRegeneration(dossier({ dsStatus: "en_instruction" }), MAINTENANT)).toBe("dossier_depose");
   });
 
-  it("expose un refus dédié quand DN est injoignable", () => {
-    // Le message doit exister : c'est lui qui remplace la suppression à l'aveugle.
-    expect(verifierRegeneration(dossier(), MAINTENANT)).toBeNull();
-  });
-
   it("refuse un lien tout juste créé, pour éviter d'empiler les brouillons", () => {
     expect(verifierRegeneration(dossier({ createdAt: ilYA(1) }), MAINTENANT)).toBe("trop_recent");
     expect(

--- a/src/features/parcours/dossiers-ds/services/regeneration.service.ts
+++ b/src/features/parcours/dossiers-ds/services/regeneration.service.ts
@@ -1,0 +1,121 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/shared/database/client";
+import { dossiersDemarchesSimplifiees, ORIGINE_TENTATIVE } from "@/shared/database/schema";
+import { dossiersDsTentativesRepo, parcoursRepo } from "@/shared/database/repositories";
+import type { ActionResult } from "@/shared/types";
+import { graphqlClient } from "../adapters/graphql/client";
+import { getDossierByStep } from "./dossier-ds.service";
+
+/**
+ * Secours du demandeur dont le lien DN ne fonctionne plus (ADR-0027).
+ *
+ * On ne sait pas si son brouillon est mort : DN masque les brouillons à l'API instructeur. On
+ * ne cherche donc pas à le diagnostiquer, on lui rend la main — après avoir vérifié qu'aucun
+ * de ses numéros connus n'a été déposé entre-temps, auquel cas il faut rattacher, pas recréer.
+ *
+ * Retirer le pointeur ne perd plus rien : le numéro reste au registre des tentatives, et la
+ * réconciliation le retrouvera s'il finit par être déposé.
+ */
+
+/** Fenêtre anti-rafale : évite qu'un double-clic n'empile les brouillons côté DN. */
+export const DELAI_MIN_REGENERATION_MINUTES = 10;
+
+export type RefusRegeneration = "aucun_dossier" | "dossier_depose" | "trop_recent";
+
+interface DossierPourRegeneration {
+  createdAt: Date;
+  submittedAt: Date | null;
+  lastSyncAt: Date | null;
+  dsStatus: string | null;
+}
+
+/**
+ * Peut-on régénérer ? Sans effet de bord.
+ * On refuse sur un dossier déjà déposé : son lien est valide, c'est l'URL stable qui s'applique.
+ */
+export function verifierRegeneration(
+  dossier: DossierPourRegeneration | null,
+  maintenant: Date
+): RefusRegeneration | null {
+  if (!dossier) return "aucun_dossier";
+  if (dossier.submittedAt || dossier.lastSyncAt || dossier.dsStatus) return "dossier_depose";
+
+  const minutes = (maintenant.getTime() - dossier.createdAt.getTime()) / 60_000;
+  if (minutes < DELAI_MIN_REGENERATION_MINUTES) return "trop_recent";
+
+  return null;
+}
+
+const MESSAGES: Record<RefusRegeneration, string> = {
+  aucun_dossier: "Aucun formulaire à régénérer pour cette étape.",
+  dossier_depose: "Votre dossier a déjà été transmis : votre lien pointe vers le dossier déposé.",
+  trop_recent: "Votre lien vient d'être créé. Essayez d'abord de l'ouvrir, puis réessayez dans quelques minutes.",
+};
+
+export type ResultatRegeneration =
+  /** Un numéro déjà connu a été déposé entre-temps : on rattache au lieu de recréer. */
+  | { statut: "rattache"; dsNumber: string }
+  /** Le pointeur a été retiré : l'app peut créer un nouveau prérempli. */
+  | { statut: "a_recreer" };
+
+/** Repointe l'étape vers un dossier réellement déposé et remet l'état à zéro pour la sync. */
+async function rattacher(dossierId: string, dsNumber: string): Promise<void> {
+  await db
+    .update(dossiersDemarchesSimplifiees)
+    .set({
+      dsNumber,
+      dsId: null,
+      dsStatus: null,
+      submittedAt: null,
+      instructedAt: null,
+      processedAt: null,
+      lastSyncAt: null,
+      dnProbeState: null,
+      dnProbeAt: null,
+      dsUrl: null,
+    })
+    .where(eq(dossiersDemarchesSimplifiees.id, dossierId));
+}
+
+export async function regenererLienPrefill(userId: string): Promise<ActionResult<ResultatRegeneration>> {
+  const parcours = await parcoursRepo.findByUserId(userId);
+  if (!parcours) return { success: false, error: "Parcours non trouvé" };
+
+  const step = parcours.currentStep;
+  const dossier = await getDossierByStep(parcours.id, step);
+
+  const refus = verifierRegeneration(dossier, new Date());
+  if (refus) return { success: false, error: MESSAGES[refus] };
+  if (!dossier?.dsNumber) return { success: false, error: MESSAGES.aucun_dossier };
+
+  // Le numéro courant doit être au registre AVANT qu'on retire le pointeur.
+  await dossiersDsTentativesRepo.record({
+    parcoursId: parcours.id,
+    step,
+    dsNumber: dossier.dsNumber,
+    origine: ORIGINE_TENTATIVE.PREFILL,
+    dsId: dossier.dsId,
+    dsDemarcheId: dossier.dsDemarcheId,
+    dsUrl: dossier.dsUrl,
+  });
+
+  // Un ancien brouillon a-t-il été déposé depuis ? Alors il n'y a rien à recréer.
+  const tentatives = await dossiersDsTentativesRepo.findByParcoursStep(parcours.id, step);
+  for (const tentative of tentatives) {
+    try {
+      const dn = await graphqlClient.getDossierStatus(Number(tentative.dsNumber));
+      if (dn) {
+        await rattacher(dossier.id, tentative.dsNumber);
+        return { success: true, data: { statut: "rattache", dsNumber: tentative.dsNumber } };
+      }
+    } catch {
+      // Invisible de l'API : brouillon non déposé ou purgé, on ne peut pas trancher. Suivant.
+    }
+  }
+
+  // Le pointeur part, le numéro reste au registre : la réconciliation le rattrapera si l'usager
+  // finit par déposer l'ancien brouillon.
+  await db.delete(dossiersDemarchesSimplifiees).where(eq(dossiersDemarchesSimplifiees.id, dossier.id));
+
+  return { success: true, data: { statut: "a_recreer" } };
+}

--- a/src/features/parcours/dossiers-ds/services/regeneration.service.ts
+++ b/src/features/parcours/dossiers-ds/services/regeneration.service.ts
@@ -1,9 +1,9 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { db } from "@/shared/database/client";
 import { dossiersDemarchesSimplifiees, ORIGINE_TENTATIVE } from "@/shared/database/schema";
 import { dossiersDsTentativesRepo, parcoursRepo } from "@/shared/database/repositories";
 import type { ActionResult } from "@/shared/types";
-import { graphqlClient } from "../adapters/graphql/client";
+import { graphqlClient, DsGraphQLError } from "../adapters/graphql/client";
 import { getDossierByStep } from "./dossier-ds.service";
 
 /**
@@ -20,7 +20,7 @@ import { getDossierByStep } from "./dossier-ds.service";
 /** Fenêtre anti-rafale : évite qu'un double-clic n'empile les brouillons côté DN. */
 export const DELAI_MIN_REGENERATION_MINUTES = 10;
 
-export type RefusRegeneration = "aucun_dossier" | "dossier_depose" | "trop_recent";
+export type RefusRegeneration = "aucun_dossier" | "dossier_depose" | "trop_recent" | "verification_impossible";
 
 interface DossierPourRegeneration {
   createdAt: Date;
@@ -50,6 +50,8 @@ const MESSAGES: Record<RefusRegeneration, string> = {
   aucun_dossier: "Aucun formulaire à régénérer pour cette étape.",
   dossier_depose: "Votre dossier a déjà été transmis : votre lien pointe vers le dossier déposé.",
   trop_recent: "Votre lien vient d'être créé. Essayez d'abord de l'ouvrir, puis réessayez dans quelques minutes.",
+  verification_impossible:
+    "Nous n'arrivons pas à joindre Démarches Numériques pour le moment. Réessayez dans quelques minutes.",
 };
 
 export type ResultatRegeneration =
@@ -107,14 +109,40 @@ export async function regenererLienPrefill(userId: string): Promise<ActionResult
         await rattacher(dossier.id, tentative.dsNumber);
         return { success: true, data: { statut: "rattache", dsNumber: tentative.dsNumber } };
       }
-    } catch {
-      // Invisible de l'API : brouillon non déposé ou purgé, on ne peut pas trancher. Suivant.
+    } catch (error) {
+      // SEUL un `not_found` typé signifie « invisible de l'API instructeur », donc non déposé.
+      // Toute autre erreur (réseau, unauthorized, 500) nous laisse aveugles : on s'arrête là
+      // plutôt que de retirer un pointeur peut-être vivant.
+      const code = error instanceof DsGraphQLError ? error.code : undefined;
+      if (code !== "not_found") {
+        console.error("regenererLienPrefill : sondage DN impossible", { dsNumber: tentative.dsNumber, code });
+        return { success: false, error: MESSAGES.verification_impossible };
+      }
     }
   }
 
   // Le pointeur part, le numéro reste au registre : la réconciliation le rattrapera si l'usager
   // finit par déposer l'ancien brouillon.
-  await db.delete(dossiersDemarchesSimplifiees).where(eq(dossiersDemarchesSimplifiees.id, dossier.id));
+  //
+  // Compare-and-swap : entre le sondage et ici, une sync ou une réconciliation a pu confirmer
+  // ou repointer cette ligne. On ne supprime donc que si elle porte TOUJOURS le même numéro et
+  // n'a toujours pas été observée déposée.
+  const supprimes = await db
+    .delete(dossiersDemarchesSimplifiees)
+    .where(
+      and(
+        eq(dossiersDemarchesSimplifiees.id, dossier.id),
+        eq(dossiersDemarchesSimplifiees.dsNumber, dossier.dsNumber),
+        isNull(dossiersDemarchesSimplifiees.submittedAt),
+        isNull(dossiersDemarchesSimplifiees.lastSyncAt)
+      )
+    )
+    .returning({ id: dossiersDemarchesSimplifiees.id });
+
+  if (supprimes.length === 0) {
+    // La ligne a bougé sous nos pieds : elle est désormais rattachée à un dossier réel.
+    return { success: false, error: MESSAGES.dossier_depose };
+  }
 
   return { success: true, data: { statut: "a_recreer" } };
 }

--- a/src/features/parcours/dossiers-ds/services/regeneration.service.ts
+++ b/src/features/parcours/dossiers-ds/services/regeneration.service.ts
@@ -96,7 +96,6 @@ export async function regenererLienPrefill(userId: string): Promise<ActionResult
     origine: ORIGINE_TENTATIVE.PREFILL,
     dsId: dossier.dsId,
     dsDemarcheId: dossier.dsDemarcheId,
-    dsUrl: dossier.dsUrl,
   });
 
   // Un ancien brouillon a-t-il été déposé depuis ? Alors il n'y a rien à recréer.

--- a/src/features/parcours/dossiers-ds/utils/annotation-fpa.utils.ts
+++ b/src/features/parcours/dossiers-ds/utils/annotation-fpa.utils.ts
@@ -1,3 +1,5 @@
+import type { AnnotationReconciliation } from "../adapters/graphql/types";
+
 /**
  * Lecture de l'annotation « lien vers le dossier FPA » (ADR-0025) dans l'autre sens : elle
  * contient l'URL `.../espace-agent/dossiers/<parcoursId>`, donc l'identifiant du parcours.
@@ -5,34 +7,49 @@
  */
 
 const UUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
-// On reconnaît le chemin, pas le libellé de l'annotation : celui-ci peut être renommé
-// côté DN, et son id diffère d'une démarche à l'autre (ADR-0025).
 const LIEN_FPA = new RegExp(`/espace-agent/dossiers/(${UUID})`, "i");
 
-/**
- * Tous les `parcoursId` distincts portés par les annotations d'un dossier.
- *
- * Il y en a normalement zéro ou un. Deux valeurs différentes signifient qu'une annotation a
- * été modifiée à la main côté DN, ou qu'un dossier a été dupliqué : le dossier est alors
- * ambigu et ne doit **jamais** être rattaché automatiquement (ADR-0027).
- */
-export function extraireParcoursIdsDepuisAnnotations(
-  annotations: Array<{ stringValue?: string | null }> | null | undefined
-): string[] {
-  if (!annotations?.length) return [];
-
-  const ids = new Set<string>();
-  for (const annotation of annotations) {
-    const match = annotation.stringValue?.match(LIEN_FPA);
-    if (match) ids.add(match[1].toLowerCase());
-  }
-  return [...ids];
+export interface LectureAnnotationFpa {
+  /** `null` si absente, illisible, ou si plusieurs annotations divergent. */
+  parcoursId: string | null;
+  /** Plusieurs valeurs de parcours différentes : dossier dupliqué ou annotation retouchée. */
+  ambigue: boolean;
+  /** DN signale que la valeur préremplie a été modifiée à la main : elle ne fait plus foi. */
+  modifiee: boolean;
 }
 
-/** `parcoursId` porté par une annotation, ou `null` si aucune (ou si plusieurs divergent). */
-export function extraireParcoursIdDepuisAnnotations(
-  annotations: Array<{ stringValue?: string | null }> | null | undefined
-): string | null {
-  const ids = extraireParcoursIdsDepuisAnnotations(annotations);
-  return ids.length === 1 ? ids[0] : null;
+/**
+ * Lit l'annotation FPA d'un dossier.
+ *
+ * L'annotation attendue est identifiée par son **descripteur** (`champDescriptorId`), pas par
+ * son libellé — renommable côté DN — ni par l'id de l'instance, qui change d'un dossier à
+ * l'autre. Quand le descripteur n'est pas connu (démarche non répertoriée), on retombe sur la
+ * reconnaissance du chemin dans n'importe quelle annotation.
+ */
+export function lireAnnotationFpa(
+  annotations: AnnotationReconciliation[] | null | undefined,
+  champDescriptorId: string | null
+): LectureAnnotationFpa {
+  if (!annotations?.length) return { parcoursId: null, ambigue: false, modifiee: false };
+
+  const candidates = champDescriptorId
+    ? annotations.filter((a) => a.champDescriptorId === champDescriptorId)
+    : annotations;
+
+  const ids = new Set<string>();
+  let modifiee = false;
+
+  for (const annotation of candidates) {
+    const match = annotation.stringValue?.match(LIEN_FPA);
+    if (!match) continue;
+    ids.add(match[1].toLowerCase());
+    if (annotation.prefilledValueModified) modifiee = true;
+  }
+
+  const distincts = [...ids];
+  return {
+    parcoursId: distincts.length === 1 ? distincts[0] : null,
+    ambigue: distincts.length > 1,
+    modifiee,
+  };
 }

--- a/src/features/parcours/dossiers-ds/utils/annotation-fpa.utils.ts
+++ b/src/features/parcours/dossiers-ds/utils/annotation-fpa.utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Lecture de l'annotation « lien vers le dossier FPA » (ADR-0025) dans l'autre sens : elle
+ * contient l'URL `.../espace-agent/dossiers/<parcoursId>`, donc l'identifiant du parcours.
+ * C'est la clé de rattachement d'un dossier déposé à son parcours (ADR-0027).
+ */
+
+const UUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+// On reconnaît le chemin, pas le libellé de l'annotation : celui-ci peut être renommé
+// côté DN, et son id diffère d'une démarche à l'autre (ADR-0025).
+const LIEN_FPA = new RegExp(`/espace-agent/dossiers/(${UUID})`, "i");
+
+/** `parcoursId` porté par une annotation, ou `null` si aucune ne contient de lien FPA. */
+export function extraireParcoursIdDepuisAnnotations(
+  annotations: Array<{ stringValue?: string | null }> | null | undefined
+): string | null {
+  if (!annotations?.length) return null;
+
+  for (const annotation of annotations) {
+    const match = annotation.stringValue?.match(LIEN_FPA);
+    if (match) return match[1].toLowerCase();
+  }
+  return null;
+}

--- a/src/features/parcours/dossiers-ds/utils/annotation-fpa.utils.ts
+++ b/src/features/parcours/dossiers-ds/utils/annotation-fpa.utils.ts
@@ -9,15 +9,30 @@ const UUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 // côté DN, et son id diffère d'une démarche à l'autre (ADR-0025).
 const LIEN_FPA = new RegExp(`/espace-agent/dossiers/(${UUID})`, "i");
 
-/** `parcoursId` porté par une annotation, ou `null` si aucune ne contient de lien FPA. */
+/**
+ * Tous les `parcoursId` distincts portés par les annotations d'un dossier.
+ *
+ * Il y en a normalement zéro ou un. Deux valeurs différentes signifient qu'une annotation a
+ * été modifiée à la main côté DN, ou qu'un dossier a été dupliqué : le dossier est alors
+ * ambigu et ne doit **jamais** être rattaché automatiquement (ADR-0027).
+ */
+export function extraireParcoursIdsDepuisAnnotations(
+  annotations: Array<{ stringValue?: string | null }> | null | undefined
+): string[] {
+  if (!annotations?.length) return [];
+
+  const ids = new Set<string>();
+  for (const annotation of annotations) {
+    const match = annotation.stringValue?.match(LIEN_FPA);
+    if (match) ids.add(match[1].toLowerCase());
+  }
+  return [...ids];
+}
+
+/** `parcoursId` porté par une annotation, ou `null` si aucune (ou si plusieurs divergent). */
 export function extraireParcoursIdDepuisAnnotations(
   annotations: Array<{ stringValue?: string | null }> | null | undefined
 ): string | null {
-  if (!annotations?.length) return null;
-
-  for (const annotation of annotations) {
-    const match = annotation.stringValue?.match(LIEN_FPA);
-    if (match) return match[1].toLowerCase();
-  }
-  return null;
+  const ids = extraireParcoursIdsDepuisAnnotations(annotations);
+  return ids.length === 1 ? ids[0] : null;
 }

--- a/src/shared/database/migrations/0044_thankful_tenebrous.sql
+++ b/src/shared/database/migrations/0044_thankful_tenebrous.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "dossiers_ds_tentatives" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"parcours_id" uuid NOT NULL,
+	"step" "step" NOT NULL,
+	"ds_number" varchar(50) NOT NULL,
+	"ds_id" varchar(50),
+	"ds_demarche_id" varchar(50),
+	"origine" varchar(30) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "dossiers_ds_tentatives_ds_number_unique" UNIQUE("ds_number")
+);
+--> statement-breakpoint
+ALTER TABLE "dossiers_ds_tentatives" ADD CONSTRAINT "dossiers_ds_tentatives_parcours_id_parcours_prevention_id_fk" FOREIGN KEY ("parcours_id") REFERENCES "public"."parcours_prevention"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "dossiers_ds_tentatives_parcours_step_idx" ON "dossiers_ds_tentatives" USING btree ("parcours_id","step");

--- a/src/shared/database/migrations/0045_flat_dark_beast.sql
+++ b/src/shared/database/migrations/0045_flat_dark_beast.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "ds_reconciliation_observations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"ds_number" varchar(50) NOT NULL,
+	"parcours_id" uuid,
+	"step" "step",
+	"verdict" varchar(40) NOT NULL,
+	"ds_state" varchar(30),
+	"detail" text,
+	"observed_at" timestamp DEFAULT now() NOT NULL,
+	"resolved_at" timestamp,
+	"resolved_by" uuid,
+	"resolution" varchar(30),
+	CONSTRAINT "ds_reconciliation_observations_ds_number_unique" UNIQUE("ds_number")
+);
+--> statement-breakpoint
+ALTER TABLE "ds_reconciliation_observations" ADD CONSTRAINT "ds_reconciliation_observations_parcours_id_parcours_prevention_id_fk" FOREIGN KEY ("parcours_id") REFERENCES "public"."parcours_prevention"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ds_reconciliation_observations" ADD CONSTRAINT "ds_reconciliation_observations_resolved_by_agents_id_fk" FOREIGN KEY ("resolved_by") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "ds_reconciliation_observations_verdict_idx" ON "ds_reconciliation_observations" USING btree ("verdict");--> statement-breakpoint
+CREATE INDEX "ds_reconciliation_observations_parcours_idx" ON "ds_reconciliation_observations" USING btree ("parcours_id");

--- a/src/shared/database/migrations/0046_charming_hellcat.sql
+++ b/src/shared/database/migrations/0046_charming_hellcat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ds_reconciliation_observations" ADD COLUMN "candidats" jsonb;

--- a/src/shared/database/migrations/meta/0044_snapshot.json
+++ b/src/shared/database/migrations/meta/0044_snapshot.json
@@ -1,0 +1,2202 @@
+{
+  "id": "c2161a1a-d684-4465-990e-2cbadd1c7ee7",
+  "prevId": "0f13ac39-0daf-4543-b16b-8cb5f1fa22c6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departement_code": {
+          "name": "departement_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sub": {
+          "name": "sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usual_name": {
+          "name": "usual_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siret": {
+          "name": "siret",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizational_unit": {
+          "name": "organizational_unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "agent_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'administrateur'"
+        },
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "agents_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": [
+            "entreprise_amo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agents_allers_vers_id_allers_vers_id_fk": {
+          "name": "agents_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "allers_vers",
+          "columnsFrom": [
+            "allers_vers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_sub_unique": {
+          "name": "agents_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub"
+          ]
+        },
+        "agents_email_unique": {
+          "name": "agents_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers_departements": {
+      "name": "allers_vers_departements",
+      "schema": "",
+      "columns": {
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_departement": {
+          "name": "code_departement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allers_vers_departements_allers_vers_id_allers_vers_id_fk": {
+          "name": "allers_vers_departements_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "allers_vers_departements",
+          "tableTo": "allers_vers",
+          "columnsFrom": [
+            "allers_vers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "allers_vers_departements_allers_vers_id_code_departement_pk": {
+          "name": "allers_vers_departements_allers_vers_id_code_departement_pk",
+          "columns": [
+            "allers_vers_id",
+            "code_departement"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers_epci": {
+      "name": "allers_vers_epci",
+      "schema": "",
+      "columns": {
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_epci": {
+          "name": "code_epci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allers_vers_epci_allers_vers_id_allers_vers_id_fk": {
+          "name": "allers_vers_epci_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "allers_vers_epci",
+          "tableTo": "allers_vers",
+          "columnsFrom": [
+            "allers_vers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "allers_vers_epci_allers_vers_id_code_epci_pk": {
+          "name": "allers_vers_epci_allers_vers_id_code_epci_pk",
+          "columns": [
+            "allers_vers_id",
+            "code_epci"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers": {
+      "name": "allers_vers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails": {
+          "name": "emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "horaires": {
+          "name": "horaires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.amo_validation_tokens": {
+      "name": "amo_validation_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_amo_validation_id": {
+          "name": "parcours_amo_validation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "amo_validation_token_idx": {
+          "name": "amo_validation_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "amo_validation_validation_id_idx": {
+          "name": "amo_validation_validation_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_amo_validation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "amo_validation_tokens_parcours_amo_validation_id_parcours_amo_validations_id_fk": {
+          "name": "amo_validation_tokens_parcours_amo_validation_id_parcours_amo_validations_id_fk",
+          "tableFrom": "amo_validation_tokens",
+          "tableTo": "parcours_amo_validations",
+          "columnsFrom": [
+            "parcours_amo_validation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "amo_validation_tokens_token_unique": {
+          "name": "amo_validation_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catastrophes_naturelles": {
+      "name": "catastrophes_naturelles",
+      "schema": "",
+      "columns": {
+        "code_national_catnat": {
+          "name": "code_national_catnat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_debut_evt": {
+          "name": "date_debut_evt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_fin_evt": {
+          "name": "date_fin_evt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_publication_arrete": {
+          "name": "date_publication_arrete",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_publication_jo": {
+          "name": "date_publication_jo",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle_risque_jo": {
+          "name": "libelle_risque_jo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle_commune": {
+          "name": "libelle_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catastrophes_naturelles_code_insee_idx": {
+          "name": "catastrophes_naturelles_code_insee_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_date_debut_evt_idx": {
+          "name": "catastrophes_naturelles_date_debut_evt_idx",
+          "columns": [
+            {
+              "expression": "date_debut_evt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_code_insee_date_idx": {
+          "name": "catastrophes_naturelles_code_insee_date_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_debut_evt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_libelle_risque_idx": {
+          "name": "catastrophes_naturelles_libelle_risque_idx",
+          "columns": [
+            {
+              "expression": "libelle_risque_jo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_code_national_idx": {
+          "name": "catastrophes_naturelles_code_national_idx",
+          "columns": [
+            {
+              "expression": "code_national_catnat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "catastrophes_naturelles_code_national_catnat_code_insee_pk": {
+          "name": "catastrophes_naturelles_code_national_catnat_code_insee_pk",
+          "columns": [
+            "code_national_catnat",
+            "code_insee"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dossiers_demarches_simplifiees": {
+      "name": "dossiers_demarches_simplifiees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_id": {
+          "name": "ds_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_demarche_id": {
+          "name": "ds_demarche_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_status": {
+          "name": "ds_status",
+          "type": "ds_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructed_at": {
+          "name": "instructed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_url": {
+          "name": "ds_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dn_probe_state": {
+          "name": "dn_probe_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dn_probe_at": {
+          "name": "dn_probe_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dossiers_demarches_simplifiees_parcours_id_parcours_prevention_id_fk": {
+          "name": "dossiers_demarches_simplifiees_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "dossiers_demarches_simplifiees",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dossiers_demarches_simplifiees_ds_number_unique": {
+          "name": "dossiers_demarches_simplifiees_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ds_number"
+          ]
+        },
+        "dossiers_ds_parcours_step_unique": {
+          "name": "dossiers_ds_parcours_step_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parcours_id",
+            "step"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dossiers_ds_tentatives": {
+      "name": "dossiers_ds_tentatives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_id": {
+          "name": "ds_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_demarche_id": {
+          "name": "ds_demarche_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origine": {
+          "name": "origine",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dossiers_ds_tentatives_parcours_step_idx": {
+          "name": "dossiers_ds_tentatives_parcours_step_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dossiers_ds_tentatives_parcours_id_parcours_prevention_id_fk": {
+          "name": "dossiers_ds_tentatives_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "dossiers_ds_tentatives",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dossiers_ds_tentatives_ds_number_unique": {
+          "name": "dossiers_ds_tentatives_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ds_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo_communes": {
+      "name": "entreprises_amo_communes",
+      "schema": "",
+      "columns": {
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entreprises_amo_communes_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "entreprises_amo_communes_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "entreprises_amo_communes",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": [
+            "entreprise_amo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entreprises_amo_communes_entreprise_amo_id_code_insee_pk": {
+          "name": "entreprises_amo_communes_entreprise_amo_id_code_insee_pk",
+          "columns": [
+            "entreprise_amo_id",
+            "code_insee"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo_epci": {
+      "name": "entreprises_amo_epci",
+      "schema": "",
+      "columns": {
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_epci": {
+          "name": "code_epci",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entreprises_amo_epci_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "entreprises_amo_epci_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "entreprises_amo_epci",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": [
+            "entreprise_amo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entreprises_amo_epci_entreprise_amo_id_code_epci_pk": {
+          "name": "entreprises_amo_epci_entreprise_amo_id_code_epci_pk",
+          "columns": [
+            "entreprise_amo_id",
+            "code_epci"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo": {
+      "name": "entreprises_amo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siret": {
+          "name": "siret",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departements": {
+          "name": "departements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails": {
+          "name": "emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horaires": {
+          "name": "horaires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entreprises_amo_siret_unique": {
+          "name": "entreprises_amo_siret_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "siret"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fc_id": {
+          "name": "fc_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nom_famille": {
+          "name": "nom_famille",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prenom": {
+          "name": "prenom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_contact": {
+          "name": "email_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_acquisition": {
+          "name": "source_acquisition",
+          "type": "source_acquisition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_acquisition_precision": {
+          "name": "source_acquisition_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partner_source": {
+          "name": "partner_source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token_expires_at": {
+          "name": "claim_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_fc_id_unique": {
+          "name": "users_fc_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "fc_id"
+          ]
+        },
+        "users_claim_token_unique": {
+          "name": "users_claim_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "claim_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_prevention": {
+      "name": "parcours_prevention",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'choix_amo'"
+        },
+        "current_status": {
+          "name": "current_status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "situation_particulier": {
+          "name": "situation_particulier",
+          "type": "situation_particulier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prospect'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data": {
+          "name": "rga_simulation_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_completed_at": {
+          "name": "rga_simulation_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_data_deleted_at": {
+          "name": "rga_data_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_data_deletion_reason": {
+          "name": "rga_data_deletion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data_agent": {
+          "name": "rga_simulation_data_agent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data_agent_baseline": {
+          "name": "rga_simulation_data_agent_baseline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_agent_edited_at": {
+          "name": "rga_simulation_agent_edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_agent_edited_by": {
+          "name": "rga_simulation_agent_edited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by": {
+          "name": "archived_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parcours_prevention_user_id_users_id_fk": {
+          "name": "parcours_prevention_user_id_users_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_rga_simulation_agent_edited_by_agents_id_fk": {
+          "name": "parcours_prevention_rga_simulation_agent_edited_by_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "rga_simulation_agent_edited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_archived_by_agents_id_fk": {
+          "name": "parcours_prevention_archived_by_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "archived_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_created_by_agent_id_agents_id_fk": {
+          "name": "parcours_prevention_created_by_agent_id_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parcours_prevention_user_id_unique": {
+          "name": "parcours_prevention_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_actions": {
+      "name": "parcours_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_precision": {
+          "name": "action_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rdv_date": {
+          "name": "rdv_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_structure": {
+          "name": "author_structure",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_structure_type": {
+          "name": "author_structure_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parcours_actions_parcours_id_parcours_prevention_id_fk": {
+          "name": "parcours_actions_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "parcours_actions",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_actions_agent_id_agents_id_fk": {
+          "name": "parcours_actions_agent_id_agents_id_fk",
+          "tableFrom": "parcours_actions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_amo_validations": {
+      "name": "parcours_amo_validations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statut": {
+          "name": "statut",
+          "type": "statut_validation_amo",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en_attente'"
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "attribution_amo_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manuel'"
+        },
+        "commentaire": {
+          "name": "commentaire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "est_mandataire_financier": {
+          "name": "est_mandataire_financier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demande_arret_at": {
+          "name": "demande_arret_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prenom": {
+          "name": "user_prenom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_nom": {
+          "name": "user_nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_telephone": {
+          "name": "user_telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse_logement": {
+          "name": "adresse_logement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brevo_message_id": {
+          "name": "brevo_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_sent_at": {
+          "name": "email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_delivered_at": {
+          "name": "email_delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_opened_at": {
+          "name": "email_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_clicked_at": {
+          "name": "email_clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bounce_type": {
+          "name": "email_bounce_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bounce_reason": {
+          "name": "email_bounce_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "choisie_at": {
+          "name": "choisie_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validee_at": {
+          "name": "validee_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parcours_amo_validations_brevo_message_id_idx": {
+          "name": "parcours_amo_validations_brevo_message_id_idx",
+          "columns": [
+            {
+              "expression": "brevo_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parcours_amo_validations_parcours_id_parcours_prevention_id_fk": {
+          "name": "parcours_amo_validations_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "parcours_amo_validations",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_amo_validations_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "parcours_amo_validations_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "parcours_amo_validations",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": [
+            "entreprise_amo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parcours_amo_validations_parcours_id_unique": {
+          "name": "parcours_amo_validations_parcours_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parcours_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prospect_qualifications": {
+      "name": "prospect_qualifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions_realisees": {
+          "name": "actions_realisees",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raisons_ineligibilite": {
+          "name": "raisons_ineligibilite",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "est_mandataire_financier": {
+          "name": "est_mandataire_financier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "prospect_qualifications_parcours_id_idx": {
+          "name": "prospect_qualifications_parcours_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prospect_qualifications_parcours_id_parcours_prevention_id_fk": {
+          "name": "prospect_qualifications_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "prospect_qualifications",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prospect_qualifications_agent_id_agents_id_fk": {
+          "name": "prospect_qualifications_agent_id_agents_id_fk",
+          "tableFrom": "prospect_qualifications",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rga_zones": {
+      "name": "rga_zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alea": {
+          "name": "alea",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_runs": {
+      "name": "sync_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "sync_run_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "total_parcours_scanned": {
+          "name": "total_parcours_scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_parcours_updated": {
+          "name": "total_parcours_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_errors": {
+          "name": "total_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_summary": {
+          "name": "error_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_runs_started_at_idx": {
+          "name": "sync_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_run_entries": {
+      "name": "sync_run_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sync_run_id": {
+          "name": "sync_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_before": {
+          "name": "step_before",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_after": {
+          "name": "step_after",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_status_changes": {
+          "name": "ds_status_changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_advanced": {
+          "name": "step_advanced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_run_entries_sync_run_id_idx": {
+          "name": "sync_run_entries_sync_run_id_idx",
+          "columns": [
+            {
+              "expression": "sync_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_run_entries_parcours_id_idx": {
+          "name": "sync_run_entries_parcours_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_run_entries_sync_run_id_sync_runs_id_fk": {
+          "name": "sync_run_entries_sync_run_id_sync_runs_id_fk",
+          "tableFrom": "sync_run_entries",
+          "tableTo": "sync_runs",
+          "columnsFrom": [
+            "sync_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_run_entries_parcours_id_parcours_prevention_id_fk": {
+          "name": "sync_run_entries_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "sync_run_entries",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "public",
+      "values": [
+        "administrateur",
+        "super_administrateur",
+        "amo",
+        "analyste",
+        "allers_vers",
+        "amo_et_allers_vers"
+      ]
+    },
+    "public.ds_status": {
+      "name": "ds_status",
+      "schema": "public",
+      "values": [
+        "en_construction",
+        "en_instruction",
+        "accepte",
+        "refuse",
+        "classe_sans_suite",
+        "non_accessible"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "todo",
+        "en_instruction",
+        "valide"
+      ]
+    },
+    "public.statut_validation_amo": {
+      "name": "statut_validation_amo",
+      "schema": "public",
+      "values": [
+        "en_attente",
+        "logement_eligible",
+        "logement_non_eligible",
+        "accompagnement_refuse",
+        "sans_amo"
+      ]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": [
+        "invitation",
+        "choix_amo",
+        "eligibilite",
+        "diagnostic",
+        "devis",
+        "factures"
+      ]
+    },
+    "public.sync_run_status": {
+      "name": "sync_run_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "partial",
+        "error"
+      ]
+    },
+    "public.sync_run_trigger": {
+      "name": "sync_run_trigger",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/shared/database/migrations/meta/0045_snapshot.json
+++ b/src/shared/database/migrations/meta/0045_snapshot.json
@@ -1,0 +1,2176 @@
+{
+  "id": "fa2f4713-ef3b-465a-bc45-9afa0b9d94f5",
+  "prevId": "c2161a1a-d684-4465-990e-2cbadd1c7ee7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departement_code": {
+          "name": "departement_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sub": {
+          "name": "sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usual_name": {
+          "name": "usual_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siret": {
+          "name": "siret",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizational_unit": {
+          "name": "organizational_unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "agent_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'administrateur'"
+        },
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "agents_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": ["entreprise_amo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agents_allers_vers_id_allers_vers_id_fk": {
+          "name": "agents_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "allers_vers",
+          "columnsFrom": ["allers_vers_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_sub_unique": {
+          "name": "agents_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": ["sub"]
+        },
+        "agents_email_unique": {
+          "name": "agents_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers_departements": {
+      "name": "allers_vers_departements",
+      "schema": "",
+      "columns": {
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_departement": {
+          "name": "code_departement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allers_vers_departements_allers_vers_id_allers_vers_id_fk": {
+          "name": "allers_vers_departements_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "allers_vers_departements",
+          "tableTo": "allers_vers",
+          "columnsFrom": ["allers_vers_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "allers_vers_departements_allers_vers_id_code_departement_pk": {
+          "name": "allers_vers_departements_allers_vers_id_code_departement_pk",
+          "columns": ["allers_vers_id", "code_departement"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers_epci": {
+      "name": "allers_vers_epci",
+      "schema": "",
+      "columns": {
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_epci": {
+          "name": "code_epci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allers_vers_epci_allers_vers_id_allers_vers_id_fk": {
+          "name": "allers_vers_epci_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "allers_vers_epci",
+          "tableTo": "allers_vers",
+          "columnsFrom": ["allers_vers_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "allers_vers_epci_allers_vers_id_code_epci_pk": {
+          "name": "allers_vers_epci_allers_vers_id_code_epci_pk",
+          "columns": ["allers_vers_id", "code_epci"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers": {
+      "name": "allers_vers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails": {
+          "name": "emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "horaires": {
+          "name": "horaires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.amo_validation_tokens": {
+      "name": "amo_validation_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_amo_validation_id": {
+          "name": "parcours_amo_validation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "amo_validation_token_idx": {
+          "name": "amo_validation_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "amo_validation_validation_id_idx": {
+          "name": "amo_validation_validation_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_amo_validation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "amo_validation_tokens_parcours_amo_validation_id_parcours_amo_validations_id_fk": {
+          "name": "amo_validation_tokens_parcours_amo_validation_id_parcours_amo_validations_id_fk",
+          "tableFrom": "amo_validation_tokens",
+          "tableTo": "parcours_amo_validations",
+          "columnsFrom": ["parcours_amo_validation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "amo_validation_tokens_token_unique": {
+          "name": "amo_validation_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catastrophes_naturelles": {
+      "name": "catastrophes_naturelles",
+      "schema": "",
+      "columns": {
+        "code_national_catnat": {
+          "name": "code_national_catnat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_debut_evt": {
+          "name": "date_debut_evt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_fin_evt": {
+          "name": "date_fin_evt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_publication_arrete": {
+          "name": "date_publication_arrete",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_publication_jo": {
+          "name": "date_publication_jo",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle_risque_jo": {
+          "name": "libelle_risque_jo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle_commune": {
+          "name": "libelle_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catastrophes_naturelles_code_insee_idx": {
+          "name": "catastrophes_naturelles_code_insee_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_date_debut_evt_idx": {
+          "name": "catastrophes_naturelles_date_debut_evt_idx",
+          "columns": [
+            {
+              "expression": "date_debut_evt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_code_insee_date_idx": {
+          "name": "catastrophes_naturelles_code_insee_date_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_debut_evt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_libelle_risque_idx": {
+          "name": "catastrophes_naturelles_libelle_risque_idx",
+          "columns": [
+            {
+              "expression": "libelle_risque_jo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_code_national_idx": {
+          "name": "catastrophes_naturelles_code_national_idx",
+          "columns": [
+            {
+              "expression": "code_national_catnat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "catastrophes_naturelles_code_national_catnat_code_insee_pk": {
+          "name": "catastrophes_naturelles_code_national_catnat_code_insee_pk",
+          "columns": ["code_national_catnat", "code_insee"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dossiers_demarches_simplifiees": {
+      "name": "dossiers_demarches_simplifiees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_id": {
+          "name": "ds_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_demarche_id": {
+          "name": "ds_demarche_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_status": {
+          "name": "ds_status",
+          "type": "ds_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructed_at": {
+          "name": "instructed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_url": {
+          "name": "ds_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dn_probe_state": {
+          "name": "dn_probe_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dn_probe_at": {
+          "name": "dn_probe_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dossiers_demarches_simplifiees_parcours_id_parcours_prevention_id_fk": {
+          "name": "dossiers_demarches_simplifiees_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "dossiers_demarches_simplifiees",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dossiers_demarches_simplifiees_ds_number_unique": {
+          "name": "dossiers_demarches_simplifiees_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["ds_number"]
+        },
+        "dossiers_ds_parcours_step_unique": {
+          "name": "dossiers_ds_parcours_step_unique",
+          "nullsNotDistinct": false,
+          "columns": ["parcours_id", "step"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dossiers_ds_tentatives": {
+      "name": "dossiers_ds_tentatives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_id": {
+          "name": "ds_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_demarche_id": {
+          "name": "ds_demarche_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origine": {
+          "name": "origine",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dossiers_ds_tentatives_parcours_step_idx": {
+          "name": "dossiers_ds_tentatives_parcours_step_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dossiers_ds_tentatives_parcours_id_parcours_prevention_id_fk": {
+          "name": "dossiers_ds_tentatives_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "dossiers_ds_tentatives",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dossiers_ds_tentatives_ds_number_unique": {
+          "name": "dossiers_ds_tentatives_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["ds_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ds_reconciliation_observations": {
+      "name": "ds_reconciliation_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_state": {
+          "name": "ds_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ds_reconciliation_observations_verdict_idx": {
+          "name": "ds_reconciliation_observations_verdict_idx",
+          "columns": [
+            {
+              "expression": "verdict",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ds_reconciliation_observations_parcours_idx": {
+          "name": "ds_reconciliation_observations_parcours_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ds_reconciliation_observations_parcours_id_parcours_prevention_id_fk": {
+          "name": "ds_reconciliation_observations_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "ds_reconciliation_observations",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ds_reconciliation_observations_resolved_by_agents_id_fk": {
+          "name": "ds_reconciliation_observations_resolved_by_agents_id_fk",
+          "tableFrom": "ds_reconciliation_observations",
+          "tableTo": "agents",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ds_reconciliation_observations_ds_number_unique": {
+          "name": "ds_reconciliation_observations_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["ds_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo_communes": {
+      "name": "entreprises_amo_communes",
+      "schema": "",
+      "columns": {
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entreprises_amo_communes_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "entreprises_amo_communes_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "entreprises_amo_communes",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": ["entreprise_amo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entreprises_amo_communes_entreprise_amo_id_code_insee_pk": {
+          "name": "entreprises_amo_communes_entreprise_amo_id_code_insee_pk",
+          "columns": ["entreprise_amo_id", "code_insee"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo_epci": {
+      "name": "entreprises_amo_epci",
+      "schema": "",
+      "columns": {
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_epci": {
+          "name": "code_epci",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entreprises_amo_epci_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "entreprises_amo_epci_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "entreprises_amo_epci",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": ["entreprise_amo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entreprises_amo_epci_entreprise_amo_id_code_epci_pk": {
+          "name": "entreprises_amo_epci_entreprise_amo_id_code_epci_pk",
+          "columns": ["entreprise_amo_id", "code_epci"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo": {
+      "name": "entreprises_amo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siret": {
+          "name": "siret",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departements": {
+          "name": "departements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails": {
+          "name": "emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horaires": {
+          "name": "horaires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entreprises_amo_siret_unique": {
+          "name": "entreprises_amo_siret_unique",
+          "nullsNotDistinct": false,
+          "columns": ["siret"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fc_id": {
+          "name": "fc_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nom_famille": {
+          "name": "nom_famille",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prenom": {
+          "name": "prenom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_contact": {
+          "name": "email_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_acquisition": {
+          "name": "source_acquisition",
+          "type": "source_acquisition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_acquisition_precision": {
+          "name": "source_acquisition_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partner_source": {
+          "name": "partner_source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token_expires_at": {
+          "name": "claim_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_fc_id_unique": {
+          "name": "users_fc_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["fc_id"]
+        },
+        "users_claim_token_unique": {
+          "name": "users_claim_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["claim_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_prevention": {
+      "name": "parcours_prevention",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'choix_amo'"
+        },
+        "current_status": {
+          "name": "current_status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "situation_particulier": {
+          "name": "situation_particulier",
+          "type": "situation_particulier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prospect'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data": {
+          "name": "rga_simulation_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_completed_at": {
+          "name": "rga_simulation_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_data_deleted_at": {
+          "name": "rga_data_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_data_deletion_reason": {
+          "name": "rga_data_deletion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data_agent": {
+          "name": "rga_simulation_data_agent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data_agent_baseline": {
+          "name": "rga_simulation_data_agent_baseline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_agent_edited_at": {
+          "name": "rga_simulation_agent_edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_agent_edited_by": {
+          "name": "rga_simulation_agent_edited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by": {
+          "name": "archived_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parcours_prevention_user_id_users_id_fk": {
+          "name": "parcours_prevention_user_id_users_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_rga_simulation_agent_edited_by_agents_id_fk": {
+          "name": "parcours_prevention_rga_simulation_agent_edited_by_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": ["rga_simulation_agent_edited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_archived_by_agents_id_fk": {
+          "name": "parcours_prevention_archived_by_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": ["archived_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_created_by_agent_id_agents_id_fk": {
+          "name": "parcours_prevention_created_by_agent_id_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": ["created_by_agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parcours_prevention_user_id_unique": {
+          "name": "parcours_prevention_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_actions": {
+      "name": "parcours_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_precision": {
+          "name": "action_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rdv_date": {
+          "name": "rdv_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_structure": {
+          "name": "author_structure",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_structure_type": {
+          "name": "author_structure_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parcours_actions_parcours_id_parcours_prevention_id_fk": {
+          "name": "parcours_actions_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "parcours_actions",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_actions_agent_id_agents_id_fk": {
+          "name": "parcours_actions_agent_id_agents_id_fk",
+          "tableFrom": "parcours_actions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_amo_validations": {
+      "name": "parcours_amo_validations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statut": {
+          "name": "statut",
+          "type": "statut_validation_amo",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en_attente'"
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "attribution_amo_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manuel'"
+        },
+        "commentaire": {
+          "name": "commentaire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "est_mandataire_financier": {
+          "name": "est_mandataire_financier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demande_arret_at": {
+          "name": "demande_arret_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prenom": {
+          "name": "user_prenom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_nom": {
+          "name": "user_nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_telephone": {
+          "name": "user_telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse_logement": {
+          "name": "adresse_logement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brevo_message_id": {
+          "name": "brevo_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_sent_at": {
+          "name": "email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_delivered_at": {
+          "name": "email_delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_opened_at": {
+          "name": "email_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_clicked_at": {
+          "name": "email_clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bounce_type": {
+          "name": "email_bounce_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bounce_reason": {
+          "name": "email_bounce_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "choisie_at": {
+          "name": "choisie_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validee_at": {
+          "name": "validee_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parcours_amo_validations_brevo_message_id_idx": {
+          "name": "parcours_amo_validations_brevo_message_id_idx",
+          "columns": [
+            {
+              "expression": "brevo_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parcours_amo_validations_parcours_id_parcours_prevention_id_fk": {
+          "name": "parcours_amo_validations_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "parcours_amo_validations",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_amo_validations_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "parcours_amo_validations_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "parcours_amo_validations",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": ["entreprise_amo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parcours_amo_validations_parcours_id_unique": {
+          "name": "parcours_amo_validations_parcours_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["parcours_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prospect_qualifications": {
+      "name": "prospect_qualifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions_realisees": {
+          "name": "actions_realisees",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raisons_ineligibilite": {
+          "name": "raisons_ineligibilite",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "est_mandataire_financier": {
+          "name": "est_mandataire_financier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "prospect_qualifications_parcours_id_idx": {
+          "name": "prospect_qualifications_parcours_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prospect_qualifications_parcours_id_parcours_prevention_id_fk": {
+          "name": "prospect_qualifications_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "prospect_qualifications",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prospect_qualifications_agent_id_agents_id_fk": {
+          "name": "prospect_qualifications_agent_id_agents_id_fk",
+          "tableFrom": "prospect_qualifications",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rga_zones": {
+      "name": "rga_zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alea": {
+          "name": "alea",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_runs": {
+      "name": "sync_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "sync_run_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "total_parcours_scanned": {
+          "name": "total_parcours_scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_parcours_updated": {
+          "name": "total_parcours_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_errors": {
+          "name": "total_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_summary": {
+          "name": "error_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_runs_started_at_idx": {
+          "name": "sync_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_run_entries": {
+      "name": "sync_run_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sync_run_id": {
+          "name": "sync_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_before": {
+          "name": "step_before",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_after": {
+          "name": "step_after",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_status_changes": {
+          "name": "ds_status_changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_advanced": {
+          "name": "step_advanced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_run_entries_sync_run_id_idx": {
+          "name": "sync_run_entries_sync_run_id_idx",
+          "columns": [
+            {
+              "expression": "sync_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_run_entries_parcours_id_idx": {
+          "name": "sync_run_entries_parcours_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_run_entries_sync_run_id_sync_runs_id_fk": {
+          "name": "sync_run_entries_sync_run_id_sync_runs_id_fk",
+          "tableFrom": "sync_run_entries",
+          "tableTo": "sync_runs",
+          "columnsFrom": ["sync_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_run_entries_parcours_id_parcours_prevention_id_fk": {
+          "name": "sync_run_entries_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "sync_run_entries",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": ["parcours_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "public",
+      "values": ["administrateur", "super_administrateur", "amo", "analyste", "allers_vers", "amo_et_allers_vers"]
+    },
+    "public.ds_status": {
+      "name": "ds_status",
+      "schema": "public",
+      "values": ["en_construction", "en_instruction", "accepte", "refuse", "classe_sans_suite", "non_accessible"]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": ["todo", "en_instruction", "valide"]
+    },
+    "public.statut_validation_amo": {
+      "name": "statut_validation_amo",
+      "schema": "public",
+      "values": ["en_attente", "logement_eligible", "logement_non_eligible", "accompagnement_refuse", "sans_amo"]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": ["invitation", "choix_amo", "eligibilite", "diagnostic", "devis", "factures"]
+    },
+    "public.sync_run_status": {
+      "name": "sync_run_status",
+      "schema": "public",
+      "values": ["success", "partial", "error"]
+    },
+    "public.sync_run_trigger": {
+      "name": "sync_run_trigger",
+      "schema": "public",
+      "values": ["cron", "manual"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/shared/database/migrations/meta/0046_snapshot.json
+++ b/src/shared/database/migrations/meta/0046_snapshot.json
@@ -1,0 +1,2356 @@
+{
+  "id": "457e5c62-f0fc-4891-803e-9b0b1074230a",
+  "prevId": "fa2f4713-ef3b-465a-bc45-9afa0b9d94f5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departement_code": {
+          "name": "departement_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sub": {
+          "name": "sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usual_name": {
+          "name": "usual_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siret": {
+          "name": "siret",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizational_unit": {
+          "name": "organizational_unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "agent_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'administrateur'"
+        },
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "agents_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": [
+            "entreprise_amo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agents_allers_vers_id_allers_vers_id_fk": {
+          "name": "agents_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "allers_vers",
+          "columnsFrom": [
+            "allers_vers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_sub_unique": {
+          "name": "agents_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub"
+          ]
+        },
+        "agents_email_unique": {
+          "name": "agents_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers_departements": {
+      "name": "allers_vers_departements",
+      "schema": "",
+      "columns": {
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_departement": {
+          "name": "code_departement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allers_vers_departements_allers_vers_id_allers_vers_id_fk": {
+          "name": "allers_vers_departements_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "allers_vers_departements",
+          "tableTo": "allers_vers",
+          "columnsFrom": [
+            "allers_vers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "allers_vers_departements_allers_vers_id_code_departement_pk": {
+          "name": "allers_vers_departements_allers_vers_id_code_departement_pk",
+          "columns": [
+            "allers_vers_id",
+            "code_departement"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers_epci": {
+      "name": "allers_vers_epci",
+      "schema": "",
+      "columns": {
+        "allers_vers_id": {
+          "name": "allers_vers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_epci": {
+          "name": "code_epci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allers_vers_epci_allers_vers_id_allers_vers_id_fk": {
+          "name": "allers_vers_epci_allers_vers_id_allers_vers_id_fk",
+          "tableFrom": "allers_vers_epci",
+          "tableTo": "allers_vers",
+          "columnsFrom": [
+            "allers_vers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "allers_vers_epci_allers_vers_id_code_epci_pk": {
+          "name": "allers_vers_epci_allers_vers_id_code_epci_pk",
+          "columns": [
+            "allers_vers_id",
+            "code_epci"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allers_vers": {
+      "name": "allers_vers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails": {
+          "name": "emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "horaires": {
+          "name": "horaires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.amo_validation_tokens": {
+      "name": "amo_validation_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_amo_validation_id": {
+          "name": "parcours_amo_validation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "amo_validation_token_idx": {
+          "name": "amo_validation_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "amo_validation_validation_id_idx": {
+          "name": "amo_validation_validation_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_amo_validation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "amo_validation_tokens_parcours_amo_validation_id_parcours_amo_validations_id_fk": {
+          "name": "amo_validation_tokens_parcours_amo_validation_id_parcours_amo_validations_id_fk",
+          "tableFrom": "amo_validation_tokens",
+          "tableTo": "parcours_amo_validations",
+          "columnsFrom": [
+            "parcours_amo_validation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "amo_validation_tokens_token_unique": {
+          "name": "amo_validation_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catastrophes_naturelles": {
+      "name": "catastrophes_naturelles",
+      "schema": "",
+      "columns": {
+        "code_national_catnat": {
+          "name": "code_national_catnat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_debut_evt": {
+          "name": "date_debut_evt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_fin_evt": {
+          "name": "date_fin_evt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_publication_arrete": {
+          "name": "date_publication_arrete",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_publication_jo": {
+          "name": "date_publication_jo",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle_risque_jo": {
+          "name": "libelle_risque_jo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle_commune": {
+          "name": "libelle_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catastrophes_naturelles_code_insee_idx": {
+          "name": "catastrophes_naturelles_code_insee_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_date_debut_evt_idx": {
+          "name": "catastrophes_naturelles_date_debut_evt_idx",
+          "columns": [
+            {
+              "expression": "date_debut_evt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_code_insee_date_idx": {
+          "name": "catastrophes_naturelles_code_insee_date_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_debut_evt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_libelle_risque_idx": {
+          "name": "catastrophes_naturelles_libelle_risque_idx",
+          "columns": [
+            {
+              "expression": "libelle_risque_jo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catastrophes_naturelles_code_national_idx": {
+          "name": "catastrophes_naturelles_code_national_idx",
+          "columns": [
+            {
+              "expression": "code_national_catnat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "catastrophes_naturelles_code_national_catnat_code_insee_pk": {
+          "name": "catastrophes_naturelles_code_national_catnat_code_insee_pk",
+          "columns": [
+            "code_national_catnat",
+            "code_insee"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dossiers_demarches_simplifiees": {
+      "name": "dossiers_demarches_simplifiees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_id": {
+          "name": "ds_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_demarche_id": {
+          "name": "ds_demarche_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_status": {
+          "name": "ds_status",
+          "type": "ds_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructed_at": {
+          "name": "instructed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_url": {
+          "name": "ds_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dn_probe_state": {
+          "name": "dn_probe_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dn_probe_at": {
+          "name": "dn_probe_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dossiers_demarches_simplifiees_parcours_id_parcours_prevention_id_fk": {
+          "name": "dossiers_demarches_simplifiees_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "dossiers_demarches_simplifiees",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dossiers_demarches_simplifiees_ds_number_unique": {
+          "name": "dossiers_demarches_simplifiees_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ds_number"
+          ]
+        },
+        "dossiers_ds_parcours_step_unique": {
+          "name": "dossiers_ds_parcours_step_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parcours_id",
+            "step"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dossiers_ds_tentatives": {
+      "name": "dossiers_ds_tentatives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_id": {
+          "name": "ds_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_demarche_id": {
+          "name": "ds_demarche_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origine": {
+          "name": "origine",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dossiers_ds_tentatives_parcours_step_idx": {
+          "name": "dossiers_ds_tentatives_parcours_step_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dossiers_ds_tentatives_parcours_id_parcours_prevention_id_fk": {
+          "name": "dossiers_ds_tentatives_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "dossiers_ds_tentatives",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dossiers_ds_tentatives_ds_number_unique": {
+          "name": "dossiers_ds_tentatives_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ds_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ds_reconciliation_observations": {
+      "name": "ds_reconciliation_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ds_number": {
+          "name": "ds_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ds_state": {
+          "name": "ds_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidats": {
+          "name": "candidats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ds_reconciliation_observations_verdict_idx": {
+          "name": "ds_reconciliation_observations_verdict_idx",
+          "columns": [
+            {
+              "expression": "verdict",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ds_reconciliation_observations_parcours_idx": {
+          "name": "ds_reconciliation_observations_parcours_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ds_reconciliation_observations_parcours_id_parcours_prevention_id_fk": {
+          "name": "ds_reconciliation_observations_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "ds_reconciliation_observations",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ds_reconciliation_observations_resolved_by_agents_id_fk": {
+          "name": "ds_reconciliation_observations_resolved_by_agents_id_fk",
+          "tableFrom": "ds_reconciliation_observations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ds_reconciliation_observations_ds_number_unique": {
+          "name": "ds_reconciliation_observations_ds_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ds_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo_communes": {
+      "name": "entreprises_amo_communes",
+      "schema": "",
+      "columns": {
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entreprises_amo_communes_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "entreprises_amo_communes_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "entreprises_amo_communes",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": [
+            "entreprise_amo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entreprises_amo_communes_entreprise_amo_id_code_insee_pk": {
+          "name": "entreprises_amo_communes_entreprise_amo_id_code_insee_pk",
+          "columns": [
+            "entreprise_amo_id",
+            "code_insee"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo_epci": {
+      "name": "entreprises_amo_epci",
+      "schema": "",
+      "columns": {
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_epci": {
+          "name": "code_epci",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entreprises_amo_epci_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "entreprises_amo_epci_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "entreprises_amo_epci",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": [
+            "entreprise_amo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entreprises_amo_epci_entreprise_amo_id_code_epci_pk": {
+          "name": "entreprises_amo_epci_entreprise_amo_id_code_epci_pk",
+          "columns": [
+            "entreprise_amo_id",
+            "code_epci"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entreprises_amo": {
+      "name": "entreprises_amo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siret": {
+          "name": "siret",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departements": {
+          "name": "departements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails": {
+          "name": "emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horaires": {
+          "name": "horaires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entreprises_amo_siret_unique": {
+          "name": "entreprises_amo_siret_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "siret"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fc_id": {
+          "name": "fc_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nom_famille": {
+          "name": "nom_famille",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prenom": {
+          "name": "prenom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_contact": {
+          "name": "email_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_acquisition": {
+          "name": "source_acquisition",
+          "type": "source_acquisition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_acquisition_precision": {
+          "name": "source_acquisition_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partner_source": {
+          "name": "partner_source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token_expires_at": {
+          "name": "claim_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_fc_id_unique": {
+          "name": "users_fc_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "fc_id"
+          ]
+        },
+        "users_claim_token_unique": {
+          "name": "users_claim_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "claim_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_prevention": {
+      "name": "parcours_prevention",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'choix_amo'"
+        },
+        "current_status": {
+          "name": "current_status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "situation_particulier": {
+          "name": "situation_particulier",
+          "type": "situation_particulier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prospect'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data": {
+          "name": "rga_simulation_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_completed_at": {
+          "name": "rga_simulation_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_data_deleted_at": {
+          "name": "rga_data_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_data_deletion_reason": {
+          "name": "rga_data_deletion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data_agent": {
+          "name": "rga_simulation_data_agent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_data_agent_baseline": {
+          "name": "rga_simulation_data_agent_baseline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_agent_edited_at": {
+          "name": "rga_simulation_agent_edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rga_simulation_agent_edited_by": {
+          "name": "rga_simulation_agent_edited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by": {
+          "name": "archived_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parcours_prevention_user_id_users_id_fk": {
+          "name": "parcours_prevention_user_id_users_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_rga_simulation_agent_edited_by_agents_id_fk": {
+          "name": "parcours_prevention_rga_simulation_agent_edited_by_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "rga_simulation_agent_edited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_archived_by_agents_id_fk": {
+          "name": "parcours_prevention_archived_by_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "archived_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parcours_prevention_created_by_agent_id_agents_id_fk": {
+          "name": "parcours_prevention_created_by_agent_id_agents_id_fk",
+          "tableFrom": "parcours_prevention",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parcours_prevention_user_id_unique": {
+          "name": "parcours_prevention_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_actions": {
+      "name": "parcours_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_precision": {
+          "name": "action_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rdv_date": {
+          "name": "rdv_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_structure": {
+          "name": "author_structure",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_structure_type": {
+          "name": "author_structure_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parcours_actions_parcours_id_parcours_prevention_id_fk": {
+          "name": "parcours_actions_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "parcours_actions",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_actions_agent_id_agents_id_fk": {
+          "name": "parcours_actions_agent_id_agents_id_fk",
+          "tableFrom": "parcours_actions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parcours_amo_validations": {
+      "name": "parcours_amo_validations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entreprise_amo_id": {
+          "name": "entreprise_amo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statut": {
+          "name": "statut",
+          "type": "statut_validation_amo",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en_attente'"
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "attribution_amo_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manuel'"
+        },
+        "commentaire": {
+          "name": "commentaire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "est_mandataire_financier": {
+          "name": "est_mandataire_financier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demande_arret_at": {
+          "name": "demande_arret_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prenom": {
+          "name": "user_prenom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_nom": {
+          "name": "user_nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_telephone": {
+          "name": "user_telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse_logement": {
+          "name": "adresse_logement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brevo_message_id": {
+          "name": "brevo_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_sent_at": {
+          "name": "email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_delivered_at": {
+          "name": "email_delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_opened_at": {
+          "name": "email_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_clicked_at": {
+          "name": "email_clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bounce_type": {
+          "name": "email_bounce_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bounce_reason": {
+          "name": "email_bounce_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "choisie_at": {
+          "name": "choisie_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validee_at": {
+          "name": "validee_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parcours_amo_validations_brevo_message_id_idx": {
+          "name": "parcours_amo_validations_brevo_message_id_idx",
+          "columns": [
+            {
+              "expression": "brevo_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parcours_amo_validations_parcours_id_parcours_prevention_id_fk": {
+          "name": "parcours_amo_validations_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "parcours_amo_validations",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parcours_amo_validations_entreprise_amo_id_entreprises_amo_id_fk": {
+          "name": "parcours_amo_validations_entreprise_amo_id_entreprises_amo_id_fk",
+          "tableFrom": "parcours_amo_validations",
+          "tableTo": "entreprises_amo",
+          "columnsFrom": [
+            "entreprise_amo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parcours_amo_validations_parcours_id_unique": {
+          "name": "parcours_amo_validations_parcours_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parcours_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prospect_qualifications": {
+      "name": "prospect_qualifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions_realisees": {
+          "name": "actions_realisees",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raisons_ineligibilite": {
+          "name": "raisons_ineligibilite",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "est_mandataire_financier": {
+          "name": "est_mandataire_financier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "prospect_qualifications_parcours_id_idx": {
+          "name": "prospect_qualifications_parcours_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prospect_qualifications_parcours_id_parcours_prevention_id_fk": {
+          "name": "prospect_qualifications_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "prospect_qualifications",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prospect_qualifications_agent_id_agents_id_fk": {
+          "name": "prospect_qualifications_agent_id_agents_id_fk",
+          "tableFrom": "prospect_qualifications",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rga_zones": {
+      "name": "rga_zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alea": {
+          "name": "alea",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_runs": {
+      "name": "sync_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "sync_run_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "total_parcours_scanned": {
+          "name": "total_parcours_scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_parcours_updated": {
+          "name": "total_parcours_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_errors": {
+          "name": "total_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_summary": {
+          "name": "error_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_runs_started_at_idx": {
+          "name": "sync_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_run_entries": {
+      "name": "sync_run_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sync_run_id": {
+          "name": "sync_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcours_id": {
+          "name": "parcours_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_before": {
+          "name": "step_before",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_after": {
+          "name": "step_after",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ds_status_changes": {
+          "name": "ds_status_changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_advanced": {
+          "name": "step_advanced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_run_entries_sync_run_id_idx": {
+          "name": "sync_run_entries_sync_run_id_idx",
+          "columns": [
+            {
+              "expression": "sync_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_run_entries_parcours_id_idx": {
+          "name": "sync_run_entries_parcours_id_idx",
+          "columns": [
+            {
+              "expression": "parcours_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_run_entries_sync_run_id_sync_runs_id_fk": {
+          "name": "sync_run_entries_sync_run_id_sync_runs_id_fk",
+          "tableFrom": "sync_run_entries",
+          "tableTo": "sync_runs",
+          "columnsFrom": [
+            "sync_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_run_entries_parcours_id_parcours_prevention_id_fk": {
+          "name": "sync_run_entries_parcours_id_parcours_prevention_id_fk",
+          "tableFrom": "sync_run_entries",
+          "tableTo": "parcours_prevention",
+          "columnsFrom": [
+            "parcours_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "public",
+      "values": [
+        "administrateur",
+        "super_administrateur",
+        "amo",
+        "analyste",
+        "allers_vers",
+        "amo_et_allers_vers"
+      ]
+    },
+    "public.ds_status": {
+      "name": "ds_status",
+      "schema": "public",
+      "values": [
+        "en_construction",
+        "en_instruction",
+        "accepte",
+        "refuse",
+        "classe_sans_suite",
+        "non_accessible"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "todo",
+        "en_instruction",
+        "valide"
+      ]
+    },
+    "public.statut_validation_amo": {
+      "name": "statut_validation_amo",
+      "schema": "public",
+      "values": [
+        "en_attente",
+        "logement_eligible",
+        "logement_non_eligible",
+        "accompagnement_refuse",
+        "sans_amo"
+      ]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": [
+        "invitation",
+        "choix_amo",
+        "eligibilite",
+        "diagnostic",
+        "devis",
+        "factures"
+      ]
+    },
+    "public.sync_run_status": {
+      "name": "sync_run_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "partial",
+        "error"
+      ]
+    },
+    "public.sync_run_trigger": {
+      "name": "sync_run_trigger",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/shared/database/migrations/meta/_journal.json
+++ b/src/shared/database/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1787666190138,
       "tag": "0043_little_rhino",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1787734705124,
+      "tag": "0044_thankful_tenebrous",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/database/migrations/meta/_journal.json
+++ b/src/shared/database/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1787735509963,
       "tag": "0045_flat_dark_beast",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1787743092972,
+      "tag": "0046_charming_hellcat",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/database/migrations/meta/_journal.json
+++ b/src/shared/database/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1787734705124,
       "tag": "0044_thankful_tenebrous",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1787735509963,
+      "tag": "0045_flat_dark_beast",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/database/repositories/dossiers-ds-tentatives.repository.ts
+++ b/src/shared/database/repositories/dossiers-ds-tentatives.repository.ts
@@ -1,0 +1,72 @@
+import { and, desc, eq } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import { db } from "../client";
+import { dossiersDsTentatives, type DossierDsTentative, type OrigineTentative } from "../schema";
+import type { Step } from "@/shared/domain/value-objects/step.enum";
+
+/** Exécuteur : le client global, ou une transaction en cours. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Executor = typeof db | PgTransaction<any, any, any>;
+
+interface RecordTentativeParams {
+  parcoursId: string;
+  step: Step;
+  dsNumber: string;
+  origine: OrigineTentative;
+  dsId?: string | null;
+  dsDemarcheId?: string | null;
+  dsUrl?: string | null;
+}
+
+/**
+ * Registre append-only des numéros DN connus d'un parcours (ADR-0027).
+ * Aucune méthode de suppression : un numéro entré ici n'en sort jamais.
+ */
+export const dossiersDsTentativesRepository = {
+  /**
+   * Enregistre une tentative. Idempotent sur `ds_number` : un numéro déjà connu n'est ni
+   * dupliqué ni réécrit — sa provenance d'origine et sa date de découverte font foi.
+   * Accepte une transaction pour être écrite avec le pointeur dans le même commit.
+   */
+  async record(params: RecordTentativeParams, executor: Executor = db): Promise<void> {
+    await executor
+      .insert(dossiersDsTentatives)
+      .values({
+        parcoursId: params.parcoursId,
+        step: params.step,
+        dsNumber: params.dsNumber,
+        origine: params.origine,
+        dsId: params.dsId ?? null,
+        dsDemarcheId: params.dsDemarcheId ?? null,
+        dsUrl: params.dsUrl ?? null,
+      })
+      .onConflictDoNothing({ target: dossiersDsTentatives.dsNumber });
+  },
+
+  /** Toutes les tentatives connues d'une étape, la plus récente d'abord. */
+  async findByParcoursStep(parcoursId: string, step: Step): Promise<DossierDsTentative[]> {
+    return db
+      .select()
+      .from(dossiersDsTentatives)
+      .where(and(eq(dossiersDsTentatives.parcoursId, parcoursId), eq(dossiersDsTentatives.step, step)))
+      .orderBy(desc(dossiersDsTentatives.createdAt));
+  },
+
+  /** Le parcours auquel un numéro DN est rattaché, s'il est déjà connu. */
+  async findByDsNumber(dsNumber: string): Promise<DossierDsTentative | null> {
+    const [row] = await db
+      .select()
+      .from(dossiersDsTentatives)
+      .where(eq(dossiersDsTentatives.dsNumber, dsNumber))
+      .limit(1);
+    return row ?? null;
+  },
+
+  /**
+   * Efface l'URL de préremplissage (qui porte le `prefill_token`) sans toucher au numéro :
+   * une fois le dossier déposé, le lien n'a plus d'usage et ne doit plus être conservé.
+   */
+  async purgerUrl(dsNumber: string): Promise<void> {
+    await db.update(dossiersDsTentatives).set({ dsUrl: null }).where(eq(dossiersDsTentatives.dsNumber, dsNumber));
+  },
+};

--- a/src/shared/database/repositories/dossiers-ds-tentatives.repository.ts
+++ b/src/shared/database/repositories/dossiers-ds-tentatives.repository.ts
@@ -15,7 +15,6 @@ interface RecordTentativeParams {
   origine: OrigineTentative;
   dsId?: string | null;
   dsDemarcheId?: string | null;
-  dsUrl?: string | null;
 }
 
 /**
@@ -38,7 +37,6 @@ export const dossiersDsTentativesRepository = {
         origine: params.origine,
         dsId: params.dsId ?? null,
         dsDemarcheId: params.dsDemarcheId ?? null,
-        dsUrl: params.dsUrl ?? null,
       })
       .onConflictDoNothing({ target: dossiersDsTentatives.dsNumber });
   },
@@ -60,13 +58,5 @@ export const dossiersDsTentativesRepository = {
       .where(eq(dossiersDsTentatives.dsNumber, dsNumber))
       .limit(1);
     return row ?? null;
-  },
-
-  /**
-   * Efface l'URL de préremplissage (qui porte le `prefill_token`) sans toucher au numéro :
-   * une fois le dossier déposé, le lien n'a plus d'usage et ne doit plus être conservé.
-   */
-  async purgerUrl(dsNumber: string): Promise<void> {
-    await db.update(dossiersDsTentatives).set({ dsUrl: null }).where(eq(dossiersDsTentatives.dsNumber, dsNumber));
   },
 };

--- a/src/shared/database/repositories/dossiers-ds-tentatives.repository.ts
+++ b/src/shared/database/repositories/dossiers-ds-tentatives.repository.ts
@@ -17,6 +17,18 @@ interface RecordTentativeParams {
   dsDemarcheId?: string | null;
 }
 
+/** Un numéro DN déjà connu d'un AUTRE parcours (ou d'une autre étape) : jamais silencieux. */
+export class TentativeConflitError extends Error {
+  constructor(
+    readonly dsNumber: string,
+    readonly parcoursIdExistant: string,
+    readonly stepExistante: string
+  ) {
+    super(`Le numéro DN ${dsNumber} est déjà rattaché à un autre parcours ou une autre étape`);
+    this.name = "TentativeConflitError";
+  }
+}
+
 /**
  * Registre append-only des numéros DN connus d'un parcours (ADR-0027).
  * Aucune méthode de suppression : un numéro entré ici n'en sort jamais.
@@ -28,6 +40,21 @@ export const dossiersDsTentativesRepository = {
    * Accepte une transaction pour être écrite avec le pointeur dans le même commit.
    */
   async record(params: RecordTentativeParams, executor: Executor = db): Promise<void> {
+    // `onConflictDoNothing` seul masquerait un conflit de propriétaire : on vérifie donc à qui
+    // appartient déjà ce numéro avant de laisser passer l'idempotence (ADR-0027).
+    const [existant] = await executor
+      .select({
+        parcoursId: dossiersDsTentatives.parcoursId,
+        step: dossiersDsTentatives.step,
+      })
+      .from(dossiersDsTentatives)
+      .where(eq(dossiersDsTentatives.dsNumber, params.dsNumber))
+      .limit(1);
+
+    if (existant && (existant.parcoursId !== params.parcoursId || existant.step !== params.step)) {
+      throw new TentativeConflitError(params.dsNumber, existant.parcoursId, existant.step);
+    }
+
     await executor
       .insert(dossiersDsTentatives)
       .values({

--- a/src/shared/database/repositories/dossiers-ds-tentatives.repository.ts
+++ b/src/shared/database/repositories/dossiers-ds-tentatives.repository.ts
@@ -55,7 +55,7 @@ export const dossiersDsTentativesRepository = {
       throw new TentativeConflitError(params.dsNumber, existant.parcoursId, existant.step);
     }
 
-    await executor
+    const insere = await executor
       .insert(dossiersDsTentatives)
       .values({
         parcoursId: params.parcoursId,
@@ -65,7 +65,22 @@ export const dossiersDsTentativesRepository = {
         dsId: params.dsId ?? null,
         dsDemarcheId: params.dsDemarcheId ?? null,
       })
-      .onConflictDoNothing({ target: dossiersDsTentatives.dsNumber });
+      .onConflictDoNothing({ target: dossiersDsTentatives.dsNumber })
+      .returning({ id: dossiersDsTentatives.id });
+
+    // Rien inséré alors que le contrôle initial ne voyait rien : une écriture concurrente est
+    // passée entre les deux. On relit pour ne pas avaler un conflit de propriétaire.
+    if (insere.length === 0 && !existant) {
+      const [concurrent] = await executor
+        .select({ parcoursId: dossiersDsTentatives.parcoursId, step: dossiersDsTentatives.step })
+        .from(dossiersDsTentatives)
+        .where(eq(dossiersDsTentatives.dsNumber, params.dsNumber))
+        .limit(1);
+
+      if (concurrent && (concurrent.parcoursId !== params.parcoursId || concurrent.step !== params.step)) {
+        throw new TentativeConflitError(params.dsNumber, concurrent.parcoursId, concurrent.step);
+      }
+    }
   },
 
   /** Toutes les tentatives connues d'une étape, la plus récente d'abord. */

--- a/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
+++ b/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { db } from "../client";
 import {
   dsReconciliationObservations,
@@ -9,6 +9,9 @@ import {
   type ResolutionObservation,
 } from "../schema";
 import type { Step } from "@/shared/domain/value-objects/step.enum";
+
+/** Postgres plafonne le nombre de paramètres d'une requête : on découpe par précaution. */
+const TAILLE_LOT = 500;
 
 interface ObservationAEnregistrer {
   dsNumber: string;
@@ -34,34 +37,31 @@ export const dsReconciliationObservationsRepository = {
   async upsertMany(observations: ObservationAEnregistrer[]): Promise<void> {
     if (observations.length === 0) return;
 
-    for (const o of observations) {
+    // Un seul INSERT par lot : un balayage de démarche entière en produit plusieurs centaines.
+    for (let i = 0; i < observations.length; i += TAILLE_LOT) {
+      const lot = observations.slice(i, i + TAILLE_LOT);
+
       await db
         .insert(dsReconciliationObservations)
-        .values({
-          dsNumber: o.dsNumber,
-          parcoursId: o.parcoursId,
-          step: o.step,
-          verdict: o.verdict,
-          dsState: o.dsState,
-          detail: o.detail,
-        })
+        .values(lot)
         .onConflictDoUpdate({
           target: dsReconciliationObservations.dsNumber,
           set: {
-            parcoursId: o.parcoursId,
-            step: o.step,
-            verdict: o.verdict,
-            dsState: o.dsState,
-            detail: o.detail,
+            parcoursId: sql`excluded.parcours_id`,
+            step: sql`excluded.step`,
+            verdict: sql`excluded.verdict`,
+            dsState: sql`excluded.ds_state`,
+            detail: sql`excluded.detail`,
             observedAt: new Date(),
             // Le verdict a changé depuis la résolution : le cas redevient ouvert.
-            resolvedAt: sql`CASE WHEN ${dsReconciliationObservations.verdict} = ${o.verdict} THEN ${dsReconciliationObservations.resolvedAt} ELSE NULL END`,
+            resolvedAt: sql`CASE WHEN ${dsReconciliationObservations.verdict} = excluded.verdict THEN ${dsReconciliationObservations.resolvedAt} ELSE NULL END`,
           },
         });
     }
   },
 
-  /** Observations encore ouvertes pour les verdicts demandés, du plus ancien au plus récent. */
+  /** Observations encore ouvertes pour les verdicts demandés, les plus anciennes d'abord :
+   * un cas qui traîne depuis longtemps est un demandeur qui attend depuis longtemps. */
   async listerOuvertes(verdicts: string[]): Promise<ObservationAvecDemandeur[]> {
     if (verdicts.length === 0) return [];
 
@@ -77,7 +77,7 @@ export const dsReconciliationObservationsRepository = {
       .where(
         and(inArray(dsReconciliationObservations.verdict, verdicts), isNull(dsReconciliationObservations.resolvedAt))
       )
-      .orderBy(desc(dsReconciliationObservations.observedAt));
+      .orderBy(asc(dsReconciliationObservations.observedAt));
 
     return rows.map((r) => ({ ...r.observation, demandeurNom: r.nom, demandeurPrenom: r.prenom }));
   },

--- a/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
+++ b/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
@@ -9,6 +9,7 @@ import {
   type ResolutionObservation,
 } from "../schema";
 import type { Step } from "@/shared/domain/value-objects/step.enum";
+import type { CandidatDemandeur } from "@/features/parcours/dossiers-ds/domain/types/inspection.types";
 
 /** Postgres plafonne le nombre de paramètres d'une requête : on découpe par précaution. */
 const TAILLE_LOT = 500;
@@ -20,6 +21,7 @@ interface ObservationAEnregistrer {
   verdict: string;
   dsState: string | null;
   detail: string | null;
+  candidats?: CandidatDemandeur[] | null;
 }
 
 /** Une observation enrichie du demandeur concerné, pour l'affichage back-office. */
@@ -52,6 +54,8 @@ export const dsReconciliationObservationsRepository = {
             verdict: sql`excluded.verdict`,
             dsState: sql`excluded.ds_state`,
             detail: sql`excluded.detail`,
+            // Un balayage qui ne recalcule pas les candidats ne doit pas effacer les précédents.
+            candidats: sql`coalesce(excluded.candidats, ${dsReconciliationObservations.candidats})`,
             observedAt: new Date(),
             // Le verdict a changé depuis la résolution : le cas redevient ouvert.
             resolvedAt: sql`CASE WHEN ${dsReconciliationObservations.verdict} = excluded.verdict THEN ${dsReconciliationObservations.resolvedAt} ELSE NULL END`,

--- a/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
+++ b/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
@@ -1,0 +1,102 @@
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { db } from "../client";
+import {
+  dsReconciliationObservations,
+  parcoursPrevention,
+  users,
+  type DsReconciliationObservation,
+  type ResolutionObservation,
+} from "../schema";
+import type { Step } from "@/shared/domain/value-objects/step.enum";
+
+interface ObservationAEnregistrer {
+  dsNumber: string;
+  parcoursId: string | null;
+  step: Step;
+  verdict: string;
+  dsState: string | null;
+  detail: string | null;
+}
+
+/** Une observation enrichie du demandeur concerné, pour l'affichage back-office. */
+export interface ObservationAvecDemandeur extends DsReconciliationObservation {
+  demandeurNom: string | null;
+  demandeurPrenom: string | null;
+}
+
+export const dsReconciliationObservationsRepository = {
+  /**
+   * Enregistre ce que le balayage a constaté. Une observation par dossier DN : un nouveau
+   * passage réécrit le verdict et la date, sans toucher à la résolution déjà posée par un
+   * humain — sauf si le verdict change, auquel cas le cas est rouvert.
+   */
+  async upsertMany(observations: ObservationAEnregistrer[]): Promise<void> {
+    if (observations.length === 0) return;
+
+    for (const o of observations) {
+      await db
+        .insert(dsReconciliationObservations)
+        .values({
+          dsNumber: o.dsNumber,
+          parcoursId: o.parcoursId,
+          step: o.step,
+          verdict: o.verdict,
+          dsState: o.dsState,
+          detail: o.detail,
+        })
+        .onConflictDoUpdate({
+          target: dsReconciliationObservations.dsNumber,
+          set: {
+            parcoursId: o.parcoursId,
+            step: o.step,
+            verdict: o.verdict,
+            dsState: o.dsState,
+            detail: o.detail,
+            observedAt: new Date(),
+            // Le verdict a changé depuis la résolution : le cas redevient ouvert.
+            resolvedAt: sql`CASE WHEN ${dsReconciliationObservations.verdict} = ${o.verdict} THEN ${dsReconciliationObservations.resolvedAt} ELSE NULL END`,
+          },
+        });
+    }
+  },
+
+  /** Observations encore ouvertes pour les verdicts demandés, du plus ancien au plus récent. */
+  async listerOuvertes(verdicts: string[]): Promise<ObservationAvecDemandeur[]> {
+    if (verdicts.length === 0) return [];
+
+    const rows = await db
+      .select({
+        observation: dsReconciliationObservations,
+        nom: users.nom,
+        prenom: users.prenom,
+      })
+      .from(dsReconciliationObservations)
+      .leftJoin(parcoursPrevention, eq(parcoursPrevention.id, dsReconciliationObservations.parcoursId))
+      .leftJoin(users, eq(users.id, parcoursPrevention.userId))
+      .where(
+        and(inArray(dsReconciliationObservations.verdict, verdicts), isNull(dsReconciliationObservations.resolvedAt))
+      )
+      .orderBy(desc(dsReconciliationObservations.observedAt));
+
+    return rows.map((r) => ({ ...r.observation, demandeurNom: r.nom, demandeurPrenom: r.prenom }));
+  },
+
+  /** Compte les observations ouvertes par verdict, pour les badges d'onglets. */
+  async compterOuvertesParVerdict(): Promise<Record<string, number>> {
+    const rows = await db
+      .select({ verdict: dsReconciliationObservations.verdict, total: sql<number>`count(*)::int` })
+      .from(dsReconciliationObservations)
+      .where(isNull(dsReconciliationObservations.resolvedAt))
+      .groupBy(dsReconciliationObservations.verdict);
+
+    return Object.fromEntries(rows.map((r) => [r.verdict, r.total]));
+  },
+
+  /** Referme un cas : rattaché, arbitré ou écarté. */
+  async resoudre(dsNumber: string, resolution: ResolutionObservation, agentId: string | null): Promise<void> {
+    await db
+      .update(dsReconciliationObservations)
+      .set({ resolvedAt: new Date(), resolvedBy: agentId, resolution })
+      .where(eq(dsReconciliationObservations.dsNumber, dsNumber));
+  },
+};

--- a/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
+++ b/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
@@ -57,8 +57,11 @@ export const dsReconciliationObservationsRepository = {
             // Un balayage qui ne recalcule pas les candidats ne doit pas effacer les précédents.
             candidats: sql`coalesce(excluded.candidats, ${dsReconciliationObservations.candidats})`,
             observedAt: new Date(),
-            // Le verdict a changé depuis la résolution : le cas redevient ouvert.
+            // Le verdict a changé depuis la résolution : le cas redevient ouvert, et la
+            // résolution qui l'avait refermé ne le décrit plus — elle part avec.
             resolvedAt: sql`CASE WHEN ${dsReconciliationObservations.verdict} = excluded.verdict THEN ${dsReconciliationObservations.resolvedAt} ELSE NULL END`,
+            resolvedBy: sql`CASE WHEN ${dsReconciliationObservations.verdict} = excluded.verdict THEN ${dsReconciliationObservations.resolvedBy} ELSE NULL END`,
+            resolution: sql`CASE WHEN ${dsReconciliationObservations.verdict} = excluded.verdict THEN ${dsReconciliationObservations.resolution} ELSE NULL END`,
           },
         });
     }

--- a/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
+++ b/src/shared/database/repositories/ds-reconciliation-observations.repository.ts
@@ -4,6 +4,7 @@ import {
   dsReconciliationObservations,
   parcoursPrevention,
   users,
+  RESOLUTION_OBSERVATION,
   type DsReconciliationObservation,
   type ResolutionObservation,
 } from "../schema";
@@ -90,6 +91,24 @@ export const dsReconciliationObservationsRepository = {
       .groupBy(dsReconciliationObservations.verdict);
 
     return Object.fromEntries(rows.map((r) => [r.verdict, r.total]));
+  },
+
+  /**
+   * Referme les observations dont le dossier n'a plus rien à signaler. Sans ça, un cas réglé
+   * entre deux balayages resterait ouvert indéfiniment et la file ne se viderait jamais.
+   */
+  async refermerReglees(dsNumbers: string[]): Promise<number> {
+    if (dsNumbers.length === 0) return 0;
+
+    const fermees = await db
+      .update(dsReconciliationObservations)
+      .set({ resolvedAt: new Date(), resolvedBy: null, resolution: RESOLUTION_OBSERVATION.AUTO })
+      .where(
+        and(inArray(dsReconciliationObservations.dsNumber, dsNumbers), isNull(dsReconciliationObservations.resolvedAt))
+      )
+      .returning({ id: dsReconciliationObservations.id });
+
+    return fermees.length;
   },
 
   /** Referme un cas : rattaché, arbitré ou écarté. */

--- a/src/shared/database/repositories/index.ts
+++ b/src/shared/database/repositories/index.ts
@@ -5,6 +5,7 @@ export { userRepository as userRepo } from "./user.repository";
 export { parcoursPreventionRepository as parcoursRepo } from "./parcours-prevention.repository";
 export { parcoursActionsRepo } from "./parcours-actions.repository";
 export { dossierDemarchesSimplifieesRepository as dossierDsRepo } from "./dossiers-demarches-simplifiees.repository";
+export { dossiersDsTentativesRepository as dossiersDsTentativesRepo } from "./dossiers-ds-tentatives.repository";
 export { entreprisesAmoRepository as entreprisesAmoRepo } from "./entreprises-amo.repository";
 export { agentsRepository as agentsRepo } from "./agents.repository";
 export { agentPermissionsRepository } from "./agent-permissions.repository";

--- a/src/shared/database/repositories/index.ts
+++ b/src/shared/database/repositories/index.ts
@@ -6,6 +6,8 @@ export { parcoursPreventionRepository as parcoursRepo } from "./parcours-prevent
 export { parcoursActionsRepo } from "./parcours-actions.repository";
 export { dossierDemarchesSimplifieesRepository as dossierDsRepo } from "./dossiers-demarches-simplifiees.repository";
 export { dossiersDsTentativesRepository as dossiersDsTentativesRepo } from "./dossiers-ds-tentatives.repository";
+export { dsReconciliationObservationsRepository as dsObservationsRepo } from "./ds-reconciliation-observations.repository";
+export type { ObservationAvecDemandeur } from "./ds-reconciliation-observations.repository";
 export { entreprisesAmoRepository as entreprisesAmoRepo } from "./entreprises-amo.repository";
 export { agentsRepository as agentsRepo } from "./agents.repository";
 export { agentPermissionsRepository } from "./agent-permissions.repository";

--- a/src/shared/database/schema/dossiers-ds-tentatives.ts
+++ b/src/shared/database/schema/dossiers-ds-tentatives.ts
@@ -1,0 +1,68 @@
+import { pgTable, uuid, timestamp, varchar, index } from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { parcoursPrevention } from "./parcours-prevention";
+import { stepPgEnum } from "../enums/enums";
+
+/**
+ * Registre des tentatives : TOUT numéro de dossier DN connu pour un parcours, qu'il ait été
+ * déposé ou non. Append-only — une ligne n'est jamais supprimée, contrairement au pointeur
+ * courant `dossiers_demarches_simplifiees`. Voir ADR-0027.
+ */
+export const dossiersDsTentatives = pgTable(
+  "dossiers_ds_tentatives",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+
+    parcoursId: uuid("parcours_id")
+      .notNull()
+      .references(() => parcoursPrevention.id, { onDelete: "cascade" }),
+
+    step: stepPgEnum("step").notNull(),
+
+    // Un numéro DN n'appartient qu'à un seul parcours (invariant ADR-0027).
+    dsNumber: varchar("ds_number", { length: 50 }).notNull().unique(),
+    dsId: varchar("ds_id", { length: 50 }),
+    dsDemarcheId: varchar("ds_demarche_id", { length: 50 }),
+
+    // URL de préremplissage : porte le `prefill_token`, qui permet de réclamer le brouillon.
+    // Traitée comme un secret — purgée au dépôt, jamais recopiée dans un log (ADR-0027).
+    dsUrl: varchar("ds_url", { length: 500 }),
+
+    // prefill | reconciliation | manuel | backfill_pointeur | backfill_sync_error
+    origine: varchar("origine", { length: 30 }).notNull(),
+
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  // Plusieurs tentatives par (parcours, étape) sont normales : index non unique.
+  (t) => [index("dossiers_ds_tentatives_parcours_step_idx").on(t.parcoursId, t.step)]
+);
+
+export const dossiersDsTentativesRelations = relations(dossiersDsTentatives, ({ one }) => ({
+  parcours: one(parcoursPrevention, {
+    fields: [dossiersDsTentatives.parcoursId],
+    references: [parcoursPrevention.id],
+  }),
+}));
+
+export type DossierDsTentative = typeof dossiersDsTentatives.$inferSelect;
+export type NewDossierDsTentative = typeof dossiersDsTentatives.$inferInsert;
+
+/** Provenance d'une tentative — d'où vient la connaissance de ce numéro. */
+export const ORIGINE_TENTATIVE = {
+  /** Créée par l'app via l'API de préremplissage (cas nominal). */
+  PREFILL: "prefill",
+  /** Découverte par la réconciliation au dépôt (annotation FPA). */
+  RECONCILIATION: "reconciliation",
+  /** Saisie par un agent ou une opération manuelle (relink). */
+  MANUEL: "manuel",
+  /** Reprise du pointeur courant lors de l'amorçage du registre. */
+  BACKFILL_POINTEUR: "backfill_pointeur",
+  /** Reconstituée depuis les messages d'erreur de sync — indice, pas une preuve. */
+  BACKFILL_SYNC_ERROR: "backfill_sync_error",
+} as const;
+
+export type OrigineTentative = (typeof ORIGINE_TENTATIVE)[keyof typeof ORIGINE_TENTATIVE];

--- a/src/shared/database/schema/dossiers-ds-tentatives.ts
+++ b/src/shared/database/schema/dossiers-ds-tentatives.ts
@@ -13,6 +13,8 @@ export const dossiersDsTentatives = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
 
+    // CASCADE assumé malgré le caractère append-only : la suppression d'un parcours (RGPD)
+    // doit emporter ses tentatives. Rien d'autre ne supprime jamais une ligne d'ici.
     parcoursId: uuid("parcours_id")
       .notNull()
       .references(() => parcoursPrevention.id, { onDelete: "cascade" }),
@@ -24,10 +26,6 @@ export const dossiersDsTentatives = pgTable(
     dsId: varchar("ds_id", { length: 50 }),
     dsDemarcheId: varchar("ds_demarche_id", { length: 50 }),
 
-    // URL de préremplissage : porte le `prefill_token`, qui permet de réclamer le brouillon.
-    // Traitée comme un secret — purgée au dépôt, jamais recopiée dans un log (ADR-0027).
-    dsUrl: varchar("ds_url", { length: 500 }),
-
     // prefill | reconciliation | manuel | backfill_pointeur | backfill_sync_error
     origine: varchar("origine", { length: 30 }).notNull(),
 
@@ -37,6 +35,8 @@ export const dossiersDsTentatives = pgTable(
       .defaultNow()
       .$onUpdate(() => new Date()),
   },
+  // Le registre ne conserve QUE l'identité du dossier : l'URL de préremplissage porte le
+  // `prefill_token` (un secret) et vit uniquement sur le pointeur courant, cf. ADR-0027.
   // Plusieurs tentatives par (parcours, étape) sont normales : index non unique.
   (t) => [index("dossiers_ds_tentatives_parcours_step_idx").on(t.parcoursId, t.step)]
 );

--- a/src/shared/database/schema/ds-reconciliation-observations.ts
+++ b/src/shared/database/schema/ds-reconciliation-observations.ts
@@ -1,8 +1,9 @@
-import { pgTable, uuid, timestamp, varchar, text, index } from "drizzle-orm/pg-core";
+import { pgTable, uuid, timestamp, varchar, text, jsonb, index } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import { parcoursPrevention } from "./parcours-prevention";
 import { agents } from "./agents";
 import { stepPgEnum } from "../enums/enums";
+import type { CandidatDemandeur } from "@/features/parcours/dossiers-ds/domain/types/inspection.types";
 
 /**
  * Ce que la réconciliation a constaté sur un dossier DN déposé, et ce qu'il en a été fait
@@ -30,6 +31,12 @@ export const dsReconciliationObservations = pgTable(
     dsState: varchar("ds_state", { length: 30 }),
     /** Contexte utile à l'arbitrage : numéro du pointeur au moment du constat, par exemple. */
     detail: text("detail"),
+
+    /**
+     * Demandeurs qui correspondent au dossier, calculés au balayage (ADR-0027). Stockés pour
+     * que la file les affiche sans re-interroger DN à chaque ouverture.
+     */
+    candidats: jsonb("candidats").$type<CandidatDemandeur[]>(),
 
     observedAt: timestamp("observed_at", { mode: "date" }).notNull().defaultNow(),
 

--- a/src/shared/database/schema/ds-reconciliation-observations.ts
+++ b/src/shared/database/schema/ds-reconciliation-observations.ts
@@ -1,0 +1,67 @@
+import { pgTable, uuid, timestamp, varchar, text, index } from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { parcoursPrevention } from "./parcours-prevention";
+import { agents } from "./agents";
+import { stepPgEnum } from "../enums/enums";
+
+/**
+ * Ce que la réconciliation a constaté sur un dossier DN déposé, et ce qu'il en a été fait
+ * (ADR-0027). Sans cette table, le rapport ne vit que dans la sortie d'un script : rien à
+ * afficher dans le back-office, et aucun moyen de savoir si un cas a déjà été traité.
+ *
+ * Une ligne par dossier DN observé, mise à jour à chaque passage. Les dossiers sans rien à
+ * signaler (déjà rattachés au bon parcours) n'y entrent pas.
+ */
+export const dsReconciliationObservations = pgTable(
+  "ds_reconciliation_observations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+
+    /** Dossier DN observé. Unique : un dossier n'a qu'une observation courante. */
+    dsNumber: varchar("ds_number", { length: 50 }).notNull().unique(),
+
+    /** Parcours visé par l'annotation FPA — `null` quand le dossier n'en porte pas. */
+    parcoursId: uuid("parcours_id").references(() => parcoursPrevention.id, { onDelete: "set null" }),
+    step: stepPgEnum("step"),
+
+    /** Verdict de `decideRattachement` (rattachement, conflit_*, sans_annotation…). */
+    verdict: varchar("verdict", { length: 40 }).notNull(),
+    /** État du dossier côté DN au moment de l'observation. */
+    dsState: varchar("ds_state", { length: 30 }),
+    /** Contexte utile à l'arbitrage : numéro du pointeur au moment du constat, par exemple. */
+    detail: text("detail"),
+
+    observedAt: timestamp("observed_at", { mode: "date" }).notNull().defaultNow(),
+
+    /** Traité par un humain : rattaché, arbitré, ou écarté. */
+    resolvedAt: timestamp("resolved_at", { mode: "date" }),
+    resolvedBy: uuid("resolved_by").references(() => agents.id, { onDelete: "set null" }),
+    resolution: varchar("resolution", { length: 30 }),
+  },
+  (t) => [
+    index("ds_reconciliation_observations_verdict_idx").on(t.verdict),
+    index("ds_reconciliation_observations_parcours_idx").on(t.parcoursId),
+  ]
+);
+
+export const dsReconciliationObservationsRelations = relations(dsReconciliationObservations, ({ one }) => ({
+  parcours: one(parcoursPrevention, {
+    fields: [dsReconciliationObservations.parcoursId],
+    references: [parcoursPrevention.id],
+  }),
+}));
+
+export type DsReconciliationObservation = typeof dsReconciliationObservations.$inferSelect;
+export type NewDsReconciliationObservation = typeof dsReconciliationObservations.$inferInsert;
+
+/** Comment un cas a été refermé. */
+export const RESOLUTION_OBSERVATION = {
+  /** Le dossier a été rattaché à son parcours. */
+  RATTACHE: "rattache",
+  /** Conflit tranché à la main (côté DN ou en base). */
+  ARBITRE: "arbitre",
+  /** Sans suite : dossier hors périmètre, doublon abandonné, test… */
+  ECARTE: "ecarte",
+} as const;
+
+export type ResolutionObservation = (typeof RESOLUTION_OBSERVATION)[keyof typeof RESOLUTION_OBSERVATION];

--- a/src/shared/database/schema/ds-reconciliation-observations.ts
+++ b/src/shared/database/schema/ds-reconciliation-observations.ts
@@ -62,6 +62,8 @@ export const RESOLUTION_OBSERVATION = {
   ARBITRE: "arbitre",
   /** Sans suite : dossier hors périmètre, doublon abandonné, test… */
   ECARTE: "ecarte",
+  /** Refermé par un balayage : le cas n'a plus rien à signaler. */
+  AUTO: "auto",
 } as const;
 
 export type ResolutionObservation = (typeof RESOLUTION_OBSERVATION)[keyof typeof RESOLUTION_OBSERVATION];

--- a/src/shared/database/schema/index.ts
+++ b/src/shared/database/schema/index.ts
@@ -14,6 +14,7 @@ export * from "./users";
 export * from "./parcours-prevention";
 export * from "./parcours-actions";
 export * from "./dossiers-demarches-simplifiees";
+export * from "./dossiers-ds-tentatives";
 export * from "./entreprises-amo";
 export * from "./entreprises-amo-communes";
 export * from "./entreprises-amo-epci";

--- a/src/shared/database/schema/index.ts
+++ b/src/shared/database/schema/index.ts
@@ -15,6 +15,7 @@ export * from "./parcours-prevention";
 export * from "./parcours-actions";
 export * from "./dossiers-demarches-simplifiees";
 export * from "./dossiers-ds-tentatives";
+export * from "./ds-reconciliation-observations";
 export * from "./entreprises-amo";
 export * from "./entreprises-amo-communes";
 export * from "./entreprises-amo-epci";


### PR DESCRIPTION
Une ligne dossiers_demarches_simplifiees désignait à la fois le dernier brouillon prérempli fabriqué et le dossier administratif du demandeur. De cette confusion venaient les liens cassés, les dossiers orphelins et la campagne de suppression de juin.

La PR sépare les deux : un registre conserve définitivement tout numéro DN connu, et une réconciliation retrouve au dépôt le parcours d'un dossier via l'annotation FPA qui porte son parcoursId. Le demandeur dont le lien ne marche plus se débloque seul, l'AMO peut rattacher un dossier par son numéro, et le back-office expose deux files de travail : ce qu'il faut rattacher, ce qu'il faut arbitrer.

Rien ne s'exécute automatiquement : la réconciliation ne tourne que sur demande, sans écriture par défaut, et refuse d'agir sur un balayage incomplet. Le branchement sur le CRON viendra après observation en production.

Deux migrations (0044 registre, 0045 observations). Décision : ADR-0027. Corrections issues d'une revue Codex : échec fermé sur scan partiel et panne DN, compare-and-swap sur le retrait de pointeur, unicité vérifiée sur les deux tables, prefill_token retiré des logs et du registre.